### PR TITLE
Add project_root and packages to EnvironmentManager

### DIFF
--- a/src/exgentic/environment/docker.py
+++ b/src/exgentic/environment/docker.py
@@ -12,6 +12,8 @@ import sys
 import tempfile
 from pathlib import Path
 
+import tomllib
+
 from .helpers import find_package_file, read_lines
 
 
@@ -30,24 +32,50 @@ class DockerBackend:
         Args:
             env_dir: Root directory for this environment.
             module_path: Dotted module path for locating package resources.
-            **kwargs: Accepts ``name`` (environment name) and ``force``.
+            **kwargs: Accepts ``name``, ``force``, ``project_root`` (Path),
+                and ``packages`` (list[str]).
 
         Returns:
             Marker data with ``image`` tag.
         """
         name: str = kwargs.get("name", env_dir.name)  # type: ignore[assignment]
         force: bool = kwargs.get("force", False)  # type: ignore[assignment]
+        project_root: Path | None = kwargs.get("project_root")  # type: ignore[assignment]
+        packages: list[str] | None = kwargs.get("packages")  # type: ignore[assignment]
 
         req_path = find_package_file(module_path, "requirements.txt") if module_path else None
         setup_path = find_package_file(module_path, "setup.sh") if module_path else None
         sysdeps_path = find_package_file(module_path, "system-deps.txt") if module_path else None
 
-        image_tag = self._image_tag(name, req_path, setup_path, sysdeps_path)
+        image_tag = self._image_tag(
+            name,
+            req_path,
+            setup_path,
+            sysdeps_path,
+            project_root=project_root,
+            packages=packages,
+        )
 
         if not force and self._image_exists(image_tag):
             return {"image": image_tag}
 
-        self._build_image(image_tag, req_path, setup_path, sysdeps_path)
+        if project_root is not None:
+            self._build_project_image(
+                image_tag,
+                project_root,
+                req_path=req_path,
+                setup_path=setup_path,
+                sysdeps_path=sysdeps_path,
+                packages=packages,
+            )
+        else:
+            self._build_image(
+                image_tag,
+                req_path,
+                setup_path,
+                sysdeps_path,
+                packages=packages,
+            )
         return {"image": image_tag}
 
     def uninstall(self, env_dir: Path, marker_data: dict) -> None:
@@ -66,12 +94,25 @@ class DockerBackend:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _image_tag(name: str, *file_paths: Path | None) -> str:
+    def _image_tag(
+        name: str,
+        *file_paths: Path | None,
+        project_root: Path | None = None,
+        packages: list[str] | None = None,
+    ) -> str:
         """Compute a deterministic image tag from content hashes."""
         h = hashlib.sha256()
         for path in file_paths:
             if path is not None:
                 h.update(path.read_text().encode())
+            h.update(b"\x00")
+        if project_root is not None:
+            pyproject = project_root / "pyproject.toml"
+            if pyproject.is_file():
+                h.update(pyproject.read_text().encode())
+            h.update(b"\x00")
+        if packages:
+            h.update("\n".join(sorted(packages)).encode())
             h.update(b"\x00")
         safe_name = name.replace("/", "-")
         return f"{safe_name}:{h.hexdigest()[:12]}"
@@ -92,7 +133,10 @@ class DockerBackend:
         req_path: Path | None,
         setup_path: Path | None,
         sysdeps_path: Path | None,
+        *,
+        packages: list[str] | None = None,
     ) -> None:
+        """Build an image without a project root (original behavior)."""
         py_version = f"{sys.version_info.major}.{sys.version_info.minor}"
         tmp_dir = Path(tempfile.mkdtemp(prefix="exgentic-docker-"))
         try:
@@ -117,6 +161,9 @@ class DockerBackend:
                 lines.append("COPY requirements.txt /tmp/")
                 lines.append("RUN GIT_LFS_SKIP_SMUDGE=1 uv pip install --no-cache -r /tmp/requirements.txt")
 
+            if packages:
+                lines.append(f"RUN uv pip install --no-cache {' '.join(packages)}")
+
             if setup_path is not None:
                 shutil.copy2(setup_path, tmp_dir / "setup.sh")
                 lines.append("COPY setup.sh /tmp/")
@@ -130,3 +177,102 @@ class DockerBackend:
             )
         finally:
             shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    @staticmethod
+    def _build_project_image(
+        tag: str,
+        project_root: Path,
+        *,
+        req_path: Path | None = None,
+        setup_path: Path | None = None,
+        sysdeps_path: Path | None = None,
+        packages: list[str] | None = None,
+    ) -> None:
+        """Build an image with two-layer project install for caching."""
+        py_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+        lines = [
+            f"FROM python:{py_version}-slim",
+            "RUN apt-get update && apt-get install -y --no-install-recommends git git-lfs"
+            " && rm -rf /var/lib/apt/lists/* && git lfs install",
+            "RUN pip install --no-cache-dir uv",
+            "ENV UV_SYSTEM_PYTHON=true",
+            "WORKDIR /app",
+        ]
+
+        if sysdeps_path is not None:
+            pkgs = read_lines(sysdeps_path)
+            if pkgs:
+                lines.append(
+                    "RUN apt-get update && apt-get install -y " + " ".join(pkgs) + " && rm -rf /var/lib/apt/lists/*"
+                )
+
+        # Layer 1 — install dependencies (cached unless pyproject.toml changes).
+        copy_parts = ["COPY pyproject.toml ./"]
+        if (project_root / "README.md").is_file():
+            copy_parts.append("COPY README.md ./")
+        lines.append(" ".join(copy_parts) if len(copy_parts) == 1 else "\n".join(copy_parts))
+
+        # Determine the package name for the stub __init__.py.
+        pyproject_data = tomllib.loads((project_root / "pyproject.toml").read_text())
+        pkg_name = pyproject_data.get("project", {}).get("name", "").replace("-", "_")
+        if pkg_name:
+            lines.append(f"RUN mkdir -p src/{pkg_name} && touch src/{pkg_name}/__init__.py")
+
+        # Create stub directories for hatch force-include paths.
+        force_includes = (
+            pyproject_data.get("tool", {})
+            .get("hatch", {})
+            .get("build", {})
+            .get("targets", {})
+            .get("wheel", {})
+            .get("force-include", {})
+        )
+        for src_path in force_includes:
+            lines.append(f"RUN mkdir -p '{src_path}'")
+
+        lines.append("RUN uv pip install --no-cache .")
+
+        # Layer 2 — install source code only (fast, deps already cached).
+        lines.extend(
+            [
+                "COPY src/ src/",
+                "RUN uv pip install --no-cache --no-deps .",
+            ]
+        )
+
+        # Module requirements.
+        if req_path is not None:
+            try:
+                rel = req_path.resolve().relative_to(project_root.resolve())
+                lines.append(f"COPY {rel} /tmp/requirements.txt")
+            except ValueError:
+                # req_path is outside project_root — copy into build context.
+                shutil.copy2(req_path, project_root / ".tmp_requirements.txt")
+                lines.append("COPY .tmp_requirements.txt /tmp/requirements.txt")
+            lines.append("RUN GIT_LFS_SKIP_SMUDGE=1 uv pip install --no-cache -r /tmp/requirements.txt")
+
+        # Extra packages.
+        if packages:
+            lines.append(f"RUN uv pip install --no-cache {' '.join(packages)}")
+
+        # Setup script.
+        if setup_path is not None:
+            try:
+                rel = setup_path.resolve().relative_to(project_root.resolve())
+                lines.append(f"COPY {rel} /tmp/setup.sh")
+            except ValueError:
+                shutil.copy2(setup_path, project_root / ".tmp_setup.sh")
+                lines.append("COPY .tmp_setup.sh /tmp/setup.sh")
+            lines.append("RUN bash /tmp/setup.sh")
+
+        # Write Dockerfile to a temp file and build with project_root as context.
+        dockerfile = Path(tempfile.mktemp(prefix="exgentic-dockerfile-", suffix=".Dockerfile"))
+        try:
+            dockerfile.write_text("\n".join(lines) + "\n")
+            subprocess.run(
+                ["docker", "build", "-f", str(dockerfile), "-t", tag, str(project_root)],
+                check=True,
+            )
+        finally:
+            dockerfile.unlink(missing_ok=True)

--- a/src/exgentic/environment/helpers.py
+++ b/src/exgentic/environment/helpers.py
@@ -30,6 +30,17 @@ def build_subprocess_env() -> dict:
     return env
 
 
+def install_project(uv: str, python_target: str, project_root: Path, env: dict) -> None:
+    """Install a Python project from *project_root* into the target Python."""
+    subprocess.run(
+        [uv, "pip", "install", "--python", python_target, "--no-cache", str(project_root)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
 def install_packages(uv: str, python_target: str, packages: list[str], env: dict) -> None:
     """Install packages into the target Python environment."""
     subprocess.run(

--- a/src/exgentic/environment/local.py
+++ b/src/exgentic/environment/local.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 from .helpers import (
     build_subprocess_env,
+    install_packages,
+    install_project,
     install_requirements,
     require_uv,
     run_setup_sh,
@@ -32,17 +34,28 @@ class LocalBackend:
         Args:
             env_dir: Root directory for data/markers.
             module_path: Dotted module path for locating package resources.
-            **kwargs: Additional keyword arguments (ignored).
+            **kwargs: Accepts ``project_root`` (Path) and ``packages`` (list).
 
         Returns:
             Extra marker data (``python`` path).
         """
-        if module_path is not None:
+        project_root: Path | None = kwargs.get("project_root")  # type: ignore[assignment]
+        packages: list[str] | None = kwargs.get("packages")  # type: ignore[assignment]
+
+        if project_root is not None or packages or module_path is not None:
             uv = require_uv()
             env = build_subprocess_env()
-            install_requirements(uv, sys.executable, module_path, env)
-            validate_system_deps(module_path)
-            run_setup_sh(module_path, env_dir)
+
+            if project_root is not None:
+                install_project(uv, sys.executable, project_root, env)
+
+            if packages:
+                install_packages(uv, sys.executable, packages, env)
+
+            if module_path is not None:
+                install_requirements(uv, sys.executable, module_path, env)
+                validate_system_deps(module_path)
+                run_setup_sh(module_path, env_dir)
 
         return {"python": sys.executable}
 

--- a/src/exgentic/environment/manager.py
+++ b/src/exgentic/environment/manager.py
@@ -55,7 +55,8 @@ class EnvironmentManager:
         env_type: EnvType = EnvType.VENV,
         force: bool = False,
         module_path: str | None = None,
-        venv_packages: list[str] | None = None,
+        project_root: Path | None = None,
+        packages: list[str] | None = None,
     ) -> Path:
         """Install an environment.
 
@@ -64,7 +65,8 @@ class EnvironmentManager:
             env_type: Type of environment to create.
             force: Re-create even if already installed.
             module_path: Dotted module path for locating package resources.
-            venv_packages: Extra packages to install (venv only).
+            project_root: Root of a Python project to install into the env.
+            packages: Extra pip packages to install.
 
         Returns:
             The environment directory path.
@@ -81,8 +83,10 @@ class EnvironmentManager:
 
         # Build kwargs for the backend.
         kwargs: dict[str, object] = {}
-        if venv_packages is not None:
-            kwargs["venv_packages"] = venv_packages
+        if project_root is not None:
+            kwargs["project_root"] = project_root
+        if packages is not None:
+            kwargs["packages"] = packages
         if env_type is EnvType.DOCKER:
             kwargs["name"] = name
             kwargs["force"] = force

--- a/src/exgentic/environment/protocol.py
+++ b/src/exgentic/environment/protocol.py
@@ -18,7 +18,11 @@ class EnvironmentBackend(Protocol):
         Args:
             env_dir: Root directory for this environment.
             module_path: Dotted module path for locating package resources.
-            **kwargs: Backend-specific options (e.g. ``venv_packages``).
+            **kwargs: Common options forwarded by the manager:
+                ``project_root`` (Path | None) - root of a Python project to install.
+                ``packages`` (list[str] | None) - extra pip packages to install.
+                Backends may also receive backend-specific options (e.g. ``name``,
+                ``force`` for Docker).
 
         Returns:
             Extra marker data to persist (may be empty).

--- a/src/exgentic/environment/venv.py
+++ b/src/exgentic/environment/venv.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from .helpers import (
     build_subprocess_env,
     install_packages,
+    install_project,
     install_requirements,
     require_uv,
     run_setup_sh,
@@ -35,12 +36,13 @@ class VenvBackend:
         Args:
             env_dir: Root directory for this environment.
             module_path: Dotted module path for locating package resources.
-            **kwargs: Accepts ``venv_packages`` (list of extra packages).
+            **kwargs: Accepts ``project_root`` (Path) and ``packages`` (list).
 
         Returns:
             Empty dict (no extra marker data).
         """
-        venv_packages: list[str] | None = kwargs.get("venv_packages")  # type: ignore[assignment]
+        project_root: Path | None = kwargs.get("project_root")  # type: ignore[assignment]
+        packages: list[str] | None = kwargs.get("packages")  # type: ignore[assignment]
 
         venv_dir = env_dir / "venv"
         if venv_dir.exists():
@@ -59,8 +61,11 @@ class VenvBackend:
             venv_py = str(venv_dir / "bin" / "python")
             env = build_subprocess_env()
 
-            if venv_packages:
-                install_packages(uv, venv_py, venv_packages, env)
+            if project_root is not None:
+                install_project(uv, venv_py, project_root, env)
+
+            if packages:
+                install_packages(uv, venv_py, packages, env)
 
             if module_path is not None:
                 install_requirements(uv, venv_py, module_path, env)

--- a/tests/environment/test_manager.py
+++ b/tests/environment/test_manager.py
@@ -90,6 +90,33 @@ def _docker_mock_result(**overrides):
     return result
 
 
+def _create_fake_project(tmp_path: Path, *, name: str = "myproject") -> Path:
+    """Create a minimal Python project with pyproject.toml and src layout."""
+    project = tmp_path / f"project_{name}"
+    project.mkdir(parents=True)
+    pkg_name = name.replace("-", "_")
+    src_dir = project / "src" / pkg_name
+    src_dir.mkdir(parents=True)
+    (src_dir / "__init__.py").write_text('__version__ = "0.1.0"\n')
+    (project / "README.md").write_text(f"# {name}\n")
+    (project / "pyproject.toml").write_text(
+        textwrap.dedent(
+            f"""\
+        [project]
+        name = "{name}"
+        version = "0.1.0"
+        requires-python = ">=3.10"
+        dependencies = []
+
+        [build-system]
+        requires = ["hatchling"]
+        build-backend = "hatchling.build"
+        """
+        )
+    )
+    return project
+
+
 # ---------------------------------------------------------------------------
 # Venv install
 # ---------------------------------------------------------------------------
@@ -157,7 +184,7 @@ class TestVenvInstall:
 
         with mock.patch("subprocess.run", side_effect=fail_pip):
             with pytest.raises(subprocess.CalledProcessError):
-                mgr.install("mybench", venv_packages=["some-pkg"], module_path=module_path)
+                mgr.install("mybench", packages=["some-pkg"], module_path=module_path)
 
         venv_dir = mgr.env_path("mybench") / "venv"
         assert not venv_dir.exists()
@@ -934,6 +961,280 @@ class TestRequireUv:
 
 
 # ---------------------------------------------------------------------------
+# Project root & packages
+# ---------------------------------------------------------------------------
+
+
+class TestVenvProjectRoot:
+    """Venv backend installs a Python project from project_root."""
+
+    def test_project_root_installs_project(self, tmp_path: Path) -> None:
+        project = _create_fake_project(tmp_path)
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        pip_calls: list[list[str]] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "pip" in cmd and "install" in cmd:
+                pip_calls.append(list(cmd))
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("mybench", project_root=project)
+
+        # First pip call should install the project root.
+        assert len(pip_calls) >= 1
+        assert str(project) in pip_calls[0]
+
+    def test_packages_installed_into_venv(self, tmp_path: Path) -> None:
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        pip_calls: list[list[str]] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "pip" in cmd and "install" in cmd:
+                pip_calls.append(list(cmd))
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("mybench", packages=["numpy", "pandas"])
+
+        assert len(pip_calls) == 1
+        assert "numpy" in pip_calls[0]
+        assert "pandas" in pip_calls[0]
+
+    def test_project_root_and_packages_combined(self, tmp_path: Path) -> None:
+        project = _create_fake_project(tmp_path)
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        pip_calls: list[list[str]] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "pip" in cmd and "install" in cmd:
+                pip_calls.append(list(cmd))
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("mybench", project_root=project, packages=["numpy"])
+
+        # Two separate pip calls: project root, then packages.
+        assert len(pip_calls) == 2
+        assert str(project) in pip_calls[0]
+        assert "numpy" in pip_calls[1]
+
+    def test_without_project_root_still_works(self, tmp_path: Path) -> None:
+        module_path = _create_fake_package(tmp_path, with_requirements=False, with_setup=False)
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        env_dir = mgr.install("mybench", module_path=module_path)
+
+        assert (env_dir / "venv" / "bin" / "python").exists()
+        assert mgr.is_installed("mybench", env_type=EnvType.VENV)
+
+
+class TestLocalProjectRoot:
+    """Local backend installs project_root and packages into host Python."""
+
+    def test_project_root_installs_into_host_python(self, tmp_path: Path) -> None:
+        project = _create_fake_project(tmp_path)
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        pip_calls: list[list[str]] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "pip" in cmd and "install" in cmd:
+                pip_calls.append(list(cmd))
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("mybench", env_type=EnvType.LOCAL, project_root=project)
+
+        assert len(pip_calls) == 1
+        assert str(project) in pip_calls[0]
+        python_idx = pip_calls[0].index("--python") + 1
+        assert pip_calls[0][python_idx] == sys.executable
+
+    def test_packages_installs_into_host_python(self, tmp_path: Path) -> None:
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        pip_calls: list[list[str]] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and "pip" in cmd and "install" in cmd:
+                pip_calls.append(list(cmd))
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("mybench", env_type=EnvType.LOCAL, packages=["numpy"])
+
+        assert len(pip_calls) == 1
+        assert "numpy" in pip_calls[0]
+
+
+class TestDockerProjectRoot:
+    """Docker backend uses two-layer build when project_root is provided."""
+
+    def test_project_root_triggers_two_layer_build(self, tmp_path: Path) -> None:
+        project = _create_fake_project(tmp_path)
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        dockerfiles: list[str] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[0] == "docker":
+                if cmd[1] == "build":
+                    # Read dockerfile from -f argument.
+                    if "-f" in cmd:
+                        df_idx = list(cmd).index("-f") + 1
+                        df_path = Path(cmd[df_idx])
+                        if df_path.exists():
+                            dockerfiles.append(df_path.read_text())
+                if cmd[1:3] == ["image", "inspect"]:
+                    return _docker_mock_result(returncode=1)
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("mybench", env_type=EnvType.DOCKER, project_root=project)
+
+        assert len(dockerfiles) == 1
+        df = dockerfiles[0]
+        assert "COPY pyproject.toml" in df
+        assert "COPY src/ src/" in df
+        assert "uv pip install --no-cache ." in df
+        assert "uv pip install --no-cache --no-deps ." in df
+
+    def test_docker_build_context_is_project_root(self, tmp_path: Path) -> None:
+        project = _create_fake_project(tmp_path)
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        build_contexts: list[str] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[0] == "docker":
+                if cmd[1] == "build":
+                    build_contexts.append(cmd[-1])
+                if cmd[1:3] == ["image", "inspect"]:
+                    return _docker_mock_result(returncode=1)
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("mybench", env_type=EnvType.DOCKER, project_root=project)
+
+        assert len(build_contexts) == 1
+        assert build_contexts[0] == str(project)
+
+    def test_docker_without_project_root_uses_tmp_dir(self, tmp_path: Path) -> None:
+        module_path = _create_fake_package(tmp_path, with_requirements=True, with_setup=False)
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        build_contexts: list[str] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[0] == "docker":
+                if cmd[1] == "build":
+                    build_contexts.append(cmd[-1])
+                if cmd[1:3] == ["image", "inspect"]:
+                    return _docker_mock_result(returncode=1)
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("mybench", env_type=EnvType.DOCKER, module_path=module_path)
+
+        assert len(build_contexts) == 1
+        assert "exgentic-docker-" in build_contexts[0]
+
+    def test_docker_packages_in_dockerfile(self, tmp_path: Path) -> None:
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        dockerfiles: list[str] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[0] == "docker":
+                if cmd[1] == "build":
+                    df = Path(cmd[-1]) / "Dockerfile"
+                    if df.exists():
+                        dockerfiles.append(df.read_text())
+                if cmd[1:3] == ["image", "inspect"]:
+                    return _docker_mock_result(returncode=1)
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("mybench", env_type=EnvType.DOCKER, packages=["numpy", "pandas"])
+
+        assert len(dockerfiles) == 1
+        assert "uv pip install --no-cache numpy pandas" in dockerfiles[0]
+
+    def test_content_hash_includes_project_root(self, tmp_path: Path) -> None:
+        project = _create_fake_project(tmp_path, name="proj-a")
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        tags: list[str] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[0] == "docker":
+                if cmd[1] == "build":
+                    idx = list(cmd).index("-t")
+                    tags.append(cmd[idx + 1])
+                if cmd[1:3] == ["image", "inspect"]:
+                    return _docker_mock_result(returncode=1)
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("a", env_type=EnvType.DOCKER, project_root=project)
+            mgr.install("b", env_type=EnvType.DOCKER)
+
+        assert len(tags) == 2
+        assert tags[0].split(":")[-1] != tags[1].split(":")[-1]
+
+    def test_project_root_with_force_includes(self, tmp_path: Path) -> None:
+        project = _create_fake_project(tmp_path, name="withfi")
+        # Add force-include to pyproject.toml.
+        pyproject = project / "pyproject.toml"
+        pyproject.write_text(
+            pyproject.read_text()
+            + textwrap.dedent(
+                """\
+
+            [tool.hatch.build.targets.wheel.force-include]
+            "configs/" = "withfi/configs/"
+            """
+            )
+        )
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        dockerfiles: list[str] = []
+
+        def capture_run(cmd, **kwargs):
+            if isinstance(cmd, list) and cmd[0] == "docker":
+                if cmd[1] == "build":
+                    if "-f" in cmd:
+                        df_idx = list(cmd).index("-f") + 1
+                        df_path = Path(cmd[df_idx])
+                        if df_path.exists():
+                            dockerfiles.append(df_path.read_text())
+                if cmd[1:3] == ["image", "inspect"]:
+                    return _docker_mock_result(returncode=1)
+                return _docker_mock_result()
+            return _real_subprocess_run(cmd, **kwargs)
+
+        with mock.patch("subprocess.run", side_effect=capture_run):
+            mgr.install("mybench", env_type=EnvType.DOCKER, project_root=project)
+
+        assert len(dockerfiles) == 1
+        assert "mkdir -p 'configs/'" in dockerfiles[0]
+
+
+# ---------------------------------------------------------------------------
 # Docker integration (requires Docker/Podman running)
 # ---------------------------------------------------------------------------
 
@@ -1009,3 +1310,43 @@ class TestDockerIntegration:
         assert not mgr.is_installed("inttest4", env_type=EnvType.DOCKER)
 
         mgr.uninstall("inttest4")
+
+    def test_docker_project_root_installs_package(self, tmp_path: Path) -> None:
+        """Build Docker image with project_root and verify the package is importable inside."""
+        project = _create_fake_project(tmp_path, name="mypkg")
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        mgr.install("inttest5", env_type=EnvType.DOCKER, project_root=project)
+
+        image_tag = mgr.docker_image("inttest5")
+        assert image_tag is not None
+
+        result = subprocess.run(
+            ["docker", "run", "--rm", image_tag, "python", "-c", "import mypkg; print(mypkg.__version__)"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "0.1.0"
+
+        mgr.uninstall("inttest5")
+
+    def test_venv_project_root_installs_package(self, tmp_path: Path) -> None:
+        """Create venv with project_root and verify the package is importable inside."""
+        project = _create_fake_project(tmp_path, name="mypkg2")
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+
+        mgr.install("inttest6", env_type=EnvType.VENV, project_root=project)
+
+        venv_py = mgr.venv_python("inttest6")
+        result = subprocess.run(
+            [venv_py, "-c", "import mypkg2; print(mypkg2.__version__)"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "0.1.0"
+
+        mgr.uninstall("inttest6")


### PR DESCRIPTION
## Summary

- All three backends (venv, local, docker) now accept `project_root: Path | None` to install a Python project and `packages: list[str] | None` for extra pip deps
- Replaces the `venv_packages` param with the generic `packages` that works across all backends
- Docker uses a two-layer build when `project_root` is given: deps layer (pyproject.toml + stubs → `uv pip install .`) cached separately from the source layer (COPY src/ → `uv pip install --no-deps .`), so source-only changes don't bust the dep cache
- Image tag hash includes `project_root`'s pyproject.toml content and sorted packages, so content changes trigger rebuilds

## Test plan

- [ ] `pytest tests/environment/test_manager.py -k "not TestDockerIntegration"` — 69 unit tests pass (Docker calls mocked; Dockerfile content and build context verified)
- [ ] `TestDockerProjectRoot` — 6 new tests: two-layer build triggered, build context is project_root, packages in Dockerfile, hash changes with project_root, force-include stubs
- [ ] `TestVenvProjectRoot` — 4 new tests: project_root installs project into venv, packages installed, both combined, without project_root still works
- [ ] `TestLocalProjectRoot` — 2 new tests: project_root and packages installed into host Python
- [ ] `TestDockerIntegration::test_docker_project_root_installs_package` — builds real image, runs `import mypkg` inside container (requires Docker daemon)
- [ ] `TestDockerIntegration::test_venv_project_root_installs_package` — creates real venv, runs `import mypkg2` inside it (requires Docker daemon for full suite)