### PR TITLE
Fix evaluate failing after uv tool install

### DIFF
--- a/src/exgentic/interfaces/lib/api.py
+++ b/src/exgentic/interfaces/lib/api.py
@@ -701,8 +701,9 @@ def setup_benchmark(benchmark: str, force: bool = False, runner: str | None = No
             from ...adapters.runners._utils import find_project_root
 
             root = find_project_root()
+            install_target = str(root) if (root / "pyproject.toml").exists() else "exgentic"
             subprocess.run(
-                [uv_bin, "pip", "install", "--python", str(venv_path / "bin" / "python"), "--no-cache", str(root)],
+                [uv_bin, "pip", "install", "--python", str(venv_path / "bin" / "python"), "--no-cache", install_target],
                 check=True,
                 capture_output=True,
                 text=True,
@@ -776,8 +777,9 @@ def setup_agent(agent: str, force: bool = False, runner: str | None = None) -> N
             from ...adapters.runners._utils import find_project_root
 
             root = find_project_root()
+            install_target = str(root) if (root / "pyproject.toml").exists() else "exgentic"
             subprocess.run(
-                [uv_bin, "pip", "install", "--python", str(venv_path / "bin" / "python"), "--no-cache", str(root)],
+                [uv_bin, "pip", "install", "--python", str(venv_path / "bin" / "python"), "--no-cache", install_target],
                 check=True,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
## Summary

- Fix `exgentic evaluate` crashing with `uv tool install` environments
- When no `pyproject.toml` exists at project root, install exgentic from PyPI instead of local path
- Applies to both benchmark and agent venv setup

## Problem

After `uv tool install exgentic`, running `exgentic evaluate` fails:
```
error: /Users/.../.exgentic does not appear to be a Python project,
as neither pyproject.toml nor setup.py are present
```

The venv runner tried to install exgentic from `find_project_root()` which returns `~/.exgentic/` — not a Python project.

## Fix

One-line check: if `pyproject.toml` exists at root, install from local path (dev mode). Otherwise install `exgentic` from PyPI.

## Test plan

- [ ] `uv tool install exgentic` → `exgentic setup --benchmark tau2` → `exgentic evaluate` works
- [ ] Dev mode (from repo with pyproject.toml) still installs from local source