### PR TITLE
fix: disable OTEL traces for LiteLLM health checks

### DIFF
--- a/src/exgentic/integrations/litellm/health.py
+++ b/src/exgentic/integrations/litellm/health.py
@@ -17,6 +17,7 @@ async def acheck_model_accessible(model: str) -> None:
             "model": model,
             "messages": [{"role": "user", "content": "test from litellm"}],
             "max_tokens": 5,
+            "no-log": True,
         },
         mode="chat",
     )


### PR DESCRIPTION
Add 'no-log: True' flag to litellm.ahealth_check() call to prevent generation of OpenTelemetry traces during model health checks.

Health checks are diagnostic operations that don't need to be traced and can clutter observability data. Using LiteLLM's built-in no-log flag disables all logging callbacks including OTEL trace generation for these specific calls.