### PR TITLE
Fix stale venvs not rebuilt when agent has no setup files

### DIFF
--- a/src/exgentic/environment/manager.py
+++ b/src/exgentic/environment/manager.py
@@ -139,6 +139,10 @@ class EnvironmentManager:
     # Queries
     # ------------------------------------------------------------------
 
+    def has_marker(self, name: str) -> bool:
+        """Return True if the environment has ever been installed (marker exists)."""
+        return bool(self._read_marker(name))
+
     def is_installed(self, name: str, *, env_type: EnvType | None = None) -> bool:
         """Check if an environment is installed and up-to-date.
 

--- a/src/exgentic/interfaces/cli/commands/evaluate.py
+++ b/src/exgentic/interfaces/cli/commands/evaluate.py
@@ -89,10 +89,12 @@ def _ensure_installed(
     bench_name = f"benchmarks/{benchmark}"
     agent_name = f"agents/{agent}"
 
-    if not mgr.is_installed(bench_name, env_type=env_type) and _needs_setup(benchmark, "benchmark"):
-        to_install.append(("benchmark", benchmark, bench_name))
-    if not mgr.is_installed(agent_name, env_type=env_type) and _needs_setup(agent, "agent"):
-        to_install.append(("agent", agent, agent_name))
+    if not mgr.is_installed(bench_name, env_type=env_type):
+        if mgr.has_marker(bench_name) or _needs_setup(benchmark, "benchmark"):
+            to_install.append(("benchmark", benchmark, bench_name))
+    if not mgr.is_installed(agent_name, env_type=env_type):
+        if mgr.has_marker(agent_name) or _needs_setup(agent, "agent"):
+            to_install.append(("agent", agent, agent_name))
 
     if not to_install:
         return

--- a/tests/environment/test_manager.py
+++ b/tests/environment/test_manager.py
@@ -223,6 +223,27 @@ class TestVenvInstall:
         assert not sentinel.exists()
         assert mgr.is_installed("mybench", env_type=EnvType.VENV)
 
+    def test_has_marker_false_before_install(self, tmp_path: Path) -> None:
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+        assert not mgr.has_marker("mybench")
+
+    def test_has_marker_true_with_marker_file(self, tmp_path: Path) -> None:
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+        marker_path = mgr.env_path("mybench") / ".installed"
+        marker_path.parent.mkdir(parents=True, exist_ok=True)
+        marker_path.write_text(json.dumps({"venv": {"exgentic_version": "1.0.0"}}))
+        assert mgr.has_marker("mybench")
+
+    def test_has_marker_true_when_version_stale(self, tmp_path: Path) -> None:
+        """has_marker returns True even when the version is stale."""
+        mgr = EnvironmentManager(base_dir=tmp_path / "envs")
+        marker_path = mgr.env_path("mybench") / ".installed"
+        marker_path.parent.mkdir(parents=True, exist_ok=True)
+        marker_path.write_text(json.dumps({"venv": {"exgentic_version": "0.0.0.fake"}}))
+
+        assert not mgr.is_installed("mybench", env_type=EnvType.VENV)
+        assert mgr.has_marker("mybench")
+
     def test_force_reinstalls(self, tmp_path: Path) -> None:
         module_path = _create_fake_package(tmp_path, with_requirements=False, with_setup=False)
         mgr = EnvironmentManager(base_dir=tmp_path / "envs")


### PR DESCRIPTION
## Summary
- `_ensure_installed()` gated venv reinstall on `_needs_setup()` which checks for `setup.sh`/`requirements.txt`
- Agents like `tool_calling` have neither, so stale venvs were never rebuilt even when the exgentic version changed
- Fix: when a marker exists (previously installed) but `is_installed()` returns `False` (version stale), always rebuild — `_needs_setup()` only gates truly first-time installs
- Added `has_marker()` to `EnvironmentManager`

Fixes #158

## Test plan
- [x] `test_has_marker_false_before_install` — no marker → False
- [x] `test_has_marker_true_with_marker_file` — marker exists → True
- [x] `test_has_marker_true_when_version_stale` — stale version still has marker → True, enabling rebuild
- [x] `test_cli_execute_concurrent` — previously passed, still passes (no regression)
- [x] Full test suite: 232 passed, 1 pre-existing Docker failure