### PR TITLE
fix: correct relative import path for task ID cache

### DIFF
--- a/src/exgentic/interfaces/lib/api.py
+++ b/src/exgentic/interfaces/lib/api.py
@@ -543,7 +543,7 @@ def list_tasks(
     subset: str | None = None,
     benchmark_kwargs: dict[str, Any] | None = None,
 ) -> list[str]:
-    from ..core.types.run import _load_cached_task_ids, _save_cached_task_ids
+    from ...core.types.run import _load_cached_task_ids, _save_cached_task_ids
 
     benchmark_entries = get_benchmark_entries()
     if benchmark not in benchmark_entries:


### PR DESCRIPTION
## Summary
- `api.py` used `..core` (2 dots) which resolved to `exgentic.interfaces.core` — doesn't exist
- Fixed to `...core` (3 dots) to correctly reach `exgentic.core` from `exgentic.interfaces.lib`
- Introduced in #160, broke `list_tasks()` API on main

## Test plan
- [x] `test_listing_apis` — was failing, now passes