### PR TITLE
feat: global worker pool for batch evaluate

### DIFF
--- a/src/exgentic/core/orchestrator/run.py
+++ b/src/exgentic/core/orchestrator/run.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from ...interfaces.registry import load_benchmark
 from ...observers.logging import get_logger
 from ...utils.paths import get_run_paths
@@ -11,13 +13,16 @@ from ..types import (
     RunPlan,
     RunResults,
     RunStatus,
+    SessionConfig,
     SessionExecutionStatus,
     SessionIndex,
 )
 from .controller import Controller
-from .execution import execute_sessions, load_reused_results
+from .execution import _run_task_with_lock, execute_sessions, load_reused_results
 from .observer import Observer
 from .tracker import Tracker
+
+_log = logging.getLogger(__name__)
 
 
 def _build_session_indexes(run_config: RunConfig, task_ids: list[str]):
@@ -188,3 +193,95 @@ def core_aggregate(
         execute=False,
         aggregate=True,
     )
+
+
+# ---------------------------------------------------------------------------
+# Batch evaluation with a global worker pool
+# ---------------------------------------------------------------------------
+
+
+def _plan_config(run_config: RunConfig) -> tuple[RunConfig, Tracker, list[SessionConfig]]:
+    """Plan sessions for a config.  Returns (resolved config, tracker, sessions to run)."""
+    with run_config.get_context() as ctx:
+        updates = {}
+        if run_config.run_id is None:
+            updates["run_id"] = ctx.run_id
+        if run_config.cache_dir is None:
+            updates["cache_dir"] = ctx.cache_dir
+        if updates:
+            run_config = run_config.model_copy(update=updates)
+
+        # Quiet tracker — no console output during batch planning.
+        tracker = Tracker(
+            use_defaults=False,
+            max_steps=run_config.max_steps,
+            max_actions=run_config.max_actions,
+        )
+        status = RunStatus.from_config(run_config)
+        if run_config.task_ids is None and status.task_ids:
+            run_config = run_config.model_copy(update={"task_ids": status.task_ids})
+
+        tracker.on_run_start(run_config)
+        plan = RunPlan.from_config_and_status(run_config, status)
+
+    _log.info(
+        "%s/%s: %d to run, %d to reuse",
+        run_config.benchmark,
+        run_config.agent,
+        len(plan.to_run),
+        len(plan.reuse),
+    )
+    return run_config, tracker, plan.to_run
+
+
+def core_batch_evaluate(
+    run_configs: list[RunConfig],
+    *,
+    max_workers: int = 4,
+) -> list[RunResults]:
+    """Evaluate multiple configs with a single global worker pool.
+
+    1. **Plan** — resolve sessions per config (sequential, fast).
+    2. **Execute** — run ALL sessions in one ``ThreadPoolExecutor``.
+    3. **Aggregate** — score each config from disk (sequential).
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+    from contextvars import copy_context
+
+    # Phase 1: plan.
+    configs: list[RunConfig] = []
+    work: list[tuple[SessionConfig, RunConfig, Tracker]] = []
+
+    for cfg in run_configs:
+        cfg, tracker, sessions = _plan_config(cfg)
+        configs.append(cfg)
+        for sc in sessions:
+            work.append((sc, cfg, tracker))
+
+    _log.info("Batch: %d sessions, %d configs, %d workers", len(work), len(configs), max_workers)
+
+    # Phase 2: execute.
+    if work:
+
+        def _run(item: tuple[SessionConfig, RunConfig, Tracker]) -> None:
+            sc, cfg, tracker = item
+            with cfg.get_context():
+                _run_task_with_lock(session_config=sc, tracker=tracker, log=_log)
+
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {pool.submit(copy_context().run, _run, item): item for item in work}
+            for future in as_completed(futures):
+                try:
+                    future.result()
+                except Exception:
+                    sc, _, _ = futures[future]
+                    _log.exception("Session %s failed", sc.get_session_id())
+
+    # Phase 3: aggregate from disk.
+    results: list[RunResults] = []
+    for cfg in configs:
+        try:
+            results.append(core_aggregate(run_config=cfg))
+        except Exception:
+            _log.exception("Aggregation failed for %s", cfg.run_id)
+    return results

--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -16,7 +16,7 @@ import rich_click as click
 from ....core.types import RunConfig, SessionConfig
 from ....core.types.session import SessionExecutionStatus, SessionOutcomeStatus
 from ....utils.paths import get_run_paths, get_session_paths
-from ...lib.api import aggregate, evaluate, execute, status
+from ...lib.api import aggregate, execute, status
 from ..options import (
     _format_exception_for_cli,
     _should_show_traceback,
@@ -379,11 +379,13 @@ def batch_cmd(debug: bool) -> None:
     multiple=True,
     help="RunConfig/SessionConfig path or glob pattern (repeatable).",
 )
+@click.option("--num-tasks", type=int, default=None, help="Override num_tasks for display.")
 @click.pass_context
 def batch_status_cmd(
     ctx: click.Context,
     debug: bool,
     config_values: tuple[str, ...],
+    num_tasks: int | None,
 ) -> None:
     """Show a status table for multiple config files."""
     apply_debug_mode(debug)
@@ -393,74 +395,60 @@ def batch_status_cmd(
     for i, config_path in enumerate(config_paths, start=1):
         row: dict[str, str] = {
             "#": str(i),
-            "config": _format_config_link(config_path, max_len=30),
-            "run_id": "-",
             "benchmark": "-",
             "agent": "-",
-            "subset": "-",
-            "models": "-",
-            "ready": "-",
-            "aggregated": "-",
-            "finished": "-",
-            "errors": "-",
+            "model": "-",
+            "sessions": "-",
             "score": "-",
             "cost": "-",
         }
         try:
             cfg = _load_run_like_config(config_path)
+            if num_tasks is not None and isinstance(cfg, RunConfig):
+                cfg = cfg.with_overrides(num_tasks=num_tasks)
             run_status = status(cfg)
-            (
-                score,
-                cost,
-                models,
-                ready,
-                finished,
-                errors,
-                aggregated,
-            ) = _load_results_summary(run_status.results_path)
-            if models == "-":
-                models = run_status.model_name or "-"
-            models = _truncate_leading(models, 24)
-            if ready is None or finished is None or errors is None:
-                ready = 0
-                finished = 0
-                errors = 0
-                if aggregated is None:
-                    aggregated = 0
-                for item in run_status.session_statuses:
-                    if item.status != SessionExecutionStatus.COMPLETED:
-                        continue
-                    if item.result_status in (
-                        SessionOutcomeStatus.ERROR,
-                        SessionOutcomeStatus.CANCELLED,
-                    ):
+            completed = 0
+            running = 0
+            errors = 0
+            for s in run_status.session_statuses:
+                if s.status == SessionExecutionStatus.RUNNING:
+                    running += 1
+                elif s.status == SessionExecutionStatus.COMPLETED:
+                    completed += 1
+                    if s.result_status in (SessionOutcomeStatus.ERROR, SessionOutcomeStatus.CANCELLED):
                         errors += 1
-                    else:
-                        ready += 1
-                        if aggregated is not None:
-                            aggregated += 1
-                    if item.result_status in (
-                        SessionOutcomeStatus.SUCCESS,
-                        SessionOutcomeStatus.UNSUCCESSFUL,
-                    ):
-                        finished += 1
+            total = run_status.total_tasks
+            parts = [f"{completed}/{total}"]
+            if running:
+                parts.append(f"{running}run")
+            if errors:
+                parts.append(f"{errors}err")
+            sessions_str = " ".join(parts)
+
+            score, cost, models, *_ = _load_results_summary(run_status.results_path)
+            model = run_status.model_name or models
+            if model != "-":
+                # Strip common prefixes for readability.
+                for prefix in ("openai/azure/", "openai/Azure/", "openai/"):
+                    if model.startswith(prefix):
+                        model = model[len(prefix) :]
+                        break
+            benchmark = run_status.benchmark_slug_name
+            subset = run_status.subset_name
+            if subset:
+                benchmark = f"{benchmark}/{subset}"
             row.update(
                 {
-                    "run_id": run_status.run_id,
-                    "benchmark": run_status.benchmark_slug_name,
+                    "benchmark": benchmark,
                     "agent": run_status.agent_slug_name,
-                    "subset": run_status.subset_name or "-",
-                    "models": models,
-                    "ready": f"{ready}/{run_status.total_tasks}",
-                    "aggregated": f"{aggregated}/{run_status.total_tasks}",
-                    "finished": f"{finished}/{run_status.total_tasks}",
-                    "errors": f"{errors}/{run_status.total_tasks}",
+                    "model": model,
+                    "sessions": sessions_str,
                     "score": score,
                     "cost": cost,
                 }
             )
         except Exception:
-            pass
+            row["benchmark"] = _short_config_path(config_path)
         rows.append(row)
 
     render_batch_status(rows)
@@ -482,7 +470,7 @@ def batch_status_cmd(
     help="RunConfig/SessionConfig path or glob pattern (repeatable).",
 )
 @click.option("--num-tasks", type=int, default=None, help="Override num_tasks for all configs.")
-@click.option("--max-workers", type=int, default=None, help="Override max_workers for all configs.")
+@click.option("--max-workers", type=int, default=None, help="Concurrent sessions across all configs.")
 @click.option("--max-steps", type=int, default=None, help="Override max_steps for all configs.")
 @click.option("--max-actions", type=int, default=None, help="Override max_actions for all configs.")
 @click.pass_context
@@ -495,24 +483,26 @@ def batch_evaluate_cmd(
     max_steps: int | None,
     max_actions: int | None,
 ) -> None:
-    """Evaluate configs sequentially."""
+    """Evaluate multiple configs with a shared worker pool.
+
+    All sessions from all configs run in a single pool of --max-workers.
+    Completed sessions are skipped.  Each config is aggregated from disk
+    after all sessions finish.
+    """
+    from ....core.orchestrator.run import core_batch_evaluate
+
     apply_debug_mode(debug)
-    config_paths = _expand_config_inputs(config_values, list(ctx.args))
-    failures: list[tuple[str, str]] = []
+    config_paths = list(_expand_config_inputs(config_values, list(ctx.args)))
+    overrides = ctx.params
 
+    configs: list[RunConfig] = []
     for config_path in config_paths:
-        click.echo(f"Running: {config_path}")
-        try:
-            cfg = _load_run_like_config(config_path)
-            if isinstance(cfg, RunConfig):
-                cfg = cfg.with_overrides(**ctx.params)
-            evaluate(config=cfg)
-        except Exception as exc:
-            failures.append((config_path, str(exc)))
-            click.echo(f"Error: {config_path}\n  {_format_batch_error(exc)}")
+        cfg = _load_run_like_config(config_path)
+        if isinstance(cfg, RunConfig):
+            cfg = cfg.with_overrides(**overrides)
+        configs.append(cfg)
 
-    if failures:
-        raise click.ClickException("Batch evaluate completed with errors in " + ", ".join(path for path, _ in failures))
+    core_batch_evaluate(configs, max_workers=max_workers or 1)
 
 
 @batch_cmd.command(

--- a/src/exgentic/interfaces/cli/render.py
+++ b/src/exgentic/interfaces/cli/render.py
@@ -125,25 +125,51 @@ def render_run_status(status: Any, output_format: str) -> None:
 
 def render_batch_status(rows: list[dict[str, str]]) -> None:
     total_configs = len(rows)
-    done_configs = sum(1 for row in rows if row.get("ready") == row.get("finished"))
     total_sessions = 0
-    total_ready = 0
+    total_completed = 0
+    total_running = 0
+    total_errors = 0
+    total_cost = 0.0
+    done_configs = 0
     for row in rows:
-        ready = row.get("ready", "-")
-        if isinstance(ready, str) and "/" in ready:
-            try:
-                done_str, total_str = ready.split("/", 1)
-                total_sessions += int(total_str)
-                total_ready += int(done_str)
-            except Exception:
-                continue
+        sessions = row.get("sessions", "-")
+        if not isinstance(sessions, str) or "/" not in sessions:
+            continue
+        try:
+            tokens = sessions.split()
+            frac = tokens[0]
+            completed = int(frac.split("/")[0])
+            planned = int(frac.split("/")[1])
+            total_completed += completed
+            total_sessions += planned
+            if completed >= planned:
+                done_configs += 1
+            for token in tokens[1:]:
+                if token.endswith("run"):
+                    total_running += int(token[:-3])
+                elif token.endswith("err"):
+                    total_errors += int(token[:-3])
+        except (ValueError, IndexError):
+            continue
+        try:
+            cost_str = row.get("cost", "0")
+            if cost_str not in ("-", ""):
+                total_cost += float(cost_str)
+        except (ValueError, TypeError):
+            pass
 
     summary = Table.grid(padding=(0, 2))
     summary.add_column(style="bold cyan")
     summary.add_column()
-    summary.add_row("Configs", f"{total_configs} total")
-    summary.add_row("Fully Done", f"{done_configs} total")
-    summary.add_row("Sessions", f"{total_ready}/{total_sessions}")
+    summary.add_row("Configs", f"{done_configs}/{total_configs} done")
+    sessions_line = f"{total_completed}/{total_sessions}"
+    if total_running:
+        sessions_line += f"  ({total_running} running)"
+    summary.add_row("Sessions", sessions_line)
+    if total_errors:
+        summary.add_row("Errors", str(total_errors))
+    if total_cost > 0:
+        summary.add_row("Total Cost", f"${total_cost:.2f}")
     CONSOLE.print(Panel(summary, title="Batch Summary", border_style="cyan"))
 
     table = Table(
@@ -151,36 +177,25 @@ def render_batch_status(rows: list[dict[str, str]]) -> None:
         box=box.SIMPLE,
         show_header=True,
         header_style="bold magenta",
+        expand=True,
     )
-    table.add_column("#", justify="right", no_wrap=True)
-    table.add_column("Config", overflow="crop", max_width=30)
-    table.add_column("Run", no_wrap=True, min_width=8)
-    table.add_column("Benchmark", no_wrap=True)
-    table.add_column("Agent", no_wrap=True)
-    table.add_column("Subset", no_wrap=True)
-    table.add_column("Models", overflow="crop", max_width=24)
-    table.add_column("Ready", justify="right")
-    table.add_column("Aggregated", justify="right")
-    table.add_column("Finished", justify="right")
-    table.add_column("Errors", justify="right")
-    table.add_column("Score", justify="right")
-    table.add_column("Cost", justify="right")
+    table.add_column("#", justify="right", width=3)
+    table.add_column("Benchmark")
+    table.add_column("Agent")
+    table.add_column("Model")
+    table.add_column("Sessions", justify="right", no_wrap=True)
+    table.add_column("Score", justify="right", no_wrap=True)
+    table.add_column("Cost", justify="right", no_wrap=True)
 
     for row in rows:
         table.add_row(
             row["#"],
-            row["config"],
-            row["run_id"],
             row["benchmark"],
             row["agent"],
-            row.get("subset", "-"),
-            row["models"],
-            row["ready"],
-            row["aggregated"],
-            row["finished"],
-            row["errors"],
-            row["score"],
-            row["cost"],
+            row.get("model", "-"),
+            row.get("sessions", "-"),
+            row.get("score", "-"),
+            row.get("cost", "-"),
         )
 
     CONSOLE.print(table)

--- a/tests/api/test_cli_batch.py
+++ b/tests/api/test_cli_batch.py
@@ -45,8 +45,8 @@ def test_batch_status_multiple_configs(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert "Batch Status" in result.output
-    assert "run-a" in result.output
-    assert "run-b" in result.output
+    assert "test_benchmark" in result.output
+    assert "test_agent" in result.output
 
 
 def test_batch_status_config_glob_pattern(tmp_path):
@@ -69,8 +69,7 @@ def test_batch_status_config_glob_pattern(tmp_path):
     )
 
     assert result.exit_code == 0, result.output
-    assert "run-g1" in result.output
-    assert "run-g2" in result.output
+    assert "test_benchmark" in result.output
 
 
 def test_batch_status_shell_expanded_values_after_single_config(tmp_path):
@@ -91,8 +90,7 @@ def test_batch_status_shell_expanded_values_after_single_config(tmp_path):
     )
 
     assert result.exit_code == 0, result.output
-    assert "run-s1" in result.output
-    assert "run-s2" in result.output
+    assert "test_benchmark" in result.output
 
 
 def test_batch_extract_writes_csv(tmp_path):


### PR DESCRIPTION
## Summary
`batch evaluate` now uses a global worker pool and improved status display.

### Global worker pool (`core_batch_evaluate`)
```bash
exgentic batch evaluate \
  --config "experiments/*/*/config.json" \
  --num-tasks 30 --max-workers 8
```
Sessions from ALL configs share a single `ThreadPoolExecutor`. Three phases:
1. **Plan** — resolve sessions per config (sequential)
2. **Execute** — run all sessions in one global pool
3. **Aggregate** — score each config from disk (sequential)

### Improved `batch status`
```bash
exgentic batch status --num-tasks 30 --config "experiments/*/*/config.json"
```
- Shows benchmark/subset, agent, model, sessions (with running/error counts), score, cost
- `--num-tasks` override so display matches what `batch evaluate` plans
- Summary panel with configs done, session progress, total cost

## Verified
- E2E tested: 4 tau2 configs × 2 models, global pool runs sessions across configs
- Status display tested with 50 configs
- All reused sessions handled correctly (no crashes on zero-pending configs)

## Changes
- `run.py`: `core_batch_evaluate()` — plan → execute → aggregate
- `batch.py`: `batch evaluate` routes to global pool; `batch status` shows model, sessions, `--num-tasks`
- `render.py`: Simplified table with summary dashboard