### PR TITLE
fix: fall back to ~/.exgentic/ when pyproject.toml is not found

### DIFF
--- a/src/exgentic/adapters/runners/_utils.py
+++ b/src/exgentic/adapters/runners/_utils.py
@@ -13,11 +13,19 @@ from typing import Any
 
 
 def find_project_root() -> Path:
-    """Walk up from the exgentic package to find the project root (pyproject.toml)."""
+    """Return the project root directory.
+
+    Walks up from the exgentic package looking for a ``pyproject.toml``.
+    When none is found (e.g. ``uv tool install exgentic``), falls back
+    to ``~/.exgentic/`` so that benchmark venvs and caches still have a
+    stable home directory.
+    """
     for parent in Path(__file__).resolve().parents:
         if (parent / "pyproject.toml").exists():
             return parent
-    raise FileNotFoundError("Cannot find project root (pyproject.toml)")
+    fallback = Path.home() / ".exgentic"
+    fallback.mkdir(parents=True, exist_ok=True)
+    return fallback
 
 
 def find_free_port() -> int:

--- a/tests/adapters/runners/test_utils.py
+++ b/tests/adapters/runners/test_utils.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Tests for :mod:`exgentic.adapters.runners._utils`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from exgentic.adapters.runners._utils import find_project_root
+
+
+def test_find_project_root_returns_repo_root():
+    """When a pyproject.toml exists in a parent, return that directory."""
+    root = find_project_root()
+    assert (root / "pyproject.toml").exists()
+
+
+def test_find_project_root_falls_back_to_dot_exgentic(tmp_path: Path):
+    """When no pyproject.toml is found, fall back to ~/.exgentic/."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    # Create a fake __file__ path with no pyproject.toml in any parent
+    fake_file = tmp_path / "lib" / "pkg" / "mod.py"
+    fake_file.parent.mkdir(parents=True)
+    fake_file.touch()
+
+    with (
+        patch(
+            "exgentic.adapters.runners._utils.Path.__file__",
+            create=True,
+        ),
+        patch(
+            "exgentic.adapters.runners._utils.Path.home",
+            return_value=fake_home,
+        ),
+    ):
+        # Patch __file__ at the module level so Path(__file__) resolves
+        # to a location without pyproject.toml in any ancestor.
+        import exgentic.adapters.runners._utils as mod
+
+        original_file = mod.__file__
+        try:
+            mod.__file__ = str(fake_file)
+            result = find_project_root()
+        finally:
+            mod.__file__ = original_file
+
+    expected = fake_home / ".exgentic"
+    assert result == expected
+    assert expected.is_dir()
+
+
+def test_find_project_root_fallback_is_idempotent(tmp_path: Path):
+    """Calling find_project_root twice with fallback doesn't error."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    fake_file = tmp_path / "lib" / "mod.py"
+    fake_file.parent.mkdir(parents=True)
+    fake_file.touch()
+
+    with patch(
+        "exgentic.adapters.runners._utils.Path.home",
+        return_value=fake_home,
+    ):
+        import exgentic.adapters.runners._utils as mod
+
+        original_file = mod.__file__
+        try:
+            mod.__file__ = str(fake_file)
+            result1 = find_project_root()
+            result2 = find_project_root()
+        finally:
+            mod.__file__ = original_file
+
+    assert result1 == result2
+    assert result1 == fake_home / ".exgentic"


### PR DESCRIPTION
## Summary

- `find_project_root()` in `src/exgentic/adapters/runners/_utils.py` now falls back to `~/.exgentic/` instead of raising `FileNotFoundError` when no `pyproject.toml` is found in any parent directory.
- This fixes the `exgentic evaluate` command when installed via `uv tool install exgentic`.
- Added tests for the fallback behavior.

Closes #72