### PR TITLE
Fix tau2 benchmark missing data files after setup

### DIFF
--- a/src/exgentic/benchmarks/tau2/__init__.py
+++ b/src/exgentic/benchmarks/tau2/__init__.py
@@ -4,5 +4,23 @@
 import os
 from pathlib import Path
 
+
+def _resolve_tau2_data_dir() -> str:
+    """Return the tau2 data directory path.
+
+    Checks the cache directory first (populated by ``setup.sh``), then falls
+    back to the legacy ``installation/`` path for backwards compatibility.
+    """
+    from ...utils.cache import benchmark_cache_dir
+
+    cache_data = benchmark_cache_dir("tau2") / "data"
+    if cache_data.is_dir():
+        return str(cache_data)
+
+    # Legacy path (pre-setup.sh installs that cloned into the package tree)
+    legacy = Path(__file__).resolve().parent / "installation" / "tau2-bench" / "data"
+    return str(legacy)
+
+
 if "TAU2_DATA_DIR" not in os.environ:
-    os.environ["TAU2_DATA_DIR"] = str(Path(__file__).resolve().parent / "installation" / "tau2-bench" / "data")
+    os.environ["TAU2_DATA_DIR"] = _resolve_tau2_data_dir()

--- a/src/exgentic/benchmarks/tau2/setup.sh
+++ b/src/exgentic/benchmarks/tau2/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+set -euo pipefail
+
+TAU2_REPO="https://github.com/sierra-research/tau2-bench.git"
+TAU2_REF="v0.1.3"
+DATA_ROOT="${EXGENTIC_CACHE_DIR:-.exgentic}/tau2/data"
+
+if [ -d "$DATA_ROOT/tau2/domains" ]; then
+    echo "tau2 data already present at $DATA_ROOT — skipping download."
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+echo "Cloning tau2-bench data files..."
+git clone --depth 1 --branch "$TAU2_REF" --filter=blob:none --sparse "$TAU2_REPO" "$TMPDIR/tau2-bench"
+cd "$TMPDIR/tau2-bench"
+git sparse-checkout set data
+cd - >/dev/null 2>&1
+
+mkdir -p "$DATA_ROOT"
+cp -r "$TMPDIR/tau2-bench/data/." "$DATA_ROOT/"
+
+echo "tau2 data installed to $DATA_ROOT"

--- a/tests/benchmarks/test_tau2_data_dir.py
+++ b/tests/benchmarks/test_tau2_data_dir.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Tests for tau2 data directory resolution (issue #74)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+def test_resolve_tau2_data_dir_prefers_cache(tmp_path: Path) -> None:
+    """When the cache directory contains data, it should be preferred."""
+    cache_data = tmp_path / "tau2" / "data"
+    cache_data.mkdir(parents=True)
+
+    with mock.patch(
+        "exgentic.utils.cache.benchmark_cache_dir",
+        return_value=tmp_path / "tau2",
+    ):
+        from exgentic.benchmarks.tau2 import _resolve_tau2_data_dir
+
+        result = _resolve_tau2_data_dir()
+
+    assert result == str(cache_data)
+
+
+def test_resolve_tau2_data_dir_falls_back_to_legacy(tmp_path: Path) -> None:
+    """When cache data is missing, fall back to the legacy installation path."""
+    empty_cache = tmp_path / "tau2"
+    empty_cache.mkdir(parents=True)
+    # No data/ subdirectory created — cache dir exists but data/ does not
+
+    with mock.patch(
+        "exgentic.utils.cache.benchmark_cache_dir",
+        return_value=empty_cache,
+    ):
+        from exgentic.benchmarks.tau2 import _resolve_tau2_data_dir
+
+        result = _resolve_tau2_data_dir()
+
+    # Should fall back to the legacy path under the package directory
+    expected_suffix = os.path.join("benchmarks", "tau2", "installation", "tau2-bench", "data")
+    assert result.endswith(expected_suffix)
+
+
+def test_env_var_takes_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If TAU2_DATA_DIR is already set, the module should not overwrite it."""
+    custom_dir = str(tmp_path / "my_custom_data")
+    monkeypatch.setenv("TAU2_DATA_DIR", custom_dir)
+
+    # Re-import to trigger the module-level guard
+    import importlib
+
+    import exgentic.benchmarks.tau2 as tau2_mod
+
+    importlib.reload(tau2_mod)
+
+    assert os.environ["TAU2_DATA_DIR"] == custom_dir


### PR DESCRIPTION
## Summary
- Add `setup.sh` to the tau2 benchmark that clones the tau2-bench repository data files into the exgentic cache directory during `exgentic setup --benchmark tau2`
- Update `__init__.py` to resolve `TAU2_DATA_DIR` from the cache directory, falling back to the legacy `installation/` path for backwards compatibility
- Add tests for data directory resolution logic

Closes #74

## Test plan
- [x] New unit tests for `_resolve_tau2_data_dir` covering cache preference, legacy fallback, and env var override
- [x] Pre-commit hooks pass
- [x] Existing test suite passes (pre-existing failures in `test_cli_compare` and `test_proxy_cache_execution` are unrelated)