### PR TITLE
Filter UV_*, PIP_*, CONDA_* vars from subprocess env during installs

### DIFF
--- a/src/exgentic/environment/helpers.py
+++ b/src/exgentic/environment/helpers.py
@@ -22,10 +22,29 @@ def require_uv() -> str:
     return uv
 
 
+_ENV_BLOCKLIST: frozenset[str] = frozenset(
+    {
+        "VIRTUAL_ENV",
+        "CONDA_DEFAULT_ENV",
+        "CONDA_PREFIX",
+    }
+)
+_ENV_PREFIX_BLOCKLIST: tuple[str, ...] = ("UV_", "PIP_", "VSCODE_", "LC_")
+
+
 def build_subprocess_env() -> dict:
-    """Build an env dict for subprocess calls."""
-    env = os.environ.copy()
-    env.pop("VIRTUAL_ENV", None)
+    """Build a filtered env dict for subprocess calls.
+
+    Strips virtual-env manager vars and package-tool overrides
+    (``UV_*``, ``PIP_*``) that could redirect package installs or
+    change the Python version used by uv/pip.  Preserves ``PATH``,
+    ``HOME``, and other vars needed for tools to run.
+    """
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in _ENV_BLOCKLIST and not any(k.startswith(p) for p in _ENV_PREFIX_BLOCKLIST)
+    }
     env["GIT_LFS_SKIP_SMUDGE"] = "1"
     return env
 
@@ -82,7 +101,7 @@ def run_setup_sh(module_path: str, env_dir: Path, *, venv_dir: Path | None = Non
     setup_path = find_package_file(module_path, "setup.sh")
     if setup_path is None:
         return
-    env = os.environ.copy()
+    env = build_subprocess_env()
     if venv_dir is not None:
         env["VIRTUAL_ENV"] = str(venv_dir)
         env["PATH"] = str(venv_dir / "bin") + os.pathsep + env.get("PATH", "")

--- a/tests/environment/test_manager.py
+++ b/tests/environment/test_manager.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 import shutil
 import stat
 import subprocess
@@ -22,7 +23,7 @@ from unittest import mock
 
 import pytest
 from exgentic.environment import EnvironmentManager, EnvType
-from exgentic.environment.helpers import find_package_file, require_uv
+from exgentic.environment.helpers import build_subprocess_env, find_package_file, require_uv
 
 _pkg_counter = 0
 
@@ -958,6 +959,49 @@ class TestRequireUv:
         with mock.patch("shutil.which", return_value=None):
             with pytest.raises(RuntimeError, match="Could not find 'uv'"):
                 require_uv()
+
+
+class TestBuildSubprocessEnv:
+    """build_subprocess_env strips vars that could interfere with installs."""
+
+    def test_strips_virtual_env(self) -> None:
+        with mock.patch.dict(os.environ, {"VIRTUAL_ENV": "/some/venv"}, clear=False):
+            env = build_subprocess_env()
+        assert "VIRTUAL_ENV" not in env
+
+    def test_strips_conda_vars(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"CONDA_DEFAULT_ENV": "base", "CONDA_PREFIX": "/opt/conda"},
+            clear=False,
+        ):
+            env = build_subprocess_env()
+        assert "CONDA_DEFAULT_ENV" not in env
+        assert "CONDA_PREFIX" not in env
+
+    def test_strips_uv_prefix_vars(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"UV_INDEX_URL": "https://evil.example.com", "UV_PYTHON": "3.8"},
+            clear=False,
+        ):
+            env = build_subprocess_env()
+        assert "UV_INDEX_URL" not in env
+        assert "UV_PYTHON" not in env
+
+    def test_strips_pip_prefix_vars(self) -> None:
+        with mock.patch.dict(os.environ, {"PIP_INDEX_URL": "https://evil.example.com"}, clear=False):
+            env = build_subprocess_env()
+        assert "PIP_INDEX_URL" not in env
+
+    def test_preserves_path_and_home(self) -> None:
+        env = build_subprocess_env()
+        assert "PATH" in env
+        assert "HOME" in env
+
+    def test_sets_git_lfs_skip_smudge(self) -> None:
+        env = build_subprocess_env()
+        assert env["GIT_LFS_SKIP_SMUDGE"] == "1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `build_subprocess_env()` now strips `UV_*`, `PIP_*`, `VSCODE_*`, `LC_*` prefix vars and `CONDA_DEFAULT_ENV`/`CONDA_PREFIX` block vars, in addition to `VIRTUAL_ENV`
- Prevents host tool overrides (e.g. `UV_INDEX_URL`, `PIP_INDEX_URL`, `UV_PYTHON`) from redirecting package installs or changing the Python version used during environment setup
- `run_setup_sh()` now uses `build_subprocess_env()` as its base instead of a raw `os.environ.copy()`, so setup scripts get the same filtered env
- `PATH` and `HOME` are preserved (needed for tools like `git`, `curl` during setup)

## Test plan

- [ ] `pytest tests/environment/test_manager.py -k "not TestDockerIntegration"` — 75 tests pass
- [ ] `TestBuildSubprocessEnv` — 6 new tests: strips VIRTUAL_ENV, CONDA_*, UV_* prefix, PIP_* prefix, preserves PATH/HOME, sets GIT_LFS_SKIP_SMUDGE