### PR TITLE
Fix duplicate entries in trace.jsonl file

### DIFF
--- a/src/exgentic/integrations/litellm/proxy.py
+++ b/src/exgentic/integrations/litellm/proxy.py
@@ -162,8 +162,6 @@ class LitellmProxy:
         return litellm_params
 
     def _build_config_data(self) -> dict[str, object]:
-        trace_cb = TRACE_CALLBACK
-        async_cb = ASYNC_TRACE_CALLBACK
         config_data: dict[str, object] = {
             "model_list": [
                 {
@@ -172,8 +170,6 @@ class LitellmProxy:
                 }
             ],
             "litellm_settings": {
-                "success_callback": [trace_cb, async_cb],
-                "failure_callback": [trace_cb, async_cb],
                 # Force chat/completions instead of /responses for Anthropic
                 # message translation — many backends (Azure proxies, etc.)
                 # don't expose the newer Responses API endpoint.


### PR DESCRIPTION
Closes #56

Summary: The trace.jsonl file was logging duplicate entries because callbacks were registered twice - once in proxy.py and again in config.py during startup. This fix removes the redundant registration in proxy.py.

Changes: Removed success_callback and failure_callback from litellm_settings in proxy.py. Callbacks are now registered only through _configure_callbacks() in config.py which has proper deduplication logic.

Testing: All existing trace logger tests pass and pre-commit checks pass.