### PR TITLE
docs: add Podman Rosetta troubleshooting for Apple Silicon

### DIFF
--- a/docs/podman-macos.md
+++ b/docs/podman-macos.md
@@ -57,6 +57,41 @@ docker run --platform linux/amd64 --rm alpine uname -m
 
 ---
 
+## Troubleshooting: x86_64 emulation segfaults on Apple Silicon
+
+x86_64 containers may segfault when importing heavy Python packages (pyarrow, pandas). This happens because Podman silently falls back to QEMU even when Rosetta is configured.
+
+**Check if Rosetta is active:**
+
+```bash
+podman machine ssh "cat /proc/sys/fs/binfmt_misc/rosetta 2>/dev/null || echo NOT ACTIVE"
+```
+
+- If it says `enabled` with interpreter `/mnt/rosetta` — you're fine.
+- If it says `NOT ACTIVE` — Rosetta is not running, apply the fix below.
+
+**Fix:**
+
+```bash
+podman machine ssh "sudo touch /etc/containers/enable-rosetta"
+podman machine stop
+podman machine start
+```
+
+**Verify:**
+
+```bash
+# Should say "enabled" with interpreter /mnt/rosetta
+podman machine ssh "cat /proc/sys/fs/binfmt_misc/rosetta"
+
+# Quick test — this segfaults under QEMU, works under Rosetta
+docker run --rm python:3.12-slim python3 -c "import struct; print('OK')"
+```
+
+**Why:** Podman 5.7+ has a bug where `Rosetta: true` in machine config doesn't actually enable Rosetta inside the VM. The trigger file `/etc/containers/enable-rosetta` is missing, so the activation service skips. Creating it and restarting fixes it. See [containers/podman#28181](https://github.com/containers/podman/issues/28181).
+
+---
+
 ## See also
 
 - [Runners](./runners.md) — all runner types and configuration


### PR DESCRIPTION
## Summary
- Added troubleshooting section to `docs/podman-macos.md` for x86_64 container segfaults on Apple Silicon
- Podman 5.7+ has a bug where Rosetta isn't actually enabled despite config saying so
- Documents the check, fix (`touch /etc/containers/enable-rosetta`), and verification steps
- References [containers/podman#28181](https://github.com/containers/podman/issues/28181)