### PR TITLE
Fix trace logging alias instead of actual backend model

### DIFF
--- a/src/exgentic/integrations/litellm/trace_logger.py
+++ b/src/exgentic/integrations/litellm/trace_logger.py
@@ -194,10 +194,11 @@ class TraceLogger(CustomLogger):
         file_path = self._resolve_log_path(kwargs)
         Path(file_path).parent.mkdir(parents=True, exist_ok=True)
         usage = self._extract_usage(response_obj)
+        litellm_params = kwargs.get("litellm_params") or {}
         row = {
             "timestamp": datetime.now(UTC).isoformat(),
             "status": status,
-            "model": kwargs.get("model"),
+            "model": litellm_params.get("model") or kwargs.get("model"),
             "prompt_tokens": usage.get("prompt_tokens"),
             "completion_tokens": usage.get("completion_tokens"),
             "total_tokens": usage.get("total_tokens"),
@@ -231,7 +232,7 @@ class TraceLogger(CustomLogger):
         ctx = self.get_context(kwargs)
 
         operation = "chat" if kwargs.get("messages") else "text_completion"
-        model = kwargs.get("model", "unknown")
+        model = litellm_params.get("model") or kwargs.get("model", "unknown")
         span_name = f"{operation} {model}"
 
         # Create span

--- a/tests/integrations/litellm/proxy/test_trace_logger_env.py
+++ b/tests/integrations/litellm/proxy/test_trace_logger_env.py
@@ -74,6 +74,31 @@ def test_trace_logger_uses_kwargs_context_for_log_path(tmp_path, monkeypatch) ->
     assert not env_log_path.exists()
 
 
+def test_trace_logger_resolves_alias_to_backend_model(tmp_path, monkeypatch) -> None:
+    """Trace should log the actual backend model, not the proxy alias.
+
+    Reproduces https://github.com/Exgentic/exgentic/issues/52
+    """
+    log_path = tmp_path / "trace.jsonl"
+    monkeypatch.setenv(FILE_ENV, str(log_path))
+
+    logger = TraceLogger()
+    kwargs = {
+        "model": "claude-3-5-sonnet-20241022",  # alias from CLI client
+        "litellm_params": {"model": "openai/aws/claude-opus-4-5"},  # actual backend
+        "messages": [{"role": "user", "content": "Hi"}],
+        "response_cost": 0.0,
+    }
+    response = {
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+    }
+    logger.log_success_event(kwargs, response, None, None)
+
+    record = json.loads(log_path.read_text().strip())
+    assert record["model"] == "openai/aws/claude-opus-4-5"
+
+
 def test_trace_logger_get_context_falls_back_to_try_get_context(monkeypatch) -> None:
     fallback = Context(
         run_id="run_fallback",


### PR DESCRIPTION
## Summary
- TraceLogger logged the proxy alias (e.g. `claude-3-5-sonnet-20241022`) instead of the actual backend model (e.g. `openai/aws/claude-opus-4-5`) in both JSONL trace and OTEL spans
- Resolve model from `litellm_params["model"]` which contains the real backend model after proxy routing

Fixes #52

## Test plan
- [x] Added `test_trace_logger_resolves_alias_to_backend_model` that verifies the backend model is logged when an alias is used
- [x] All existing trace logger tests pass