### PR TITLE
Set up tag-driven PyPI releases

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,59 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tag commit is on main
+        run: |
+          git fetch origin main
+          tag_commit="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          git merge-base --is-ancestor "$tag_commit" origin/main
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/exgentic/
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+src/exgentic/_version.py
 
 # Installation tracking
 .exgentic_installations/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,5 +11,9 @@ pre-commit install  # sets up git hooks
 - Run the main suite: `python -m pytest tests`
 - Run API-level tests only: `python -m pytest tests/api`
 
+## Releases
 
-
+- Release process guide: `docs/releasing.md`
+- Create and push a release tag: `scripts/release.sh 0.2.0 --push`
+- Release versions come from Git tags via `hatch-vcs`
+- PyPI publishing uses GitHub Actions Trusted Publishing

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,73 @@
+# Releasing Exgentic
+
+## Release model
+
+Exgentic uses Git tags as the single source of truth for released versions.
+There is no manually maintained version string in the source tree.
+
+- A release tag must look like `vX.Y.Z`, for example `v0.2.0`
+- Package versions are derived from Git tags via `hatch-vcs`
+- PyPI publishing runs from GitHub Actions only for pushed `v*` tags
+- The publishing workflow verifies that the tagged commit is reachable from `main`
+
+## One-time repository setup
+
+1. In PyPI, create the `exgentic` project if it does not exist yet.
+2. In PyPI project settings, add a Trusted Publisher for this GitHub repository.
+3. Use these GitHub values when configuring the publisher:
+   - Owner: `Exgentic`
+   - Repository: `exgentic`
+   - Workflow name: `publish-pypi.yml`
+   - Environment name: `pypi`
+4. In GitHub, keep the `pypi` environment enabled for this workflow if you want environment-level protections.
+
+See the official docs for the exact PyPI setup steps:
+- https://docs.pypi.org/trusted-publishers/using-a-publisher/
+- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+## Release steps
+
+1. Make sure the release commit is already merged to `main`.
+2. Update local refs:
+   ```bash
+   git checkout main
+   git pull --ff-only origin main
+   ```
+3. Create the annotated tag:
+   ```bash
+   scripts/release.sh 0.2.0
+   ```
+4. Push the tag:
+   ```bash
+   git push origin v0.2.0
+   ```
+
+Or do steps 3 and 4 in one command:
+
+```bash
+scripts/release.sh 0.2.0 --push
+```
+
+## What happens after the tag is pushed
+
+1. GitHub Actions checks out the tagged commit.
+2. The workflow confirms that commit belongs to `main`.
+3. The package is built from that exact tag.
+4. GitHub exchanges its OIDC identity with PyPI using Trusted Publishing.
+5. The distribution is uploaded to PyPI.
+
+## Verifying the release locally
+
+You can inspect the version derived from a tag before pushing:
+
+```bash
+git tag -a v0.2.0 -m "Release v0.2.0"
+python -m build
+```
+
+The built wheel and sdist should report version `0.2.0`.
+If you created a test tag by mistake, delete it locally before pushing:
+
+```bash
+git tag -d v0.2.0
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "exgentic"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Exgentic - General agent evaluation"
 authors = [{name = "Exgentic Team"}]
 license = {text = "MIT"}
@@ -64,6 +64,14 @@ dev = [
 
 [tool.hatch.metadata]
 allow-direct-references = true
+
+[tool.hatch.version]
+source = "vcs"
+tag-pattern = "^v(?P<version>.*)$"
+fallback-version = "0.0.0"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/exgentic/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/exgentic"]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/release.sh <version> [--push]
+
+Creates an annotated release tag on the current main HEAD.
+The Git tag is the single source of truth for package versioning.
+
+Examples:
+  scripts/release.sh 0.1.1
+  scripts/release.sh 0.1.1 --push
+EOF
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+version="$1"
+push_changes="${2:-}"
+
+if [[ ! "$version" =~ ^[0-9]+(\.[0-9]+){2}([A-Za-z0-9._-]+)?$ ]]; then
+  echo "Version must look like 1.2.3 or 1.2.3rc1" >&2
+  exit 1
+fi
+
+if [[ -n "$push_changes" && "$push_changes" != "--push" ]]; then
+  usage
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+current_branch="$(git branch --show-current)"
+if [[ "$current_branch" != "main" ]]; then
+  echo "Release tags must be created from main. Current branch: $current_branch" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --short)" ]]; then
+  echo "Working tree is dirty. Commit or stash changes before releasing." >&2
+  exit 1
+fi
+
+git fetch origin main --tags
+local_head="$(git rev-parse HEAD)"
+remote_head="$(git rev-parse origin/main)"
+if [[ "$local_head" != "$remote_head" ]]; then
+  echo "Local main is not at origin/main. Pull or push before releasing." >&2
+  exit 1
+fi
+
+tag="v$version"
+if git rev-parse "$tag" >/dev/null 2>&1; then
+  echo "Tag $tag already exists." >&2
+  exit 1
+fi
+
+git tag -a "$tag" -m "Release $tag"
+
+if [[ "$push_changes" == "--push" ]]; then
+  git push origin "$tag"
+fi
+
+echo "Created release tag $tag at $local_head"
+if [[ "$push_changes" != "--push" ]]; then
+  echo "Push when ready with:"
+  echo "  git push origin $tag"
+fi

--- a/src/exgentic/__init__.py
+++ b/src/exgentic/__init__.py
@@ -3,7 +3,16 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version as package_version
 from typing import Any
+
+try:
+    from ._version import version as __version__
+except ImportError:
+    try:
+        __version__ = package_version("exgentic")
+    except PackageNotFoundError:
+        __version__ = "0+unknown"
 
 from .interfaces.lib.api import (
     aggregate,
@@ -20,6 +29,7 @@ from .interfaces.lib.api import (
 from .interfaces.registry import get_agent_entries, get_benchmark_entries
 
 __all__ = [
+    "__version__",
     "aggregate",
     "evaluate",
     "execute",


### PR DESCRIPTION
## Summary
- switch package versioning to tag-derived `hatch-vcs`
- add a Trusted Publishing GitHub Actions workflow for PyPI releases
- add a release helper and dedicated release guide

## Validation
- `bash -n scripts/release.sh`
- `python -m py_compile src/exgentic/__init__.py`
- `git diff --check`
- parsed `pyproject.toml` successfully locally