### PR TITLE
fix: don't crash on incomplete session cleanup failure

### DIFF
--- a/src/exgentic/core/orchestrator/execution.py
+++ b/src/exgentic/core/orchestrator/execution.py
@@ -85,21 +85,26 @@ def _cleanup_session_dir(
     sess_paths,
     log,
 ) -> None:
-    if session_config.overwrite_sessions and sess_paths.root.exists():
-        shutil.rmtree(sess_paths.root)
-        log.info(
-            "Overwriting existing session %s (task=%s)",
-            session_config.get_session_id(),
-            session_config.task_id,
-        )
+    if not sess_paths.root.exists():
         return
-    if status.status == SessionExecutionStatus.INCOMPLETE and sess_paths.root.exists():
+    if not (session_config.overwrite_sessions or status.status == SessionExecutionStatus.INCOMPLETE):
+        return
+    # Best-effort removal.  If it fails (e.g. Docker-owned files),
+    # the session will re-run in the existing directory — new results
+    # overwrite old partial files.
+    try:
         shutil.rmtree(sess_paths.root)
-        log.info(
-            "Overwriting incomplete session %s (task=%s)",
+    except OSError:
+        log.warning(
+            "Could not fully remove session dir %s; re-running in place",
             session_config.get_session_id(),
-            session_config.task_id,
         )
+    log.info(
+        "Overwriting %s session %s (task=%s)",
+        "existing" if session_config.overwrite_sessions else "incomplete",
+        session_config.get_session_id(),
+        session_config.task_id,
+    )
 
 
 def _write_session_config(


### PR DESCRIPTION
## Problem
When an incomplete session directory can't be deleted (e.g. Docker-owned files), `shutil.rmtree` raises `PermissionError` which crashes the session task and permanently blocks that session slot. Every batch restart accumulates more zombie sessions.

## Fix
Catch `OSError` from `rmtree`, log a warning, and re-run the session in the existing directory. New results overwrite old partial files.

## Verified
- Created a session dir with a root-owned file
- Ran evaluate — orchestrator logged `Overwriting incomplete session` and completed successfully
- No crashes, no blocking

Closes #164