### PR TITLE
fix: treat missing tau2 simulations as unsuccessful, not error

### DIFF
--- a/src/exgentic/benchmarks/tau2/tau2_eval.py
+++ b/src/exgentic/benchmarks/tau2/tau2_eval.py
@@ -472,11 +472,15 @@ class TAU2Session(PairableProxySession):
             if self.file_path and Path(self.file_path).exists():
                 Path(self.results_file).parent.mkdir(parents=True, exist_ok=True)
                 move(self.file_path, self.results_file)
+        # No simulation file or empty simulations → agent produced no
+        # useful actions.  Score as unsuccessful rather than crashing.
+        if not Path(self.results_file).exists():
+            self.logger.warning("No simulation file produced; scoring as unsuccessful (score=0).")
+            return SessionScore(score=0.0, success=False, is_finished=True)
         res = Results.load(self.results_file)
         if not res.simulations:
-            self.logger.error("Tau2 produced no simulations; marking session as failed.")
-            # Finished is false when the underlying Tau2 run produced no simulations.
-            return SessionScore(score=0.0, success=False, is_finished=False)
+            self.logger.warning("No simulations in results; scoring as unsuccessful (score=0).")
+            return SessionScore(score=0.0, success=False, is_finished=True)
 
         sim = res.simulations[-1]
 
@@ -616,14 +620,12 @@ class TAU2Evaluator(Evaluator):
         files: list[Path] = []
         for paths in self.get_sessions_paths(sessions):
             fp = paths.benchmark_results
-            if not fp.exists():
-                raise FileNotFoundError(f"Missing results for planned session '{paths.session_id}' at {fp}")
-            files.append(fp)
+            if fp.exists():
+                files.append(fp)
 
         base: Results | None = None
         all_sims = []
         task_map: dict[str, Any] = {}
-        errored_tasks = 0
         for fp in files:
             r = Results.load(fp)
             if base is None:
@@ -632,21 +634,21 @@ class TAU2Evaluator(Evaluator):
                 raise ValueError(f"Expected exactly 1 task per result file, got {len(r.tasks)} in {fp}")
             if len(r.simulations) > 1:
                 raise ValueError(f"Expected at most 1 simulation per result file, got {len(r.simulations)} in {fp}")
-
             if len(r.simulations) == 0:
-                errored_tasks += 1
                 continue
-
             all_sims.extend(r.simulations)
             for t in r.tasks:
                 task_map[t.id] = t
 
         total_sessions = len(sessions)
 
+        # No simulations at all → return score=0 instead of crashing.
         if len(all_sims) == 0 or base is None:
-            raise RuntimeError(
-                f"All {total_sessions} tau2 sessions errored out with no simulations. "
-                f"Check session error logs for details."
+            return BenchmarkResults(
+                benchmark_name=f"tau2-{self._subset}",
+                total_tasks=total_sessions,
+                score=0.0,
+                metrics={"avg_reward": 0.0},
             )
 
         combined = Results(info=base.info, tasks=list(task_map.values()), simulations=all_sims)

--- a/tests/benchmarks/test_tau2_aggregate.py
+++ b/tests/benchmarks/test_tau2_aggregate.py
@@ -212,8 +212,8 @@ class TestAggregateSessions:
         assert result.score == 0.8
         assert result.total_tasks == 2
 
-    def test_all_sessions_errored_raises(self, evaluator, tmp_path: Path):
-        """When every session errored, raise RuntimeError instead of silently returning."""
+    def test_all_sessions_empty_returns_zero_score(self, evaluator, tmp_path: Path):
+        """When every session has no simulations, return score=0 instead of crashing."""
         err1 = tmp_path / "err1" / "results.json"
         err2 = tmp_path / "err2" / "results.json"
 
@@ -233,8 +233,9 @@ class TestAggregateSessions:
                 _make_session_paths(err2, "err2"),
             ],
         ):
-            with pytest.raises(RuntimeError, match="All 2 tau2 sessions errored out"):
-                evaluator.aggregate_sessions(sessions)
+            result = evaluator.aggregate_sessions(sessions)
+            assert result.score == 0.0
+            assert result.metrics["avg_reward"] == 0.0
 
     def test_rejects_file_with_multiple_tasks(self, evaluator, tmp_path: Path):
         """A result file with != 1 task should raise ValueError."""


### PR DESCRIPTION
## Summary
When the agent runs but produces no actions (e.g. Kimi returns text instead of tool calls), tau2 previously crashed with `FileNotFoundError` on the missing simulation file. This crashed the entire run with no `results.json`.

The fix distinguishes between **infrastructure errors** (caught before `score()` is ever called) and **model performing poorly** (no actions produced during normal session completion):

- `score()`: If no simulation file exists when scoring, return `score=0, success=False, is_finished=True` with a warning — the model tried, it just didn't do anything useful
- `aggregate_sessions()`: Skip sessions without benchmark results instead of crashing. When all sessions produced no simulations, return `score=0` with metadata instead of `RuntimeError`

## Why this is correct
The orchestrator's session flow guarantees the separation:
- **Error path**: `HealthCheckError`, `AgentError`, `BenchmarkError` → caught in `run_session()` → `on_session_error()` → `score()` is never called
- **Normal completion**: `AgentTerminationError` / `BenchmarkTerminationError` → `on_session_scoring()` → `score()` called

So if `score()` runs and finds no simulation, it's by definition not an infra error.

## Test plan
- [ ] Run tau2 with Kimi+claude_code (known to return text not tool calls) — verify sessions complete as unsuccessful (not error) and `results.json` is produced
- [ ] Run tau2 with a working model — verify normal scoring unchanged