### PR TITLE
Add AI/CLI agent directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,14 @@ ENV/
 env.bak/
 venv.bak/
 
+# AI/CLI agent metadata
+.bob/
+.claude/
+.cursor/
+.aider*
+.copilot/
+.continue/
+
 # VS Code settings
 .vscode/
 .history/


### PR DESCRIPTION
## Summary
Adds common AI coding agent metadata directories to `.gitignore` to prevent accidental commits of tool-specific files (session data, notes, configs).

## Directories added
- `.bob/` — Bob Shell
- `.claude/` — Claude Code
- `.cursor/` — Cursor
- `.aider*` — Aider
- `.copilot/` — GitHub Copilot
- `.continue/` — Continue

These are local tool metadata that should never be committed.