### PR TITLE
Surface errors from Tau2 runner thread to the user

### DIFF
--- a/src/exgentic/benchmarks/tau2/tau2_benchmark.py
+++ b/src/exgentic/benchmarks/tau2/tau2_benchmark.py
@@ -311,30 +311,36 @@ class TAU2Session(PairableProxySession):
 
     def close(self):
         self.logger.debug("Closing session")
-        # Check if the runner thread encountered an error and surface it
-        if self._runner_error is not None:
-            raise RuntimeError(f"TAU2 runner thread failed with error: {self._runner_error}") from self._runner_error
-        super().close()  # This sets self.completed = True
-        t = self._runner_thread
-        self.logger.debug(f"Thread state: alive={t.is_alive() if t else 'None'}")
-        if t and t.is_alive():
-            self.logger.debug("Waiting for runner thread")
-            t.join(timeout=10.0)
-            if t.is_alive():
-                self.logger.warning("Runner thread did not exit cleanly, continuing anyway")
-        self.logger.debug("Thread join completed")
-        if not Path(self.results_file).exists():
-            if self.file_path and Path(self.file_path).exists():
-                self.logger.debug("Moving results file")
-                move(self.file_path, self.results_file)
-                self.logger.debug("File move completed")
-            else:
-                self.logger.error("Results file not found")
-                raise FileNotFoundError(f"TAU2 results file not found for session {self.session_id}: {self.file_path}")
+        try:
+            super().close()  # This sets self.completed = True
+            t = self._runner_thread
+            self.logger.debug(f"Thread state: alive={t.is_alive() if t else 'None'}")
+            if t and t.is_alive():
+                self.logger.debug("Waiting for runner thread")
+                t.join(timeout=10.0)
+                if t.is_alive():
+                    self.logger.warning("Runner thread did not exit cleanly, continuing anyway")
+            self.logger.debug("Thread join completed")
+            if not Path(self.results_file).exists():
+                if self.file_path and Path(self.file_path).exists():
+                    self.logger.debug("Moving results file")
+                    move(self.file_path, self.results_file)
+                    self.logger.debug("File move completed")
+                else:
+                    self.logger.error("Results file not found")
+                    raise FileNotFoundError(
+                        f"TAU2 results file not found for session {self.session_id}: {self.file_path}"
+                    )
 
-        self.logger.debug("Closing logging")
-        if not t or not t.is_alive():
-            close_logger(self.logger)
+            self.logger.debug("Closing logging")
+            if not t or not t.is_alive():
+                close_logger(self.logger)
+        finally:
+            # Surface runner thread error after cleanup to avoid leaking resources
+            if self._runner_error is not None:
+                raise RuntimeError(
+                    f"TAU2 runner thread failed with error: {self._runner_error}"
+                ) from self._runner_error
 
     def get_cost(self) -> CostReport:
         def _custom_token_cost(input_tokens: int, output_tokens: int) -> float | None:


### PR DESCRIPTION
Closes #67

## Summary
The Tau2 benchmark runs its domain simulation in a daemon thread. Previously, when the runner thread failed (e.g., model auth expires, API errors, unexpected exceptions), the error was caught and logged but never propagated to the caller. Users only discovered failures when `score()` returned 0 with no indication of what went wrong.

This PR fixes the issue by storing exceptions from the runner thread and surfacing them when the user interacts with the session.

## Changes
- Added `_runner_error` attribute to `TAU2Session` to store exceptions from the runner thread
- Modified the exception handler in `_runner()` to store the exception in `_runner_error`
- Added error checks in both `score()` and `close()` methods that raise a `RuntimeError` with the original exception as the cause when `_runner_error` is set
- The error message clearly indicates the runner thread failed and includes the original exception details

## Testing
- Verified the modified file compiles without syntax errors
- The fix ensures that any exception in the runner thread will be surfaced to the user at the next interaction point (`score()` or `close()`)
- Error propagation uses proper exception chaining (`raise ... from ...`) to preserve the full traceback

## Notes
This addresses the "errors swallowed mid-run" part of the issue. PR #63 already addressed the pre-flight health check aspect.