### PR TITLE
fix: include benchmark_kwargs in task ID cache key

### DIFF
--- a/src/exgentic/core/types/run.py
+++ b/src/exgentic/core/types/run.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import random
@@ -245,14 +246,24 @@ class RunPlan(BaseModel):
 _log = logging.getLogger(__name__)
 
 
-def _task_ids_cache_path(benchmark_slug: str, subset: str) -> Path:
+def _task_ids_cache_key(benchmark_slug: str, subset: str, benchmark_kwargs: dict | None = None) -> str:
+    """Build a cache filename that includes subset and any benchmark kwargs."""
+    key = subset
+    if benchmark_kwargs:
+        # Stable hash of kwargs so different configs get separate caches
+        h = hashlib.sha256(json.dumps(benchmark_kwargs, sort_keys=True).encode()).hexdigest()[:12]
+        key = f"{subset}_{h}"
+    return key
+
+
+def _task_ids_cache_path(benchmark_slug: str, cache_key: str) -> Path:
     from ...environment.instance import get_manager
 
-    return get_manager().env_path(f"benchmarks/{benchmark_slug}") / f"task_ids_{subset}.json"
+    return get_manager().env_path(f"benchmarks/{benchmark_slug}") / f"task_ids_{cache_key}.json"
 
 
-def _load_cached_task_ids(benchmark_slug: str, subset: str) -> list[str] | None:
-    path = _task_ids_cache_path(benchmark_slug, subset)
+def _load_cached_task_ids(benchmark_slug: str, cache_key: str) -> list[str] | None:
+    path = _task_ids_cache_path(benchmark_slug, cache_key)
     if not path.exists():
         return None
     try:
@@ -262,8 +273,8 @@ def _load_cached_task_ids(benchmark_slug: str, subset: str) -> list[str] | None:
         return None
 
 
-def _save_cached_task_ids(benchmark_slug: str, subset: str, task_ids: list[str]) -> None:
-    path = _task_ids_cache_path(benchmark_slug, subset)
+def _save_cached_task_ids(benchmark_slug: str, cache_key: str, task_ids: list[str]) -> None:
+    path = _task_ids_cache_path(benchmark_slug, cache_key)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(task_ids), encoding="utf-8")
@@ -328,7 +339,8 @@ class RunConfig(BaseEvaluationConfig):
         if task_ids is None:
             bench_cls = load_benchmark(resolved.benchmark)
             benchmark = bench_cls(**(resolved.benchmark_kwargs or {}))
-            selected = _load_cached_task_ids(resolved.benchmark, benchmark.subset_name)
+            cache_key = _task_ids_cache_key(resolved.benchmark, benchmark.subset_name, resolved.benchmark_kwargs)
+            selected = _load_cached_task_ids(resolved.benchmark, cache_key)
             if selected is None:
                 evaluator = benchmark.get_evaluator()
                 try:
@@ -338,7 +350,7 @@ class RunConfig(BaseEvaluationConfig):
                         evaluator.close()
                     except Exception:
                         pass
-                _save_cached_task_ids(resolved.benchmark, benchmark.subset_name, selected)
+                _save_cached_task_ids(resolved.benchmark, cache_key, selected)
             benchmark.close()
             if resolved.num_tasks is not None:
                 seed = benchmark.seed

--- a/src/exgentic/interfaces/lib/api.py
+++ b/src/exgentic/interfaces/lib/api.py
@@ -543,7 +543,7 @@ def list_tasks(
     subset: str | None = None,
     benchmark_kwargs: dict[str, Any] | None = None,
 ) -> list[str]:
-    from ...core.types.run import _load_cached_task_ids, _save_cached_task_ids
+    from ...core.types.run import _load_cached_task_ids, _save_cached_task_ids, _task_ids_cache_key
 
     benchmark_entries = get_benchmark_entries()
     if benchmark not in benchmark_entries:
@@ -555,8 +555,8 @@ def list_tasks(
         bench_kwargs = apply_subset_kwargs(benchmark, subset, bench_kwargs)
     bench_cls = load_benchmark_class(benchmark)
     benchmark_obj: Benchmark = bench_cls(**bench_kwargs)
-    subset_name = benchmark_obj.subset_name
-    cached = _load_cached_task_ids(benchmark, subset_name)
+    cache_key = _task_ids_cache_key(benchmark, benchmark_obj.subset_name, bench_kwargs or None)
+    cached = _load_cached_task_ids(benchmark, cache_key)
     if cached is not None:
         benchmark_obj.close()
         return cached
@@ -572,7 +572,7 @@ def list_tasks(
         except Exception:
             pass
         benchmark_obj.close()
-    _save_cached_task_ids(benchmark, subset_name, tasks)
+    _save_cached_task_ids(benchmark, cache_key, tasks)
     return tasks
 
 

--- a/tests/core/test_task_list_cache.py
+++ b/tests/core/test_task_list_cache.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from exgentic.core.types.run import (
     _load_cached_task_ids,
     _save_cached_task_ids,
+    _task_ids_cache_key,
 )
 
 
@@ -20,10 +21,11 @@ def test_save_and_load_round_trip(tmp_path, monkeypatch) -> None:
         "exgentic.environment.instance.get_manager",
         lambda: _fake_manager(tmp_path),
     )
+    key = _task_ids_cache_key("gsm8k", "main")
     ids = ["0", "1", "2", "42"]
-    _save_cached_task_ids("gsm8k", "main", ids)
+    _save_cached_task_ids("gsm8k", key, ids)
 
-    result = _load_cached_task_ids("gsm8k", "main")
+    result = _load_cached_task_ids("gsm8k", key)
     assert result == ids
 
 
@@ -32,7 +34,8 @@ def test_load_returns_none_when_no_cache(tmp_path, monkeypatch) -> None:
         "exgentic.environment.instance.get_manager",
         lambda: _fake_manager(tmp_path),
     )
-    assert _load_cached_task_ids("gsm8k", "main") is None
+    key = _task_ids_cache_key("gsm8k", "main")
+    assert _load_cached_task_ids("gsm8k", key) is None
 
 
 def test_load_returns_none_on_corrupt_file(tmp_path, monkeypatch) -> None:
@@ -44,7 +47,8 @@ def test_load_returns_none_on_corrupt_file(tmp_path, monkeypatch) -> None:
     cache_dir.mkdir(parents=True)
     (cache_dir / "task_ids_main.json").write_text("not json{{{")
 
-    assert _load_cached_task_ids("gsm8k", "main") is None
+    key = _task_ids_cache_key("gsm8k", "main")
+    assert _load_cached_task_ids("gsm8k", key) is None
 
 
 def test_different_subsets_cached_separately(tmp_path, monkeypatch) -> None:
@@ -52,8 +56,31 @@ def test_different_subsets_cached_separately(tmp_path, monkeypatch) -> None:
         "exgentic.environment.instance.get_manager",
         lambda: _fake_manager(tmp_path),
     )
-    _save_cached_task_ids("appworld", "train", ["a", "b"])
-    _save_cached_task_ids("appworld", "dev", ["x", "y", "z"])
+    key_train = _task_ids_cache_key("appworld", "train")
+    key_dev = _task_ids_cache_key("appworld", "dev")
+    _save_cached_task_ids("appworld", key_train, ["a", "b"])
+    _save_cached_task_ids("appworld", key_dev, ["x", "y", "z"])
 
-    assert _load_cached_task_ids("appworld", "train") == ["a", "b"]
-    assert _load_cached_task_ids("appworld", "dev") == ["x", "y", "z"]
+    assert _load_cached_task_ids("appworld", key_train) == ["a", "b"]
+    assert _load_cached_task_ids("appworld", key_dev) == ["x", "y", "z"]
+
+
+def test_different_kwargs_cached_separately(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "exgentic.environment.instance.get_manager",
+        lambda: _fake_manager(tmp_path),
+    )
+    key1 = _task_ids_cache_key("test", "main", {"tasks": ["a"]})
+    key2 = _task_ids_cache_key("test", "main", {"tasks": ["a", "b"]})
+    assert key1 != key2
+
+    _save_cached_task_ids("test", key1, ["a"])
+    _save_cached_task_ids("test", key2, ["a", "b"])
+
+    assert _load_cached_task_ids("test", key1) == ["a"]
+    assert _load_cached_task_ids("test", key2) == ["a", "b"]
+
+
+def test_no_kwargs_same_as_none(tmp_path, monkeypatch) -> None:
+    assert _task_ids_cache_key("x", "main") == _task_ids_cache_key("x", "main", None)
+    assert _task_ids_cache_key("x", "main") == _task_ids_cache_key("x", "main", {})


### PR DESCRIPTION
## Summary
- Task ID cache keyed only on `(benchmark_slug, subset)` but `benchmark_kwargs` can change the task list
- This caused `test_evaluate_full_flow` to fail on main — test passes custom task lists via kwargs, and the stale cache returned wrong IDs
- Fix: hash `benchmark_kwargs` into the cache filename so different configs get separate caches

## Test plan
- [x] `test_different_kwargs_cached_separately` — verifies different kwargs produce different cache keys
- [x] `test_no_kwargs_same_as_none` — verifies empty/None kwargs are equivalent
- [x] `test_evaluate_full_flow[direct]` — was failing on main, now passes
- [x] Full suite: 398 passed (1 pre-existing proxy failure)