### PR TITLE
fix: reduce CLI startup time from 2.5s to 0.25s

### DIFF
--- a/src/exgentic/core/orchestrator/session.py
+++ b/src/exgentic/core/orchestrator/session.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
-from ...integrations.litellm.health import HealthCheckError
 from ..types import SessionConfig
 from .controller import Controller
 from .observer import Observer
@@ -74,8 +73,6 @@ def run_session(
             raise BenchmarkTerminationError()
         raise AgentTerminationError()
 
-    except HealthCheckError as exc:
-        tracker.on_session_error(session, AgentError(exc))
     except KeyboardInterrupt:
         tracker.on_session_error(session, RunCancelError())
         _close_session_agent(session, agent_instance)
@@ -108,6 +105,13 @@ def run_session(
     except BenchmarkError as exc:
         tracker.on_session_error(session, exc)
         agent_instance.close()
+    except RuntimeError as exc:
+        from ...integrations.litellm.health import HealthCheckError
+
+        if isinstance(exc, HealthCheckError):
+            tracker.on_session_error(session, AgentError(exc))
+        else:
+            raise
     except SessionCancelError as exc:
         tracker.on_session_error(session, exc)
         _close_session_agent(session, agent_instance)


### PR DESCRIPTION
## Summary
- `exgentic --help` took **2.5s** — nearly all from eagerly importing heavy deps
- Two lazy import fixes:
  - `session.py`: defer `HealthCheckError` import (triggered `litellm`, **1.24s**)
  - `observers/logging`: defer `uvicorn.logging` import (**25ms**, only needed by `configure_uvicorn_file_logging`)
- Result: **2.5s → 0.25s** (10x faster)
- Added regression tests that fail if `litellm` or `uvicorn` get imported at startup, or if total import time exceeds 1s

Fixes #48

## Test plan
- [x] `time exgentic --help` — 0.25s (was 2.5s)
- [x] `test_cli_import_time` — asserts import < 1s
- [x] `test_no_litellm_on_import` — asserts litellm not in sys.modules
- [x] `test_no_uvicorn_on_import` — asserts uvicorn not in sys.modules
- [x] `pytest tests/api/test_api_runners.py` — all passing (evaluations still work)