### PR TITLE
Add standalone EnvironmentInstaller module

### DIFF
--- a/src/exgentic/utils/installer.py
+++ b/src/exgentic/utils/installer.py
@@ -93,71 +93,83 @@ class EnvironmentInstaller:
             shutil.rmtree(env_dir)
         env_dir.mkdir(parents=True, exist_ok=True)
 
-        uv_bin = _require_uv()
+        try:
+            uv_bin = _require_uv()
 
-        # 1 & 2  -- create venv
-        venv_dir = env_dir / "venv"
-        subprocess.run(
-            [
-                uv_bin,
-                "venv",
-                str(venv_dir),
-                "--python",
-                f"{sys.version_info.major}.{sys.version_info.minor}",
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-
-        venv_python = str(venv_dir / "bin" / "python")
-
-        # 3  -- install exgentic into the venv
-        project_root = _find_project_root()
-        if project_root is not None:
+            # 1 & 2  -- create venv
+            venv_dir = env_dir / "venv"
             subprocess.run(
-                [uv_bin, "pip", "install", "--python", venv_python, "--no-cache", str(project_root)],
+                [
+                    uv_bin,
+                    "venv",
+                    str(venv_dir),
+                    "--python",
+                    f"{sys.version_info.major}.{sys.version_info.minor}",
+                ],
                 check=True,
                 capture_output=True,
                 text=True,
             )
 
-        # 4  -- install requirements.txt (if found)
-        if module_path is not None:
-            req_path = _find_package_file(module_path, "requirements.txt")
-            if req_path is not None:
-                lines = [
-                    line.strip()
-                    for line in req_path.read_text().splitlines()
-                    if line.strip() and not line.strip().startswith("#")
-                ]
-                if lines:
-                    env = os.environ.copy()
-                    env.pop("VIRTUAL_ENV", None)
-                    env["GIT_LFS_SKIP_SMUDGE"] = "1"
-                    subprocess.run(
-                        [uv_bin, "pip", "install", "--python", venv_python, "-r", str(req_path)],
-                        check=True,
-                        env=env,
-                    )
+            venv_python = str(venv_dir / "bin" / "python")
 
-        # 5  -- validate system-deps.txt (if found)
-        if module_path is not None:
-            _validate_system_deps(module_path)
+            # Build a consistent env dict for subprocess calls:
+            # - remove VIRTUAL_ENV so uv targets the right venv
+            # - skip LFS smudge to speed up git-based installs
+            env = os.environ.copy()
+            env.pop("VIRTUAL_ENV", None)
+            env["GIT_LFS_SKIP_SMUDGE"] = "1"
 
-        # 6  -- run setup.sh (if found)
-        if module_path is not None:
-            setup_path = _find_package_file(module_path, "setup.sh")
-            if setup_path is not None:
-                env = os.environ.copy()
-                env["EXGENTIC_CACHE_DIR"] = str(env_dir)
-                env["VIRTUAL_ENV"] = str(venv_dir)
-                venv_bin = str(venv_dir / "bin")
-                env["PATH"] = venv_bin + os.pathsep + env.get("PATH", "")
-                subprocess.run(["bash", str(setup_path)], check=True, env=env)
+            # 3  -- install exgentic into the venv
+            project_root = _find_project_root()
+            if project_root is not None:
+                subprocess.run(
+                    [uv_bin, "pip", "install", "--python", venv_python, "--no-cache", str(project_root)],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                )
 
-        # 7  -- write .installed marker
-        (env_dir / ".installed").write_text("")
+            # 4  -- install requirements.txt (if found)
+            if module_path is not None:
+                req_path = _find_package_file(module_path, "requirements.txt")
+                if req_path is not None:
+                    lines = [
+                        line.strip()
+                        for line in req_path.read_text().splitlines()
+                        if line.strip() and not line.strip().startswith("#")
+                    ]
+                    if lines:
+                        subprocess.run(
+                            [uv_bin, "pip", "install", "--python", venv_python, "-r", str(req_path)],
+                            check=True,
+                            capture_output=True,
+                            text=True,
+                            env=env,
+                        )
+
+            # 5  -- validate system-deps.txt (if found)
+            if module_path is not None:
+                _validate_system_deps(module_path)
+
+            # 6  -- run setup.sh (if found)
+            # setup.sh intentionally prints to stdout for progress visibility
+            if module_path is not None:
+                setup_path = _find_package_file(module_path, "setup.sh")
+                if setup_path is not None:
+                    setup_env = env.copy()
+                    setup_env["EXGENTIC_CACHE_DIR"] = str(env_dir)
+                    setup_env["VIRTUAL_ENV"] = str(venv_dir)
+                    venv_bin = str(venv_dir / "bin")
+                    setup_env["PATH"] = venv_bin + os.pathsep + setup_env.get("PATH", "")
+                    subprocess.run(["bash", str(setup_path)], check=True, env=setup_env)
+
+            # 7  -- write .installed marker
+            (env_dir / ".installed").write_text("")
+        except BaseException:
+            shutil.rmtree(env_dir, ignore_errors=True)
+            raise
 
         return env_dir
 
@@ -194,7 +206,11 @@ class EnvironmentInstaller:
             hash_parts.append(setup_path.read_text())
         if sysdeps_path is not None:
             hash_parts.append(sysdeps_path.read_text())
-        content_hash = hashlib.sha256("".join(hash_parts).encode()).hexdigest()[:12]
+        h = hashlib.sha256()
+        for part in hash_parts:
+            h.update(part.encode())
+            h.update(b"\x00")
+        content_hash = h.hexdigest()[:12]
         image_tag = f"exgentic-{kind}-{slug}:{content_hash}"
 
         # Reuse existing image unless force -----------------------------

--- a/tests/utils/test_installer.py
+++ b/tests/utils/test_installer.py
@@ -498,6 +498,60 @@ class TestFailureModes:
                     installer.install("bench", "benchmark", module_path=module_path)
 
 
+class TestDockerForceReinstall:
+    """Tests for docker force-reinstall behaviour."""
+
+    def test_force_reinstall_docker(self, tmp_path: Path) -> None:
+        """force=True rebuilds the docker image even when it already exists."""
+        module_path = _create_fake_package(tmp_path, with_requirements=True, with_setup=False)
+        installer = EnvironmentInstaller(base_dir=tmp_path / "envs")
+
+        build_calls: list[list[str]] = []
+
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "docker":
+                if cmd[1] == "build":
+                    build_calls.append(list(cmd))
+                if cmd[1:3] == ["image", "inspect"]:
+                    # Pretend the image already exists
+                    return _docker_mock_result(returncode=0)
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=side_effect):
+            installer.install("my-bench", "benchmark", runner="docker", force=True, module_path=module_path)
+
+        assert len(build_calls) == 1, "docker build should be called when force=True even if image exists"
+
+
+class TestCleanupOnFailedInstall:
+    """Tests that partial state is cleaned up when venv install fails."""
+
+    def test_cleanup_on_failed_install(self, tmp_path: Path) -> None:
+        """Verify env dir is removed when install fails partway through."""
+        module_path = _create_fake_package(tmp_path, with_requirements=False, with_setup=False)
+        installer = EnvironmentInstaller(base_dir=tmp_path / "envs")
+        env_dir = installer.env_path("bench", "benchmark")
+
+        # Make _find_project_root return a path so the exgentic install
+        # step runs, then have that subprocess.run call fail.
+        original_run = subprocess.run
+
+        def fail_exgentic_install(cmd, **kwargs):
+            # Let venv creation succeed but fail the pip install step
+            if isinstance(cmd, list) and "pip" in cmd and "install" in cmd:
+                raise subprocess.CalledProcessError(1, cmd)
+            return original_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=fail_exgentic_install):
+            with mock.patch("exgentic.utils.installer._find_project_root", return_value=Path("/fake/root")):
+                with pytest.raises(subprocess.CalledProcessError):
+                    installer.install("bench", "benchmark", module_path=module_path)
+
+        # The env directory must be cleaned up after failure
+        assert not env_dir.exists(), "env_dir should be removed after a failed install"
+
+
 class TestContentCorrectness:
     """Tests for marker content and directory structure."""
 


### PR DESCRIPTION
## Summary

- Adds `src/exgentic/utils/installer.py` with an `EnvironmentInstaller` class that manages isolated venv-based environments for benchmarks and agents under `~/.exgentic/{kind}s/{slug}/`
- Each environment gets its own Python venv (via `uv`), installed dependencies, setup.sh execution, and `.installed` marker
- Adds 12 unit tests in `tests/utils/test_installer.py` covering install, skip-if-installed, force-reinstall, uninstall, list, setup.sh execution, and missing-uv error handling

## Test plan

- [x] All 12 tests pass: `uv run pytest tests/utils/test_installer.py -v`
- [x] Pre-commit hooks pass: `uv run pre-commit run --all-files`

Refs #50