### PR TITLE
Fix Tau2 user model setup errors not being surfaced

### DIFF
--- a/src/exgentic/benchmarks/tau2/tau2_benchmark.py
+++ b/src/exgentic/benchmarks/tau2/tau2_benchmark.py
@@ -35,6 +35,7 @@ from ...core.types import (
     SingleObservation,
 )
 from ...integrations.litellm.config import configure_litellm
+from ...integrations.litellm.health import check_model_accessible_sync
 from ...observers.logging import (
     add_loguru_file_sink,
     attach_library_logger_to_handler,
@@ -178,6 +179,10 @@ class TAU2Session(PairableProxySession):
         base.mkdir(parents=True, exist_ok=True)
         self.file_path = str((base / f"{self._cfg.save_to}.json").resolve())
         self.results_file = self.paths.benchmark_results
+
+        # Check user simulator model accessibility before starting Tau2 runner
+        check_model_accessible_sync(self._cfg.llm_user, logger=self.logger)
+
         # Start Tau2 runner
         self.logger.debug("Staging for pairing")
         self.stage_for_pairing()


### PR DESCRIPTION
Closes #18

## Summary
This PR addresses an issue where Tau2 benchmark user simulator model configuration errors (such as invalid tokens) were not being properly surfaced to users. When the user model had configuration issues, the benchmark would fail silently or produce confusing errors instead of clearly indicating the model setup problem.

The fix adds a health check for the user simulator model before starting the Tau2 runner thread, ensuring that model accessibility issues are detected early and reported with clear error messages.

## Changes
- Added import for `check_model_accessible_sync` from `integrations.litellm.health`
- Added health check call in `TAU2Session.__init__` to validate user simulator model accessibility before starting the Tau2 runner thread
- Health check is performed after session initialization but before the background runner thread starts

## Testing
- All existing tests pass (273 passed, 15 skipped)
- Pre-commit checks pass
- The health check follows the same pattern established in PR #21 for agent models
- If the user model is inaccessible, a `RuntimeError` is raised with a clear message indicating the model and the specific error

## Notes
This complements the fix in #21 which added health checks for agent models but missed the user simulator model used by the Tau2 benchmark. The health check is performed synchronously during session initialization to fail fast before any expensive operations begin.