### PR TITLE
Add public API to Agent/Benchmark, prefix internals with _

### DIFF
--- a/docs/adding-agents.md
+++ b/docs/adding-agents.md
@@ -17,7 +17,7 @@ The agent adapts to the benchmark contract, not the other way around.
 
 That means:
 - the benchmark decides the task, context, actions, step flow, and scoring
-- the agent receives these through `get_instance_kwargs()` and must work within them
+- the agent receives these through `_get_instance_kwargs()` and must work within them
 - the agent should not require benchmark modifications to function
 - the agent should not impose protocol-specific assumptions on the benchmark
 
@@ -39,8 +39,8 @@ Exgentic agents are split into two classes with distinct roles:
 Responsibilities:
 - declare `display_name` and `slug_name` as `ClassVar[str]`
 - hold user-facing configuration fields (model name, max steps, feature flags)
-- implement `get_instance_class()` to resolve the execution class
-- implement `get_instance_kwargs()` to translate config + benchmark contract into constructor arguments
+- implement `_get_instance_class()` to resolve the execution class
+- implement `_get_instance_kwargs()` to translate config + benchmark contract into constructor arguments
 - optionally override `setup()` for non-pip setup (Docker builds, npm installs)
 - optionally override `model_name` / `get_models_names()` for dashboard metadata
 
@@ -54,21 +54,21 @@ Responsibilities:
 - optionally override `start()` for initialization that happens after construction
 - optionally override `get_cost()` to report monetary cost
 
-The agent instance receives a single `session_id` in its constructor, which scopes all logs and artifacts. Additional kwargs come from `get_instance_kwargs()`.
+The agent instance receives a single `session_id` in its constructor, which scopes all logs and artifacts. Additional kwargs come from `_get_instance_kwargs()`.
 
 ## Key Pattern: Lazy Import for Dependency Isolation
 
-The `get_instance_class()` classmethod must use a lazy import so that heavy dependencies are only loaded inside the runner environment, not on the host.
+The `_get_instance_class()` classmethod must use a lazy import so that heavy dependencies are only loaded inside the runner environment, not on the host.
 
 ```python
 @classmethod
-def get_instance_class(cls):
+def _get_instance_class(cls):
     from .instance import MyAgentInstance
 
     return MyAgentInstance
 ```
 
-This is the same pattern that `Benchmark.get_session_class()` uses. It ensures the host process never imports libraries like `litellm`, `smolagents`, `openai`, or any other agent-specific SDK.
+This is the same pattern that `Benchmark._get_session_class()` uses. It ensures the host process never imports libraries like `litellm`, `smolagents`, `openai`, or any other agent-specific SDK.
 
 ## When to Split Files
 
@@ -102,24 +102,24 @@ The rule is simple: if importing the instance class would pull in packages that 
 
 ### On the Agent class
 
-#### `get_instance_class()` (classmethod, abstract)
+#### `_get_instance_class()` (classmethod, abstract)
 
 Returns the `AgentInstance` subclass. Must use a lazy import.
 
 ```python
 @classmethod
-def get_instance_class(cls):
+def _get_instance_class(cls):
     from .instance import MyAgentInstance
 
     return MyAgentInstance
 ```
 
-#### `get_instance_kwargs()` (abstract)
+#### `_get_instance_kwargs()` (abstract)
 
 Translates the agent's configuration into constructor kwargs for the instance class. Task, context, and actions are passed separately via `start()`, not through the constructor.
 
 ```python
-def get_instance_kwargs(self, session_id: str) -> dict[str, Any]:
+def _get_instance_kwargs(self, session_id: str) -> dict[str, Any]:
     return {
         "session_id": session_id,
         "model": self.model,
@@ -250,7 +250,7 @@ class MyAgent(Agent):
     max_steps: int = 100
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         from .instance import MyAgentInstance
 
         return MyAgentInstance
@@ -259,7 +259,7 @@ class MyAgent(Agent):
     def model_name(self) -> str:
         return self.model
 
-    def get_instance_kwargs(self, session_id: str) -> dict[str, Any]:
+    def _get_instance_kwargs(self, session_id: str) -> dict[str, Any]:
         return {
             "session_id": session_id,
             "model": self.model,
@@ -326,15 +326,15 @@ Before opening a PR for a new agent, validate all of the following.
 ### Contract validation
 
 - Agent class declares `display_name` and `slug_name` as `ClassVar[str]`
-- `get_instance_class()` uses a lazy import
-- `get_instance_kwargs()` returns a dict whose keys match the instance constructor
+- `_get_instance_class()` uses a lazy import
+- `_get_instance_kwargs()` returns a dict whose keys match the instance constructor
 - The instance implements `react()` and `close()`
 - The instance calls `super().__init__(session_id)` in its constructor
 
 ### Dependency isolation validation
 
 - The Agent file does not import heavy third-party libraries at module level
-- Heavy imports only appear inside `get_instance_class()` or in the instance module
+- Heavy imports only appear inside `_get_instance_class()` or in the instance module
 - `requirements.txt` lists all agent-specific dependencies
 
 ### Registry validation
@@ -366,7 +366,7 @@ When in doubt, ask:
 1. Does the agent adapt to the benchmark, or does it require the benchmark to change?
 2. Are heavy dependencies isolated behind a lazy import?
 3. Is the Agent file importable without installing agent-specific packages?
-4. Does `get_instance_kwargs()` faithfully pass the benchmark contract through?
+4. Does `_get_instance_kwargs()` faithfully pass the benchmark contract through?
 5. Will this agent work with benchmarks that have very different action spaces?
 6. Is the configuration surface minimal and explicit?
 

--- a/docs/adding-benchmarks.md
+++ b/docs/adding-benchmarks.md
@@ -244,7 +244,7 @@ Do not mix setup logic directly into the runtime path when it can be handled onc
 
 The main benchmark file (`<name>_benchmark.py`) defines the `Benchmark` subclass that Exgentic loads in the host process. This file **must be importable without any benchmark-specific dependencies installed**.
 
-External dependencies (benchmark harnesses, datasets, ML libraries, etc.) belong in **separate files** that are only loaded inside the runner subprocess through `get_evaluator_class()` and `get_session_class()`.
+External dependencies (benchmark harnesses, datasets, ML libraries, etc.) belong in **separate files** that are only loaded inside the runner subprocess through `_get_evaluator_class()` and `_get_session_class()`.
 
 **Rule:** The benchmark class file may only import from:
 - Python standard library
@@ -268,7 +268,7 @@ Good:
 ```python
 # <name>_benchmark.py — no external deps
 class MyBenchmark(Benchmark):
-    def get_evaluator_class(self):
+    def _get_evaluator_class(self):
         from .<name>_eval import MyEvaluator  # loaded inside runner
         return MyEvaluator
 
@@ -283,7 +283,7 @@ For a benchmark package under `src/exgentic/benchmarks/<name>/`:
 - `<name>_benchmark.py` **(required)**
   - `Benchmark` subclass only
   - no external dependency imports
-  - `get_evaluator_class()` and `get_session_class()` return classes from other files
+  - `_get_evaluator_class()` and `_get_session_class()` return classes from other files
 - `<name>_eval.py` or `<name>_session.py` **(required if benchmark has external deps)**
   - evaluator, session, and runtime logic
   - may import external dependencies at module level
@@ -313,7 +313,7 @@ Before opening a PR for a new benchmark, validate all of the following.
 ### Import validation
 
 - the main benchmark file (`<name>_benchmark.py`) imports **no external dependencies**
-- `get_evaluator_class()` and `get_session_class()` load from separate files
+- `_get_evaluator_class()` and `_get_session_class()` load from separate files
 - `python -c "from exgentic.benchmarks.<name>.<name>_benchmark import <Class>"` works without deps installed
 
 ### Functional validation

--- a/misc/skills/add-agent/SKILL.md
+++ b/misc/skills/add-agent/SKILL.md
@@ -25,10 +25,10 @@ Then inspect the most relevant existing adapters:
    If the agent depends on heavy third-party libraries (litellm, smolagents, openai SDK, etc.), put the Agent in one file and the AgentInstance in `instance.py`. If deps are light, keep both in a single file.
 
 2. Implement the Agent class first.
-   Subclass `Agent`. Declare `display_name` and `slug_name` as `ClassVar[str]`. Add user-facing config fields. Implement `get_instance_class()` with a lazy import. Implement `get_instance_kwargs()` to translate config and the benchmark contract into instance constructor kwargs.
+   Subclass `Agent`. Declare `display_name` and `slug_name` as `ClassVar[str]`. Add user-facing config fields. Implement `_get_instance_class()` with a lazy import. Implement `_get_instance_kwargs()` to translate config and the benchmark contract into instance constructor kwargs.
 
 3. Implement the AgentInstance class.
-   Subclass `AgentInstance`. Accept `session_id` plus the kwargs from `get_instance_kwargs()`. Call `super().__init__(session_id)`. Implement `react()` as the core decision loop and `close()` for cleanup. Optionally override `start()` and `get_cost()`.
+   Subclass `AgentInstance`. Accept `session_id` plus the kwargs from `_get_instance_kwargs()`. Call `super().__init__(session_id)`. Implement `react()` as the core decision loop and `close()` for cleanup. Optionally override `start()` and `get_cost()`.
 
 4. Add `requirements.txt` for agent-specific dependencies.
    List only packages not already in the base exgentic install. Place the file in the agent's package directory; `RunnerMixin` discovers it automatically.
@@ -45,8 +45,8 @@ Then inspect the most relevant existing adapters:
 ## Non-negotiable rules
 
 - The Agent file must be importable without installing agent-specific packages.
-- `get_instance_class()` must use a lazy import to isolate heavy deps.
-- `get_instance_kwargs()` must faithfully pass the benchmark contract (task, context, actions, session_id) through to the instance.
+- `_get_instance_class()` must use a lazy import to isolate heavy deps.
+- `_get_instance_kwargs()` must faithfully pass the benchmark contract (task, context, actions, session_id) through to the instance.
 - The instance constructor must call `super().__init__(session_id)`.
 - `react()` must return `None` when the agent decides it is done.
 - `close()` must not raise exceptions.

--- a/src/exgentic/agents/cli/base.py
+++ b/src/exgentic/agents/cli/base.py
@@ -317,13 +317,13 @@ class ProxyBackedAgent(Agent):
     max_steps: int = 150
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         raise NotImplementedError
 
     execution_backend: ExecutionBackend = ExecutionBackend.AUTO
     model_settings: ModelSettings | None = None
 
-    def get_instance_kwargs(
+    def _get_instance_kwargs(
         self,
         session_id: str,
     ) -> dict[str, Any]:

--- a/src/exgentic/agents/cli/claude/agent.py
+++ b/src/exgentic/agents/cli/claude/agent.py
@@ -83,7 +83,7 @@ class ClaudeCodeAgent(ProxyBackedAgent):
     execution_backend: ExecutionBackend = ExecutionBackend.AUTO
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         return ClaudeCodeAgentInstance
 
     def get_models_names(self) -> list[str]:  # type: ignore[override]

--- a/src/exgentic/agents/cli/codex/agent.py
+++ b/src/exgentic/agents/cli/codex/agent.py
@@ -67,5 +67,5 @@ class CodexAgent(ProxyBackedAgent):
     execution_backend: ExecutionBackend = ExecutionBackend.AUTO
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         return CodexAgentInstance

--- a/src/exgentic/agents/cli/gemini/agent.py
+++ b/src/exgentic/agents/cli/gemini/agent.py
@@ -74,7 +74,7 @@ class GeminiAgent(ProxyBackedAgent):
     execution_backend: ExecutionBackend = ExecutionBackend.AUTO
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         return GeminiAgentInstance
 
     def get_models_names(self) -> list[str]:  # type: ignore[override]

--- a/src/exgentic/agents/litellm_tool_calling/litellm_tool_calling_agent.py
+++ b/src/exgentic/agents/litellm_tool_calling/litellm_tool_calling_agent.py
@@ -23,13 +23,13 @@ class LiteLLMToolCallingAgent(Agent):
     allow_truncated_messages: bool = False
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         from .instance import LiteLLMToolCallingAgentInstance
 
         return LiteLLMToolCallingAgentInstance
 
     @classmethod
-    def get_instance_class_ref(cls) -> str:
+    def _get_instance_class_ref(cls) -> str:
         return "exgentic.agents.litellm_tool_calling.instance:LiteLLMToolCallingAgentInstance"
 
     @property
@@ -39,7 +39,7 @@ class LiteLLMToolCallingAgent(Agent):
     def get_models_names(self) -> list[str]:  # type: ignore[override]
         return [str(self.model)]
 
-    def get_instance_kwargs(
+    def _get_instance_kwargs(
         self,
         session_id: str,
     ) -> dict[str, Any]:

--- a/src/exgentic/agents/openai/openai_mcp_agent.py
+++ b/src/exgentic/agents/openai/openai_mcp_agent.py
@@ -39,16 +39,16 @@ class OpenAIMCPAgent(Agent):
     mcp_config: MCPConfig | dict | None = None
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         from .instance import OpenAIMCPAgentInstance
 
         return OpenAIMCPAgentInstance
 
     @classmethod
-    def get_instance_class_ref(cls) -> str:
+    def _get_instance_class_ref(cls) -> str:
         return "exgentic.agents.openai.instance:OpenAIMCPAgentInstance"
 
-    def get_instance_kwargs(
+    def _get_instance_kwargs(
         self,
         session_id: str,
     ) -> dict[str, Any]:

--- a/src/exgentic/agents/replay/replay_agent.py
+++ b/src/exgentic/agents/replay/replay_agent.py
@@ -89,10 +89,10 @@ class ReplayAgent(Agent):
     runner: str | None = "direct"  # No external deps — run in host process
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         return ReplayAgentInstance
 
-    def get_instance_kwargs(
+    def _get_instance_kwargs(
         self,
         session_id: str,
     ) -> dict[str, Any]:

--- a/src/exgentic/agents/replay/replay_benchmark.py
+++ b/src/exgentic/agents/replay/replay_benchmark.py
@@ -74,14 +74,14 @@ class ReplayBenchmark(Benchmark):
     recording_dir: str
 
     @classmethod
-    def get_evaluator_class(cls):
+    def _get_evaluator_class(cls):
         return ReplayEvaluator
 
     @classmethod
-    def get_session_class(cls):
+    def _get_session_class(cls):
         return ReplaySession
 
-    def get_evaluator_kwargs(self) -> dict[str, Any]:
+    def _get_evaluator_kwargs(self) -> dict[str, Any]:
         return {"recording_dir": self.recording_dir}
 
     def runner_kwargs(self) -> dict[str, Any]:

--- a/src/exgentic/agents/smolagents/base_agent.py
+++ b/src/exgentic/agents/smolagents/base_agent.py
@@ -16,7 +16,7 @@ class SmolagentBaseAgent(Agent):
     model_settings: ModelSettings | None = None
     retry_on_all_errors: bool = True
 
-    def get_instance_kwargs(
+    def _get_instance_kwargs(
         self,
         session_id: str,
     ) -> dict[str, Any]:

--- a/src/exgentic/agents/smolagents/code_agent.py
+++ b/src/exgentic/agents/smolagents/code_agent.py
@@ -11,11 +11,11 @@ class SmolagentCodeAgent(SmolagentBaseAgent):
     slug_name: ClassVar[str] = "smolagents_code"
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         from .code_instance import SmolagentCodeAgentInstance
 
         return SmolagentCodeAgentInstance
 
     @classmethod
-    def get_instance_class_ref(cls) -> str:
+    def _get_instance_class_ref(cls) -> str:
         return "exgentic.agents.smolagents.code_instance:SmolagentCodeAgentInstance"

--- a/src/exgentic/agents/smolagents/tool_calling_agent.py
+++ b/src/exgentic/agents/smolagents/tool_calling_agent.py
@@ -11,11 +11,11 @@ class SmolagentToolCallingAgent(SmolagentBaseAgent):
     slug_name: ClassVar[str] = "smolagents_tool"
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         from .tool_calling_instance import SmolagentToolCallingAgentInstance
 
         return SmolagentToolCallingAgentInstance
 
     @classmethod
-    def get_instance_class_ref(cls) -> str:
+    def _get_instance_class_ref(cls) -> str:
         return "exgentic.agents.smolagents.tool_calling_instance:SmolagentToolCallingAgentInstance"

--- a/src/exgentic/benchmarks/appworld/appworld_benchmark.py
+++ b/src/exgentic/benchmarks/appworld/appworld_benchmark.py
@@ -4,8 +4,8 @@
 """AppWorld benchmark adapter -- light benchmark class only.
 
 Evaluator and session classes live in ``appworld_eval.py`` and are loaded
-inside the runner subprocess via ``get_evaluator_class()`` and
-``get_session_class()``.  This file must remain importable without the
+inside the runner subprocess via ``_get_evaluator_class()`` and
+``_get_session_class()``.  This file must remain importable without the
 ``appworld`` package installed.
 """
 
@@ -30,11 +30,11 @@ class AppWorldBenchmark(Benchmark, BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
-    def get_evaluator_class(cls):
+    def _get_evaluator_class(cls):
         return "exgentic.benchmarks.appworld.appworld_eval:AppWorldEvaluator"
 
     @classmethod
-    def get_session_class(cls):
+    def _get_session_class(cls):
         return "exgentic.benchmarks.appworld.appworld_eval:AppWorldSession"
 
     # Inputs
@@ -47,7 +47,7 @@ class AppWorldBenchmark(Benchmark, BaseModel):
     def list_subsets(self) -> list[str]:  # type: ignore[override]
         return list(self.available_subsets)
 
-    def get_evaluator_kwargs(self) -> dict[str, Any]:
+    def _get_evaluator_kwargs(self) -> dict[str, Any]:
         return {
             "subset": self.subset,
             "env_kwargs": self.env_kwargs,

--- a/src/exgentic/benchmarks/bfcl/bfcl_benchmark.py
+++ b/src/exgentic/benchmarks/bfcl/bfcl_benchmark.py
@@ -4,8 +4,8 @@
 """BFCL benchmark adapter — light benchmark class only.
 
 Evaluator, session, and helper classes live in ``bfcl_eval.py``
-and are loaded inside the runner subprocess via ``get_evaluator_class()``
-and ``get_session_class()``.  This file must remain importable without
+and are loaded inside the runner subprocess via ``_get_evaluator_class()``
+and ``_get_session_class()``.  This file must remain importable without
 the ``bfcl_eval`` package installed.
 """
 
@@ -75,11 +75,11 @@ class BFCLBenchmark(Benchmark, BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
 
     @classmethod
-    def get_evaluator_class(cls):
+    def _get_evaluator_class(cls):
         return "exgentic.benchmarks.bfcl.bfcl_eval:BFCLEvaluator"
 
     @classmethod
-    def get_session_class(cls):
+    def _get_session_class(cls):
         return "exgentic.benchmarks.bfcl.bfcl_eval:BFCLSession"
 
     subset: BFCLSubset = "simple_python"
@@ -87,7 +87,7 @@ class BFCLBenchmark(Benchmark, BaseModel):
     def list_subsets(self) -> list[str]:  # type: ignore[override]
         return list(self.available_subsets)
 
-    def get_evaluator_kwargs(self) -> dict[str, Any]:
+    def _get_evaluator_kwargs(self) -> dict[str, Any]:
         return {
             "subset": self.subset,
         }

--- a/src/exgentic/benchmarks/browsecompplus/browsecomp_benchmark.py
+++ b/src/exgentic/benchmarks/browsecompplus/browsecomp_benchmark.py
@@ -583,11 +583,11 @@ class BrowseCompPlusBenchmark(Benchmark, BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
-    def get_evaluator_class(cls):
+    def _get_evaluator_class(cls):
         return BrowseCompPlusEvaluator
 
     @classmethod
-    def get_session_class(cls):
+    def _get_session_class(cls):
         return BrowseCompPlusSession
 
     subset: Literal["main"] = "main"
@@ -670,7 +670,7 @@ class BrowseCompPlusBenchmark(Benchmark, BaseModel):
             kw["volumes"] = volumes
         return kw
 
-    def get_evaluator_kwargs(self) -> dict[str, Any]:
+    def _get_evaluator_kwargs(self) -> dict[str, Any]:
         kwargs: dict[str, Any] = {
             "subset": self.subset,
             "searcher_type": self.searcher_type,

--- a/src/exgentic/benchmarks/gsm8k/gsm8k_benchmark.py
+++ b/src/exgentic/benchmarks/gsm8k/gsm8k_benchmark.py
@@ -333,18 +333,18 @@ class GSM8kBenchmark(Benchmark, BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
-    def get_evaluator_class(cls):
+    def _get_evaluator_class(cls):
         return GSM8kEvaluator
 
     @classmethod
-    def get_session_class(cls):
+    def _get_session_class(cls):
         return GSM8kSession
 
     subset: Literal["main"] = "main"
     include_calculator_tool: bool = True
     runner: RunnerName | None = None  # Threadsafe; uses global default runner
 
-    def get_evaluator_kwargs(self) -> dict[str, Any]:
+    def _get_evaluator_kwargs(self) -> dict[str, Any]:
         return {
             "subset": self.subset,
             "include_calculator_tool": self.include_calculator_tool,

--- a/src/exgentic/benchmarks/hotpotqa/hotpotqa_benchmark.py
+++ b/src/exgentic/benchmarks/hotpotqa/hotpotqa_benchmark.py
@@ -355,18 +355,18 @@ class HotpotQABenchmark(Benchmark, BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
-    def get_evaluator_class(cls):
+    def _get_evaluator_class(cls):
         return HotpotQAEvaluator
 
     @classmethod
-    def get_session_class(cls):
+    def _get_session_class(cls):
         return HotpotQASession
 
     subset: Literal["distractor"] = "distractor"
     with_search_tools: bool = True
     runner: RunnerName | None = None  # Threadsafe; uses global default runner (venv)
 
-    def get_evaluator_kwargs(self) -> dict[str, Any]:
+    def _get_evaluator_kwargs(self) -> dict[str, Any]:
         return {
             "subset": self.subset,
             "with_search_tools": self.with_search_tools,

--- a/src/exgentic/benchmarks/swebench/swebench_benchmark.py
+++ b/src/exgentic/benchmarks/swebench/swebench_benchmark.py
@@ -4,8 +4,8 @@
 """SWE-bench benchmark adapter -- light benchmark class only.
 
 Evaluator, session, and helper classes live in ``swebench_eval.py``
-and are loaded inside the runner subprocess via ``get_evaluator_class()``
-and ``get_session_class()``.  This file must remain importable without
+and are loaded inside the runner subprocess via ``_get_evaluator_class()``
+and ``_get_session_class()``.  This file must remain importable without
 the ``swebench`` package installed.
 """
 
@@ -82,11 +82,11 @@ class SWEBenchBenchmark(Benchmark):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @classmethod
-    def get_evaluator_class(cls):
+    def _get_evaluator_class(cls):
         return "exgentic.benchmarks.swebench.swebench_eval:SWEBenchEvaluator"
 
     @classmethod
-    def get_session_class(cls):
+    def _get_session_class(cls):
         return "exgentic.benchmarks.swebench.swebench_eval:SWEBenchSession"
 
     subset: str | None = None
@@ -111,7 +111,7 @@ class SWEBenchBenchmark(Benchmark):
         if self.max_interactions is None:
             self.max_interactions = session_cfg.get("max_interactions")
 
-    def get_evaluator_kwargs(self) -> dict[str, Any]:
+    def _get_evaluator_kwargs(self) -> dict[str, Any]:
         return {
             "subset": self.subset,
             "require_submit_for_patch_evaluation": self.require_submit_for_patch_evaluation,

--- a/src/exgentic/benchmarks/tau2/tau2_benchmark.py
+++ b/src/exgentic/benchmarks/tau2/tau2_benchmark.py
@@ -4,8 +4,8 @@
 """TAU2 benchmark adapter — light benchmark class only.
 
 Evaluator, session, and proxy-agent classes live in ``tau2_eval.py``
-and are loaded inside the runner subprocess via ``get_evaluator_class()``
-and ``get_session_class()``.  This file must remain importable without
+and are loaded inside the runner subprocess via ``_get_evaluator_class()``
+and ``_get_session_class()``.  This file must remain importable without
 the ``tau2`` package installed.
 """
 
@@ -25,11 +25,11 @@ class TAU2Benchmark(Benchmark, BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
 
     @classmethod
-    def get_evaluator_class(cls):
+    def _get_evaluator_class(cls):
         return "exgentic.benchmarks.tau2.tau2_eval:TAU2Evaluator"
 
     @classmethod
-    def get_session_class(cls):
+    def _get_session_class(cls):
         return "exgentic.benchmarks.tau2.tau2_eval:TAU2Session"
 
     subset: Literal["mock", "retail", "airline", "telecom"] = "retail"
@@ -45,7 +45,7 @@ class TAU2Benchmark(Benchmark, BaseModel):
     def list_subsets(self) -> list[str]:  # type: ignore[override]
         return list(self.available_subsets)
 
-    def get_evaluator_kwargs(self) -> dict[str, Any]:
+    def _get_evaluator_kwargs(self) -> dict[str, Any]:
         return {
             "subset": self.subset,
             "user_simulator_model": self.user_simulator_model,

--- a/src/exgentic/core/agent.py
+++ b/src/exgentic/core/agent.py
@@ -19,10 +19,9 @@ if TYPE_CHECKING:
 class Agent(BaseModel, RunnerMixin, ABC):
     """Agent configuration — lightweight config that lives on the host.
 
-    Provides ``get_instance_class()`` to lazily resolve the execution class,
-    which can be wrapped with ``with_runner()`` for container/venv isolation,
-    mirroring how ``Benchmark`` provides ``get_session_class()`` and
-    ``get_evaluator_class()``.
+    Callers use ``get_instance(session_id)`` to obtain a running
+    ``AgentInstance`` wrapped in the configured runner, mirroring
+    ``Benchmark.get_evaluator()`` and ``Benchmark.get_session()``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -35,7 +34,7 @@ class Agent(BaseModel, RunnerMixin, ABC):
 
     @classmethod
     @abstractmethod
-    def get_instance_class(cls) -> type[AgentInstance]:
+    def _get_instance_class(cls) -> type[AgentInstance]:
         """Return the AgentInstance subclass for this agent.
 
         Subclasses implement this with a lazy import so heavy deps
@@ -44,18 +43,18 @@ class Agent(BaseModel, RunnerMixin, ABC):
         ...
 
     @classmethod
-    def get_instance_class_ref(cls) -> str:
+    def _get_instance_class_ref(cls) -> str:
         """Return a ``"module:qualname"`` string for the instance class.
 
-        By default calls ``get_instance_class()`` and converts to string.
+        By default calls ``_get_instance_class()`` and converts to string.
         Override in subclasses whose instance module has heavy third-party
         imports to return the string directly without triggering the import.
         """
-        klass = cls.get_instance_class()
+        klass = cls._get_instance_class()
         return f"{klass.__module__}:{klass.__qualname__}"
 
     @abstractmethod
-    def get_instance_kwargs(
+    def _get_instance_kwargs(
         self,
         session_id: str,
     ) -> dict[str, Any]:
@@ -66,6 +65,17 @@ class Agent(BaseModel, RunnerMixin, ABC):
         OS argument-list size limits.
         """
         ...
+
+    def get_instance(self, session_id: str) -> AgentInstance:
+        """Create an ``AgentInstance`` wrapped in the configured runner."""
+        from ..adapters.runners import with_runner
+
+        return with_runner(
+            self._get_instance_class_ref(),
+            runner=self.resolve_runner(),
+            **self._get_instance_kwargs(session_id=session_id),
+            **self.runner_kwargs(),
+        )
 
     # Optional metadata property for dashboard/leaderboards
     @property

--- a/src/exgentic/core/benchmark.py
+++ b/src/exgentic/core/benchmark.py
@@ -19,9 +19,8 @@ if TYPE_CHECKING:
 class Benchmark(BaseModel, RunnerMixin, ABC):
     """Benchmark configuration — lightweight config that lives on the host.
 
-    Provides ``get_evaluator_class()`` (task discovery & aggregation) and
-    ``get_session_class()`` (task execution). Both can be wrapped with
-    ``with_runner()`` for container isolation.
+    Callers use ``get_evaluator()`` and ``get_session()`` to obtain
+    instances wrapped in the configured runner for container isolation.
     """
 
     model_config = ConfigDict(
@@ -48,7 +47,7 @@ class Benchmark(BaseModel, RunnerMixin, ABC):
         return [subset] if subset and subset != "unknown" else []
 
     @classmethod
-    def get_evaluator_class(cls) -> type[Evaluator]:
+    def _get_evaluator_class(cls) -> type[Evaluator]:
         """Return the Evaluator subclass for this benchmark.
 
         Subclasses implement this with a lazy import so heavy deps
@@ -57,7 +56,7 @@ class Benchmark(BaseModel, RunnerMixin, ABC):
         raise NotImplementedError
 
     @classmethod
-    def get_session_class(cls) -> type[Session]:
+    def _get_session_class(cls) -> type[Session]:
         """Return the Session subclass for this benchmark.
 
         Subclasses implement this with a lazy import so heavy deps
@@ -65,9 +64,31 @@ class Benchmark(BaseModel, RunnerMixin, ABC):
         """
         raise NotImplementedError
 
-    def get_evaluator_kwargs(self) -> dict[str, Any]:
+    def _get_evaluator_kwargs(self) -> dict[str, Any]:
         """Return kwargs for constructing the Evaluator.
 
         Subclasses override this to pass benchmark-specific config.
         """
         return {}
+
+    def get_evaluator(self) -> Evaluator:
+        """Create an ``Evaluator`` wrapped in the configured runner."""
+        from ..adapters.runners import with_runner
+
+        return with_runner(
+            self._get_evaluator_class(),
+            runner=self.resolve_runner(),
+            **self._get_evaluator_kwargs(),
+            **self.runner_kwargs(),
+        )
+
+    def get_session(self, **session_kwargs: Any) -> Session:
+        """Create a ``Session`` wrapped in the configured runner."""
+        from ..adapters.runners import with_runner
+
+        return with_runner(
+            self._get_session_class(),
+            runner=self.resolve_runner(),
+            **session_kwargs,
+            **self.runner_kwargs(),
+        )

--- a/src/exgentic/core/evaluator.py
+++ b/src/exgentic/core/evaluator.py
@@ -3,8 +3,8 @@
 
 """Evaluator ABC — benchmark evaluation logic (task discovery, session config, aggregation).
 
-An Evaluator can be wrapped with ``with_runner()`` for container isolation,
-keeping heavy dependencies off the host.
+An Evaluator is created via ``Benchmark.get_evaluator()`` for container
+isolation, keeping heavy dependencies off the host.
 """
 
 from __future__ import annotations
@@ -34,7 +34,7 @@ class Evaluator(ABC):
 
         The orchestrator will call::
 
-            with_runner(session_class, runner=..., **session_kwargs, **runner_kwargs)
+            benchmark.get_session(**session_kwargs)
         """
         ...
 

--- a/src/exgentic/core/orchestrator/execution.py
+++ b/src/exgentic/core/orchestrator/execution.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 from filelock import FileLock, Timeout
 
-from ...adapters.runners import with_runner
 from ...interfaces.registry import load_agent, load_benchmark
 from ...observers.logging import get_disabled_logger
 from ...utils.paths import get_run_paths, get_session_paths
@@ -166,12 +165,7 @@ def run_session_config(
     agent = agent_cls(**(session_config.agent_kwargs or {}))
 
     # Create evaluator to obtain session kwargs.
-    evaluator = with_runner(
-        benchmark.get_evaluator_class(),
-        runner=benchmark.resolve_runner(),
-        **benchmark.get_evaluator_kwargs(),
-        **benchmark.runner_kwargs(),
-    )
+    evaluator = benchmark.get_evaluator()
 
     session_id = session_config.get_session_id()
     index = SessionIndex(
@@ -181,13 +175,8 @@ def run_session_config(
 
     try:
         session_kwargs = evaluator.get_session_kwargs(index)
-        # Create session via with_runner for isolation.
-        session = with_runner(
-            benchmark.get_session_class(),
-            runner=benchmark.resolve_runner(),
-            **session_kwargs,
-            **benchmark.runner_kwargs(),
-        )
+        # Create session via runner for isolation.
+        session = benchmark.get_session(**session_kwargs)
         # run_session handles session.close() internally.
         run_session(session_config, session, agent, tracker=tracker)
     finally:

--- a/src/exgentic/core/orchestrator/run.py
+++ b/src/exgentic/core/orchestrator/run.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from ...adapters.runners import with_runner
 from ...interfaces.registry import load_benchmark
 from ...observers.logging import get_logger
 from ...utils.paths import get_run_paths
@@ -133,12 +132,7 @@ def core_run(
             # Create evaluator for aggregation.
             bench_cls = load_benchmark(run_config.benchmark)
             benchmark = bench_cls(**(run_config.benchmark_kwargs or {}))
-            evaluator = with_runner(
-                benchmark.get_evaluator_class(),
-                runner=benchmark.resolve_runner(),
-                **benchmark.get_evaluator_kwargs(),
-                **benchmark.runner_kwargs(),
-            )
+            evaluator = benchmark.get_evaluator()
             try:
                 results = evaluator.aggregate_sessions(session_indexes)
             finally:

--- a/src/exgentic/core/orchestrator/session.py
+++ b/src/exgentic/core/orchestrator/session.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
-from ...adapters.runners import with_runner
 from ..context import agent_scope, benchmark_scope, session_scope
 from ..types import SessionConfig
 from .controller import Controller
@@ -34,19 +33,14 @@ def run_session(
 ) -> None:
     """Process a single session.
 
-    The *session* and *agent_instance* are created via ``with_runner()``
-    for isolation.
+    The *agent_instance* is created via ``agent.get_instance()`` for
+    runner isolation.
     """
     if tracker is None:
         tracker = Tracker(observers=observers, controllers=controllers)
 
     with session_scope(session.session_id, task_id=session.task_id):
-        agent_instance = with_runner(
-            agent.get_instance_class_ref(),
-            runner=agent.resolve_runner(),
-            **agent.get_instance_kwargs(session_id=session.session_id),
-            **agent.runner_kwargs(),
-        )
+        agent_instance = agent.get_instance(session_id=session.session_id)
 
         with benchmark_scope():
             observation = session.start()

--- a/src/exgentic/core/types/run.py
+++ b/src/exgentic/core/types/run.py
@@ -271,7 +271,6 @@ class RunConfig(BaseEvaluationConfig):
         *,
         resolved_config: RunConfig | None = None,
     ) -> list[SessionConfig]:
-        from ...adapters.runners import with_runner
         from ...interfaces.registry import load_benchmark
 
         resolved = resolved_config or self
@@ -280,12 +279,7 @@ class RunConfig(BaseEvaluationConfig):
         if task_ids is None:
             bench_cls = load_benchmark(resolved.benchmark)
             benchmark = bench_cls(**(resolved.benchmark_kwargs or {}))
-            evaluator = with_runner(
-                benchmark.get_evaluator_class(),
-                runner=benchmark.resolve_runner(),
-                **benchmark.get_evaluator_kwargs(),
-                **benchmark.runner_kwargs(),
-            )
+            evaluator = benchmark.get_evaluator()
             try:
                 selected = [str(t) for t in evaluator.list_tasks()]
                 if resolved.num_tasks is not None:

--- a/src/exgentic/interfaces/lib/api.py
+++ b/src/exgentic/interfaces/lib/api.py
@@ -545,16 +545,9 @@ def list_tasks(
     bench_kwargs = dict(benchmark_kwargs or {})
     if subset is not None:
         bench_kwargs = apply_subset_kwargs(benchmark, subset, bench_kwargs)
-    from ...adapters.runners import with_runner
-
     bench_cls = load_benchmark_class(benchmark)
     benchmark_obj: Benchmark = bench_cls(**bench_kwargs)
-    evaluator = with_runner(
-        benchmark_obj.get_evaluator_class(),
-        runner=benchmark_obj.resolve_runner(),
-        **benchmark_obj.get_evaluator_kwargs(),
-        **benchmark_obj.runner_kwargs(),
-    )
+    evaluator = benchmark_obj.get_evaluator()
     try:
         try:
             return evaluator.list_tasks()

--- a/src/exgentic/testing/agent.py
+++ b/src/exgentic/testing/agent.py
@@ -115,7 +115,7 @@ class TestAgent(Agent):
     runner: str | None = "direct"  # No external deps — run in host process
 
     @classmethod
-    def get_instance_class(cls):
+    def _get_instance_class(cls):
         return TestAgentInstance
 
     seed: int = 0
@@ -132,7 +132,7 @@ class TestAgent(Agent):
     finish_after: int = 2
     max_steps: int | None = None
 
-    def get_instance_kwargs(
+    def _get_instance_kwargs(
         self,
         session_id: str,
     ) -> dict[str, Any]:

--- a/src/exgentic/testing/benchmark.py
+++ b/src/exgentic/testing/benchmark.py
@@ -162,17 +162,17 @@ class TestBenchmark(Benchmark):
     tasks: list[str] = ["task-1", "task-2", "task-3"]  # noqa: RUF012
 
     @classmethod
-    def get_evaluator_class(cls):
+    def _get_evaluator_class(cls):
         return TestEvaluator
 
     @classmethod
-    def get_session_class(cls):
+    def _get_session_class(cls):
         return TestSession
 
     stop_on_step: bool = False
     invalid_observation: bool = False
 
-    def get_evaluator_kwargs(self) -> dict[str, Any]:
+    def _get_evaluator_kwargs(self) -> dict[str, Any]:
         return {
             "tasks": self.tasks,
             "stop_on_step": self.stop_on_step,

--- a/tests/adapters/runners/test_e2e_session.py
+++ b/tests/adapters/runners/test_e2e_session.py
@@ -136,8 +136,8 @@ class TestAgentWithRunnerSession:
 
     def test_good_then_finish_policy(self, session_proxy):
         agent = TestAgent(policy="good_then_finish", finish_after=3)
-        instance = agent.get_instance_class()(
-            **agent.get_instance_kwargs(session_id="sess-e2e-001"),
+        instance = agent._get_instance_class()(
+            **agent._get_instance_kwargs(session_id="sess-e2e-001"),
         )
         instance.start(
             task=session_proxy.task,
@@ -161,8 +161,8 @@ class TestAgentWithRunnerSession:
 
     def test_finish_immediately_policy(self, session_proxy):
         agent = TestAgent(policy="finish_immediately")
-        instance = agent.get_instance_class()(
-            **agent.get_instance_kwargs(session_id="sess-e2e-001"),
+        instance = agent._get_instance_class()(
+            **agent._get_instance_kwargs(session_id="sess-e2e-001"),
         )
         instance.start(
             task=session_proxy.task,

--- a/tests/api/test_agent_package_integrity.py
+++ b/tests/api/test_agent_package_integrity.py
@@ -10,11 +10,11 @@ splitting agent/benchmark modules into separate config and instance files:
    cannot discover ``requirements.txt`` / ``setup.sh``, so the CLI's
    ``needs_setup()`` returns False and dependencies are never installed.
 
-2. Host-side import of heavy deps — if ``get_instance_class_ref()`` falls
-   back to ``get_instance_class()`` (which does a lazy import), it will
+2. Host-side import of heavy deps — if ``_get_instance_class_ref()`` falls
+   back to ``_get_instance_class()`` (which does a lazy import), it will
    pull heavy third-party packages (litellm, smolagents, openai-agents)
    into the host process.  Agents with heavy deps must override
-   ``get_instance_class_ref()`` to return a string directly.
+   ``_get_instance_class_ref()`` to return a string directly.
 """
 
 from __future__ import annotations
@@ -75,7 +75,7 @@ def test_all_benchmark_packages_have_init():
 
 
 def test_agent_instance_class_ref_is_valid_string():
-    """Every agent's get_instance_class_ref() must return a 'module:class' string.
+    """Every agent's _get_instance_class_ref() must return a 'module:class' string.
 
     This verifies the ref is well-formed; it does NOT import the module
     (which would defeat the purpose of the string ref).
@@ -83,12 +83,12 @@ def test_agent_instance_class_ref_is_valid_string():
     entries = get_agent_entries()
     for slug, _entry in entries.items():
         agent_cls = load_agent(slug)
-        ref = agent_cls.get_instance_class_ref()
+        ref = agent_cls._get_instance_class_ref()
         assert isinstance(ref, str), (
-            f"Agent '{slug}': get_instance_class_ref() returned " f"{type(ref).__name__}, expected str"
+            f"Agent '{slug}': _get_instance_class_ref() returned " f"{type(ref).__name__}, expected str"
         )
         assert ":" in ref, (
-            f"Agent '{slug}': get_instance_class_ref() returned '{ref}', " f"expected 'module:qualname' format"
+            f"Agent '{slug}': _get_instance_class_ref() returned '{ref}', " f"expected 'module:qualname' format"
         )
         module_path, qualname = ref.rsplit(":", 1)
         assert module_path, f"Agent '{slug}': empty module path in ref '{ref}'"
@@ -96,14 +96,14 @@ def test_agent_instance_class_ref_is_valid_string():
 
 
 def test_agent_instance_class_ref_module_file_exists():
-    """The module referenced by get_instance_class_ref() must exist on disk.
+    """The module referenced by _get_instance_class_ref() must exist on disk.
 
     This catches typos in string refs without importing the module.
     """
     entries = get_agent_entries()
     for slug, entry in entries.items():
         agent_cls = load_agent(slug)
-        ref = agent_cls.get_instance_class_ref()
+        ref = agent_cls._get_instance_class_ref()
         module_path, _ = ref.rsplit(":", 1)
         # Convert module path to file path
         parts = module_path.split(".")
@@ -118,7 +118,8 @@ def test_agent_instance_class_ref_module_file_exists():
         # Now resolve the ref module path
         expected_file = src_root / Path(*parts[:-1]) / f"{parts[-1]}.py"
         assert expected_file.exists(), (
-            f"Agent '{slug}': get_instance_class_ref() points to " f"'{module_path}' but {expected_file} does not exist"
+            f"Agent '{slug}': _get_instance_class_ref() points to "
+            f"'{module_path}' but {expected_file} does not exist."
         )
 
 


### PR DESCRIPTION
## Summary
- Add `Agent.get_instance(session_id)`, `Benchmark.get_evaluator()`, and `Benchmark.get_session(**kwargs)` as the public API for creating runner-wrapped instances
- Encapsulates the repetitive `with_runner()` + `resolve_runner()` + `runner_kwargs()` boilerplate that was duplicated across 6 call sites
- Prefix override-only methods (`get_instance_class`, `get_instance_kwargs`, `get_evaluator_class`, `get_evaluator_kwargs`, `get_session_class`, `get_instance_class_ref`) with `_` to signal they are internal implementation details for subclasses

## Test plan
- [ ] Verify existing tests pass (no behavioral changes, only method renames)
- [ ] Confirm all agent/benchmark subclass overrides use the new `_` prefixed names
- [ ] Run a benchmark end-to-end to verify runner isolation still works