### PR TITLE
fix: enable Anthropic messages passthrough for non-Anthropic backends

### DIFF
--- a/src/exgentic/agents/cli/requirements.txt
+++ b/src/exgentic/agents/cli/requirements.txt
@@ -1,2 +1,2 @@
-litellm[proxy]
+litellm[proxy]>=1.83.4
 websockets>=16.0

--- a/src/exgentic/integrations/litellm/proxy.py
+++ b/src/exgentic/integrations/litellm/proxy.py
@@ -153,12 +153,6 @@ class LitellmProxy:
 
     def _build_litellm_params(self) -> dict[str, object]:
         litellm_params: dict[str, object] = {"model": self.model}
-        # Include api_key so the Anthropic /v1/messages pass-through
-        # path can authenticate (litellm requires it as a positional arg
-        # in anthropic_messages() even when routing to non-Anthropic backends).
-        api_key = os.environ.get("OPENAI_API_KEY")
-        if api_key:
-            litellm_params["api_key"] = api_key
         if self.model_settings.temperature is not None:
             litellm_params["temperature"] = self.model_settings.temperature
         if self.model_settings.max_tokens is not None:
@@ -179,9 +173,8 @@ class LitellmProxy:
             "litellm_settings": {
                 "success_callback": [trace_cb],
                 "failure_callback": [trace_cb],
-                # Force chat/completions instead of /responses for Anthropic
-                # message translation — many backends don't support the
-                # Responses API.
+                # Route /v1/messages through chat/completions so
+                # non-Anthropic backends can serve them.
                 "use_chat_completions_url_for_anthropic_messages": True,
             },
         }


### PR DESCRIPTION
## Summary
- Pin `litellm[proxy]>=1.83.4` — older versions don't support `use_chat_completions_url_for_anthropic_messages`
- Remove redundant `api_key` injection in `litellm_params` — litellm reads `OPENAI_API_KEY` from env automatically
- Remove redundant env var — the YAML `litellm_settings` already sets `use_chat_completions_url_for_anthropic_messages: True` via `setattr(litellm, key, value)`

The `use_chat_completions_url_for_anthropic_messages` setting is always True because the proxy exists to route non-Anthropic models — there's no scenario where False is correct.

## Test plan
- [x] Pre-commit passes
- [x] Verified working in e2e runs (claude_code × DeepSeek/Kimi across all benchmarks at 5 tasks)