### PR TITLE
fix: serialize concurrent venv installs with file lock

### DIFF
--- a/src/exgentic/environment/venv.py
+++ b/src/exgentic/environment/venv.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from filelock import FileLock
+
 from .helpers import (
     build_subprocess_env,
     get_exgentic_version,
@@ -46,38 +48,43 @@ class VenvBackend:
         packages: list[str] | None = kwargs.get("packages")  # type: ignore[assignment]
 
         venv_dir = env_dir / "venv"
-        if venv_dir.exists():
-            shutil.rmtree(venv_dir)
+        lock_path = env_dir / ".venv-install.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock = FileLock(str(lock_path), timeout=600)  # 10 min timeout for heavy installs
 
-        try:
-            uv = require_uv()
-
-            subprocess.run(
-                [uv, "venv", str(venv_dir), "--python", f"{sys.version_info.major}.{sys.version_info.minor}"],
-                check=True,
-                capture_output=True,
-                text=True,
-            )
-
-            venv_py = str(venv_dir / "bin" / "python")
-            env = build_subprocess_env()
-
-            if project_root is not None:
-                install_project(uv, venv_py, project_root, env)
-
-            if packages:
-                install_packages(uv, venv_py, packages, env)
-
-            if module_path is not None:
-                install_requirements(uv, venv_py, module_path, env)
-                validate_system_deps(module_path)
-                run_setup_sh(module_path, env_dir, venv_dir=venv_dir)
-        except BaseException:
+        with lock:
             if venv_dir.exists():
-                shutil.rmtree(venv_dir, ignore_errors=True)
-            raise
+                shutil.rmtree(venv_dir)
 
-        return {"exgentic_version": get_exgentic_version()}
+            try:
+                uv = require_uv()
+
+                subprocess.run(
+                    [uv, "venv", str(venv_dir), "--python", f"{sys.version_info.major}.{sys.version_info.minor}"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                )
+
+                venv_py = str(venv_dir / "bin" / "python")
+                env = build_subprocess_env()
+
+                if project_root is not None:
+                    install_project(uv, venv_py, project_root, env)
+
+                if packages:
+                    install_packages(uv, venv_py, packages, env)
+
+                if module_path is not None:
+                    install_requirements(uv, venv_py, module_path, env)
+                    validate_system_deps(module_path)
+                    run_setup_sh(module_path, env_dir, venv_dir=venv_dir)
+            except BaseException:
+                if venv_dir.exists():
+                    shutil.rmtree(venv_dir, ignore_errors=True)
+                raise
+
+            return {"exgentic_version": get_exgentic_version()}
 
     def exists(self, env_dir: Path, marker_data: dict) -> bool:
         """Check that the venv Python binary exists."""

--- a/tests/environment/test_venv_lock.py
+++ b/tests/environment/test_venv_lock.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Tests for VenvBackend file lock during concurrent installs."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from exgentic.environment.venv import VenvBackend
+from filelock import FileLock
+
+
+@pytest.fixture
+def env_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "envs" / "test_env"
+    d.mkdir(parents=True)
+    return d
+
+
+def test_lock_file_created_during_install(env_dir: Path):
+    """install() should create a .venv-install.lock file."""
+    backend = VenvBackend()
+    lock_path = env_dir / ".venv-install.lock"
+    assert not lock_path.exists()
+
+    try:
+        backend.install(env_dir)
+    except Exception:
+        pass  # Install may fail without uv, that's OK
+
+    assert lock_path.exists()
+
+
+def test_install_blocked_while_lock_held(env_dir: Path):
+    """install() should block when another process holds the lock."""
+    lock_path = env_dir / ".venv-install.lock"
+    lock = FileLock(str(lock_path), timeout=0)
+
+    from filelock import Timeout as LockTimeout
+
+    # Hold the lock from "another process".
+    lock.acquire()
+    try:
+        backend = VenvBackend()
+        # Patch timeout to 0 so install fails immediately instead of
+        # waiting 600s for the lock we're holding.
+        with patch("exgentic.environment.venv.FileLock", lambda p, timeout: FileLock(p, timeout=0)):
+            with pytest.raises(LockTimeout):
+                backend.install(env_dir)
+    finally:
+        lock.release()
+
+
+def test_different_env_dirs_use_independent_locks(tmp_path: Path):
+    """Installs to different env_dirs should not block each other."""
+    dir_a = tmp_path / "env_a"
+    dir_b = tmp_path / "env_b"
+    dir_a.mkdir(parents=True)
+    dir_b.mkdir(parents=True)
+
+    backend = VenvBackend()
+    results: list[str] = []
+    lock = threading.Lock()
+
+    def try_install(env_dir: Path, name: str):
+        try:
+            backend.install(env_dir)
+        except Exception:
+            pass
+        with lock:
+            results.append(name)
+
+    t1 = threading.Thread(target=try_install, args=(dir_a, "a"))
+    t2 = threading.Thread(target=try_install, args=(dir_b, "b"))
+    t1.start()
+    t2.start()
+    t1.join(timeout=10)
+    t2.join(timeout=10)
+
+    assert sorted(results) == ["a", "b"]


### PR DESCRIPTION
## Summary
- Wraps `VenvBackend.install()` with a `FileLock` to prevent concurrent processes from racing on the same venv directory
- When multiple runs share a benchmark venv (e.g. browsecompplus retriever), parallel launches previously crashed with `FileNotFoundError` during `shutil.rmtree`
- Lock file placed at `{env_dir}/.venv-install.lock`, timeout 600s (for heavy installs like Qwen3-Embedding-8B)

## Changes
- `venv.py`: Wrap install body with `FileLock`
- `test_venv_lock.py`: 3 tests verifying lock creation, serialization, and independent lock files for different env dirs

## Test plan
- [x] 3 venv lock tests pass
- [x] Pre-commit passes
- [ ] Run two `exgentic evaluate` for different browsecomp configs concurrently — second should wait for install instead of crashing
- [ ] Verify single-run install behavior unchanged