### PR TITLE
fix: update test_cost to use existing claude model

### DIFF
--- a/tests/utils/test_cost.py
+++ b/tests/utils/test_cost.py
@@ -64,11 +64,11 @@ EXAMPLE_MODELS = [
             ),
         ),
         (
-            "openai/GCP/claude-3-5-haiku",
+            "openai/GCP/claude-haiku-4-5-20251001",
             TokensCost(
-                input_cost=7.999999999999999e-05,
-                output_cost=0.00039999999999999996,
-                total_cost=0.00047999999999999996,
+                input_cost=9.999999999999999e-05,
+                output_cost=0.0005,
+                total_cost=0.0006000000000000001,
             ),
         ),
         (


### PR DESCRIPTION
## Summary
Replace non-existent claude-3-5-haiku model with claude-haiku-4-5-20251001 which exists in litellm's pricing database.

## Changes
- Updated test case in tests/utils/test_cost.py to use `claude-haiku-4-5-20251001` instead of `claude-3-5-haiku`
- Updated expected cost values to match the actual costs for this model:
  - input_cost: 9.999999999999999e-05
  - output_cost: 0.0005
  - total_cost: 0.0006000000000000001

## Testing
All 7 tests in test_cost.py now pass successfully.

## Related Issue
Fixes test failure where claude-3-5-haiku was not found in litellm's model pricing database.