### PR TITLE
feat: add batch publish command for HuggingFace datasets

### DIFF
--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -964,12 +964,11 @@ def batch_publish_cmd(
 ) -> None:
     """Publish run results to a HuggingFace dataset."""
     try:
-        from datasets import Dataset, DatasetDict, load_dataset
-    except ImportError:
+        from datasets import Dataset, load_dataset
+    except ImportError as err:
         raise click.ClickException(
-            "The 'datasets' package is required for publishing. "
-            "Install it with: pip install datasets"
-        )
+            "The 'datasets' package is required for publishing. Install it with: pip install datasets"
+        ) from err
 
     config_paths = _expand_config_inputs(config_values, list(ctx.args))
     rows, failures = _collect_results_rows(config_paths)
@@ -996,17 +995,13 @@ def batch_publish_cmd(
                 if key in existing_keys:
                     # Replace existing row with updated one
                     existing_rows = [
-                        r for r in existing_rows
-                        if (r.get("benchmark"), r.get("agent"), r.get("model")) != key
+                        r for r in existing_rows if (r.get("benchmark"), r.get("agent"), r.get("model")) != key
                     ]
                     updated += 1
                 new_rows.append(row)
 
             all_rows = existing_rows + new_rows
-            click.echo(
-                f"Publishing {len(all_rows)} row(s) "
-                f"({len(new_rows) - updated} new, {updated} updated)."
-            )
+            click.echo(f"Publishing {len(all_rows)} row(s) " f"({len(new_rows) - updated} new, {updated} updated).")
         except Exception:
             click.echo("No existing dataset found, creating new one.")
             all_rows = rows


### PR DESCRIPTION
## Summary
- Adds `exgentic batch publish` CLI command that collects run results from config files and publishes them as a HuggingFace dataset (Parquet format)
- Uses lightweight JSON loading — works without benchmark/agent modules installed
- Supports `--append` (default, deduplicates by benchmark+agent+model triple) and `--overwrite` modes
- Strips internal/bulky fields (session_results, session IDs, accumulated reports, etc.) for a clean dataset

## Usage
```bash
exgentic batch publish \
  --config '/path/to/experiments/*/config.json' \
  --repo Exgentic/open-agent-leaderboard-results \
  --private
```

## Test plan
- [x] Tested with 77 configs from feb_26 experiments — all published successfully
- [x] Verified dataset is viewable in HuggingFace Hub dataset viewer
- [ ] Test `--append` mode with existing dataset
- [ ] Test `--public` flag