### PR TITLE
fix: return UNKNOWN instead of None from _extract_result_status

### DIFF
--- a/src/exgentic/core/orchestrator/execution.py
+++ b/src/exgentic/core/orchestrator/execution.py
@@ -139,6 +139,7 @@ def _status_from_paths_without_lock(
             SessionOutcomeStatus.ERROR,
             SessionOutcomeStatus.CANCELLED,
             SessionOutcomeStatus.LIMIT_REACHED,
+            SessionOutcomeStatus.UNKNOWN,
         ):
             status = SessionExecutionStatus.INCOMPLETE
         else:

--- a/src/exgentic/core/types/session.py
+++ b/src/exgentic/core/types/session.py
@@ -99,17 +99,17 @@ class SessionStatus(BaseModel):
         return False
 
     @classmethod
-    def _extract_result_status(cls, results_path) -> Optional[SessionOutcomeStatus]:
+    def _extract_result_status(cls, results_path) -> SessionOutcomeStatus:
         try:
             payload = json.loads(results_path.read_text(encoding="utf-8"))
         except Exception:
-            return None
+            return SessionOutcomeStatus.UNKNOWN
         status = payload.get("status")
         if status:
             try:
                 return SessionOutcomeStatus(str(status))
             except ValueError:
-                return None
+                return SessionOutcomeStatus.UNKNOWN
         success = payload.get("success")
         is_finished = payload.get("is_finished")
         details = payload.get("details") or {}
@@ -123,7 +123,7 @@ class SessionStatus(BaseModel):
             return SessionOutcomeStatus.SUCCESS if success else SessionOutcomeStatus.UNSUCCESSFUL
         if is_finished is False:
             return SessionOutcomeStatus.UNFINISHED
-        return None
+        return SessionOutcomeStatus.UNKNOWN
 
     @classmethod
     def from_config(cls, session_config, *, run_paths=None) -> SessionStatus:
@@ -149,6 +149,7 @@ class SessionStatus(BaseModel):
             if result_status in (
                 SessionOutcomeStatus.ERROR,
                 SessionOutcomeStatus.CANCELLED,
+                SessionOutcomeStatus.UNKNOWN,
             ):
                 status = SessionExecutionStatus.INCOMPLETE
             else:

--- a/tests/core/test_session_status.py
+++ b/tests/core/test_session_status.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Tests for SessionStatus._extract_result_status."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from exgentic.core.types.session import SessionOutcomeStatus, SessionStatus
+
+
+def _write(path: Path, data: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def test_success(tmp_path: Path):
+    p = _write(tmp_path / "results.json", {"status": "success"})
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.SUCCESS
+
+
+def test_error(tmp_path: Path):
+    p = _write(tmp_path / "results.json", {"status": "error"})
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.ERROR
+
+
+def test_cancelled(tmp_path: Path):
+    p = _write(
+        tmp_path / "results.json",
+        {"details": {"session_metadata": {"error_source": "cancelled"}}},
+    )
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.CANCELLED
+
+
+def test_agent_error(tmp_path: Path):
+    p = _write(
+        tmp_path / "results.json",
+        {"details": {"session_metadata": {"error_source": "agent", "error": "crash"}}},
+    )
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.ERROR
+
+
+def test_finished_successful(tmp_path: Path):
+    p = _write(tmp_path / "results.json", {"success": True, "is_finished": True})
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.SUCCESS
+
+
+def test_finished_unsuccessful(tmp_path: Path):
+    p = _write(tmp_path / "results.json", {"success": False, "is_finished": True})
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.UNSUCCESSFUL
+
+
+def test_unfinished(tmp_path: Path):
+    p = _write(tmp_path / "results.json", {"is_finished": False})
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.UNFINISHED
+
+
+def test_empty_json_returns_unknown(tmp_path: Path):
+    p = _write(tmp_path / "results.json", {})
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.UNKNOWN
+
+
+def test_all_none_returns_unknown(tmp_path: Path):
+    p = _write(tmp_path / "results.json", {"score": None, "success": None, "status": None})
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.UNKNOWN
+
+
+def test_corrupt_json_returns_unknown(tmp_path: Path):
+    p = tmp_path / "results.json"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("not json", encoding="utf-8")
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.UNKNOWN
+
+
+def test_missing_file_returns_unknown(tmp_path: Path):
+    p = tmp_path / "results.json"
+    assert SessionStatus._extract_result_status(p) == SessionOutcomeStatus.UNKNOWN


### PR DESCRIPTION
## Problem
`_extract_result_status` returned `None` for unrecognizable results.json files (empty, corrupt, all-None fields). Callers treated `None` as COMPLETED, permanently blocking re-execution of interrupted sessions.

## Fix
Return `UNKNOWN` instead of `None`. Both status detection paths classify `UNKNOWN` as `INCOMPLETE`, so the session gets cleaned up and re-run automatically.

## Tests
11 unit tests covering: success, error, agent error, cancelled, finished, unfinished, empty JSON, all-None, corrupt, missing file.