### PR TITLE
Cache task IDs to disk to skip benchmark data loading

### DIFF
--- a/src/exgentic/core/types/run.py
+++ b/src/exgentic/core/types/run.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import random
+from pathlib import Path
 from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -239,6 +242,35 @@ class RunPlan(BaseModel):
         )
 
 
+_log = logging.getLogger(__name__)
+
+
+def _task_ids_cache_path(benchmark_slug: str, subset: str) -> Path:
+    from ...environment.instance import get_manager
+
+    return get_manager().env_path(f"benchmarks/{benchmark_slug}") / f"task_ids_{subset}.json"
+
+
+def _load_cached_task_ids(benchmark_slug: str, subset: str) -> list[str] | None:
+    path = _task_ids_cache_path(benchmark_slug, subset)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        _log.debug("Failed to read task ID cache %s, will regenerate", path)
+        return None
+
+
+def _save_cached_task_ids(benchmark_slug: str, subset: str, task_ids: list[str]) -> None:
+    path = _task_ids_cache_path(benchmark_slug, subset)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(task_ids), encoding="utf-8")
+    except Exception:
+        _log.debug("Failed to write task ID cache %s", path)
+
+
 class RunConfig(BaseEvaluationConfig):
     """Configuration for a run of multiple sessions."""
 
@@ -296,20 +328,23 @@ class RunConfig(BaseEvaluationConfig):
         if task_ids is None:
             bench_cls = load_benchmark(resolved.benchmark)
             benchmark = bench_cls(**(resolved.benchmark_kwargs or {}))
-            evaluator = benchmark.get_evaluator()
-            try:
-                selected = [str(t) for t in evaluator.list_tasks()]
-                if resolved.num_tasks is not None:
-                    seed = benchmark.seed
-                    rng = random.Random(seed if seed is not None else 0)
-                    rng.shuffle(selected)
-                    selected = selected[: int(resolved.num_tasks)]
-            finally:
+            selected = _load_cached_task_ids(resolved.benchmark, benchmark.subset_name)
+            if selected is None:
+                evaluator = benchmark.get_evaluator()
                 try:
-                    evaluator.close()
-                except Exception:
-                    pass
-                benchmark.close()
+                    selected = [str(t) for t in evaluator.list_tasks()]
+                finally:
+                    try:
+                        evaluator.close()
+                    except Exception:
+                        pass
+                _save_cached_task_ids(resolved.benchmark, benchmark.subset_name, selected)
+            benchmark.close()
+            if resolved.num_tasks is not None:
+                seed = benchmark.seed
+                rng = random.Random(seed if seed is not None else 0)
+                rng.shuffle(selected)
+                selected = selected[: int(resolved.num_tasks)]
         else:
             selected = [str(t) for t in task_ids]
             if resolved.num_tasks is not None:

--- a/src/exgentic/interfaces/lib/api.py
+++ b/src/exgentic/interfaces/lib/api.py
@@ -543,6 +543,8 @@ def list_tasks(
     subset: str | None = None,
     benchmark_kwargs: dict[str, Any] | None = None,
 ) -> list[str]:
+    from ..core.types.run import _load_cached_task_ids, _save_cached_task_ids
+
     benchmark_entries = get_benchmark_entries()
     if benchmark not in benchmark_entries:
         raise ValueError(
@@ -553,10 +555,15 @@ def list_tasks(
         bench_kwargs = apply_subset_kwargs(benchmark, subset, bench_kwargs)
     bench_cls = load_benchmark_class(benchmark)
     benchmark_obj: Benchmark = bench_cls(**bench_kwargs)
+    subset_name = benchmark_obj.subset_name
+    cached = _load_cached_task_ids(benchmark, subset_name)
+    if cached is not None:
+        benchmark_obj.close()
+        return cached
     evaluator = benchmark_obj.get_evaluator()
     try:
         try:
-            return evaluator.list_tasks()
+            tasks = evaluator.list_tasks()
         except NotImplementedError as exc:
             raise ValueError(str(exc)) from exc
     finally:
@@ -565,6 +572,8 @@ def list_tasks(
         except Exception:
             pass
         benchmark_obj.close()
+    _save_cached_task_ids(benchmark, subset_name, tasks)
+    return tasks
 
 
 def needs_setup(name: str, kind: str) -> bool:

--- a/tests/core/test_task_list_cache.py
+++ b/tests/core/test_task_list_cache.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+from __future__ import annotations
+
+from exgentic.core.types.run import (
+    _load_cached_task_ids,
+    _save_cached_task_ids,
+)
+
+
+def _fake_manager(tmp_path):
+    from exgentic.environment.manager import EnvironmentManager
+
+    return EnvironmentManager(base_dir=tmp_path)
+
+
+def test_save_and_load_round_trip(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "exgentic.environment.instance.get_manager",
+        lambda: _fake_manager(tmp_path),
+    )
+    ids = ["0", "1", "2", "42"]
+    _save_cached_task_ids("gsm8k", "main", ids)
+
+    result = _load_cached_task_ids("gsm8k", "main")
+    assert result == ids
+
+
+def test_load_returns_none_when_no_cache(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "exgentic.environment.instance.get_manager",
+        lambda: _fake_manager(tmp_path),
+    )
+    assert _load_cached_task_ids("gsm8k", "main") is None
+
+
+def test_load_returns_none_on_corrupt_file(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "exgentic.environment.instance.get_manager",
+        lambda: _fake_manager(tmp_path),
+    )
+    cache_dir = tmp_path / "benchmarks" / "gsm8k"
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "task_ids_main.json").write_text("not json{{{")
+
+    assert _load_cached_task_ids("gsm8k", "main") is None
+
+
+def test_different_subsets_cached_separately(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "exgentic.environment.instance.get_manager",
+        lambda: _fake_manager(tmp_path),
+    )
+    _save_cached_task_ids("appworld", "train", ["a", "b"])
+    _save_cached_task_ids("appworld", "dev", ["x", "y", "z"])
+
+    assert _load_cached_task_ids("appworld", "train") == ["a", "b"]
+    assert _load_cached_task_ids("appworld", "dev") == ["x", "y", "z"]


### PR DESCRIPTION
## Summary
- `list_tasks()` loads full benchmark data (~50s for heavy benchmarks like AppWorld) on every `evaluate` call
- Cache resolved task IDs to `~/.exgentic/benchmarks/<slug>/task_ids_<subset>.json` on first call
- Subsequent runs read from the cache file, skipping expensive data loading entirely
- Cache files live alongside existing benchmark data in `~/.exgentic/benchmarks/`

Fixes #159

## Test plan
- [x] `test_save_and_load_round_trip` — verifies write then read returns same IDs
- [x] `test_load_returns_none_when_no_cache` — verifies cache miss returns None
- [x] `test_load_returns_none_on_corrupt_file` — verifies graceful handling of bad cache
- [x] `test_different_subsets_cached_separately` — verifies per-subset isolation