### PR TITLE
Revise LICENSE to state copyright and licensor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -191,9 +191,9 @@
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-   
-      http://www.apache.org/licenses/LICENSE-2.0
-   
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
The license file is not currently stating who is provisioning the open source license. I suggest "IBM" (currently in this PR) or "Exgentic Contributors."

For more details, see the bottom of the current license statement.