### PR TITLE
Use venv runner for BrowseCompPlus retriever

### DIFF
--- a/src/exgentic/benchmarks/browsecompplus/browsecomp_benchmark.py
+++ b/src/exgentic/benchmarks/browsecompplus/browsecomp_benchmark.py
@@ -700,7 +700,7 @@ class BrowseCompPlusBenchmark(Benchmark, BaseModel):
         # sessions don't each load the heavy search index (OOM / slow).
         # Direct/thread runners share memory so the model is loaded once.
         if not self.retriever_runner and self.resolve_runner() in ("docker", "venv", "process"):
-            self.retriever_runner = "service"
+            self.retriever_runner = "venv"
         kwargs: dict[str, Any] = {
             "searcher_params": self._searcher_params(),
             "assets_dir": self._assets_dir,


### PR DESCRIPTION
## Summary
The BrowseCompPlus retriever defaulted to `"service"` runner (in-process) which requires `safetensors` and `torch` in the main project. Changed to `"venv"` runner which uses the benchmark's venv where those deps are installed.

## Error
```
ModuleNotFoundError: No module named 'safetensors'
```

## Test plan
- [ ] BrowseCompPlus benchmark runs without import errors