### PR TITLE
feat: add installation tracking and force flag to setup command

### DIFF
--- a/src/exgentic/interfaces/cli/commands/setup.py
+++ b/src/exgentic/interfaces/cli/commands/setup.py
@@ -17,7 +17,12 @@ from ..options import apply_debug_mode
 )
 @click.option("--benchmark", "benchmark", default=None, help="Benchmark slug name to set up.")
 @click.option("--agent", "agent", default=None, help="Agent slug name to set up.")
-def setup_cmd(debug: bool, benchmark: str | None, agent: str | None) -> None:
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Force reinstall even if already installed.",
+)
+def setup_cmd(debug: bool, benchmark: str | None, agent: str | None, force: bool) -> None:
     """Run a benchmark's or agent's setup.sh script."""
     apply_debug_mode(debug)
     if benchmark is not None and agent is not None:
@@ -26,9 +31,9 @@ def setup_cmd(debug: bool, benchmark: str | None, agent: str | None) -> None:
         raise click.UsageError("Specify either --benchmark or --agent.")
     try:
         if benchmark is not None:
-            setup_benchmark(benchmark)
+            setup_benchmark(benchmark, force=force)
         else:
-            setup_agent(agent)
+            setup_agent(agent, force=force)
     except Exception as exc:
         raise click.ClickException(str(exc)) from exc
 

--- a/src/exgentic/interfaces/lib/api.py
+++ b/src/exgentic/interfaces/lib/api.py
@@ -556,9 +556,34 @@ def get_setup_script_path(benchmark: str) -> str:
     return str(setup_path)
 
 
-def setup_benchmark(benchmark: str) -> None:
+def setup_benchmark(benchmark: str, force: bool = False, extra_args: list[str] | None = None) -> None:
+    """Setup a benchmark by running its setup.sh script.
+
+    Args:
+        benchmark: Benchmark slug name
+        force: Force reinstall even if already installed
+        extra_args: Additional arguments to pass to the setup script
+    """
+    from ...utils.installation_tracker import get_installations_dir, is_installed
+
+    # Check if already installed
+    if not force and is_installed(benchmark, "benchmark"):
+        print(f"Benchmark '{benchmark}' is already installed. Use --force to reinstall.")
+        return
+
+    # Remove installation marker before starting
+    if is_installed(benchmark, "benchmark"):
+        install_file = get_installations_dir() / "benchmark" / f"{benchmark}.json"
+        install_file.unlink(missing_ok=True)
+
+    # Run setup script with extra arguments
     setup_path = get_setup_script_path(benchmark)
-    subprocess.run(["bash", setup_path], check=True)
+    cmd = ["bash", setup_path]
+    if extra_args:
+        cmd.extend(extra_args)
+    subprocess.run(cmd, check=True)
+
+    # Record successful installation
     record_installation(benchmark, "benchmark")
 
 
@@ -588,9 +613,30 @@ def get_agent_setup_script_path(agent: str) -> str:
     return str(setup_path)
 
 
-def setup_agent(agent: str) -> None:
+def setup_agent(agent: str, force: bool = False) -> None:
+    """Setup an agent by running its setup.sh script.
+
+    Args:
+        agent: Agent slug name
+        force: Force reinstall even if already installed
+    """
+    from ...utils.installation_tracker import get_installations_dir, is_installed
+
+    # Check if already installed
+    if not force and is_installed(agent, "agent"):
+        print(f"Agent '{agent}' is already installed. Use --force to reinstall.")
+        return
+
+    # Remove installation marker before starting
+    if is_installed(agent, "agent"):
+        install_file = get_installations_dir() / "agent" / f"{agent}.json"
+        install_file.unlink(missing_ok=True)
+
+    # Run setup script
     setup_path = get_agent_setup_script_path(agent)
     subprocess.run(["bash", setup_path], check=True)
+
+    # Record successful installation
     record_installation(agent, "agent")
 
 


### PR DESCRIPTION
Add --force flag to 'exgentic setup' command to allow reinstallation of already-installed agents and benchmarks.

Enhanced setup_benchmark() and setup_agent() functions to:
- Check if component is already installed before running setup
- Skip installation with informative message if already installed
- Support force parameter to override installation check
- Support extra_args parameter for setup_benchmark() to pass additional arguments to setup scripts
- Delete installation marker before setup starts
- Recreate marker only after successful installation

Installation records are tracked in .exgentic_installations/ directory with separate subdirectories for agents and benchmarks.

This prevents unnecessary reinstallations and saves time on repeated runs while still allowing forced reinstalls when needed.