### PR TITLE
fix: pin pydantic to 2.12.5 to match litellm's hard pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "json-schema-to-pydantic>=0.4,<1",
     "litellm>=1.65.0,!=1.82.7,!=1.82.8,<2",
     "mcp>=1.24,<2",
-    "pydantic>=2.9.2,<3",
+    "pydantic>=2.12.5,<2.13",
     "python-dotenv>=1,<2",
     "rich>=13,<14",
     "rich-click>=1,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -774,7 +774,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1,<2" },
     { name = "opentelemetry-semantic-conventions-ai", specifier = ">=0.4.0,<1" },
     { name = "pandas", marker = "extra == 'analysis'", specifier = ">=3,<4" },
-    { name = "pydantic", specifier = ">=2.9.2,<3" },
+    { name = "pydantic", specifier = ">=2.12.5,<2.13" },
     { name = "pydantic-settings", specifier = ">=2,<3" },
     { name = "python-dotenv", specifier = ">=1,<2" },
     { name = "rich", specifier = ">=13,<14" },


### PR DESCRIPTION
## Summary

- Tightens the `pydantic` floor in `pyproject.toml` from `>=2.9.2,<3` to `>=2.12.5,<2.13`, matching the hard pin that `litellm>=1.83.4` already forces.
- Regenerates `uv.lock` to reflect the new constraint.
- Fixes #178: every non-`claude_code` session in the DeepSeek-V3.2 / Kimi-K2.5 batch runs was failing with `TypeError: SchemaSerializer.__new__() takes from 1 to 2 positional arguments but 3 were given` because the parent venv (pydantic-core 2.41) was trying to cloudpickle-decode payloads pickled by agent venvs that had drifted onto pydantic-core 2.46.

See #178 for the full root-cause writeup, including the drift table, repro, and secondary symptoms (cascading 120s venv-health timeouts).

## Why pin downward instead of upward

`litellm>=1.83.4` has `pydantic==2.12.5` as a hard dependency, so bumping the floor to `>=2.13` is unresolvable with the current `litellm>=1.65.0` constraint. Converging on 2.12.x is the only feasible direction without also bumping litellm to a hypothetical future release that unpins pydantic.

## Required post-merge action

Every agent/benchmark venv installs the main `exgentic` package via `install_project()` in `src/exgentic/environment/venv.py`, so **fresh venvs** will automatically pick up the new floor. **Stale venvs already on `pydantic==2.13.0` will not downgrade in place** (`uv pip install` does not downgrade). They must be wiped once after merge:

\`\`\`bash
rm -rf ~/.exgentic/agents/{smolagents_code,openai_solo,tool_calling}/venv
rm -rf ~/.exgentic/benchmarks/appworld/venv
\`\`\`

exgentic will rebuild them on next launch.

## Follow-up (out of scope)

A tight pin is a band-aid. The real fix is to stop cloudpickling pydantic models across venv boundaries in \`src/exgentic/adapters/runners/service.py\` and use \`model_dump_json()\` / \`model_validate_json()\` instead — immune to Rust ABI drift. Will open a separate issue for that after this lands so production runs can proceed.

## Test plan

- [ ] Merge and run \`uv sync\` on the main project — parent venv should resolve to pydantic 2.12.5 (already does, since litellm forces it).
- [ ] Wipe the four stale venvs listed above.
- [ ] Verify all rebuilt venvs report \`pydantic==2.12.5\` / \`pydantic-core==2.41.5\`:
  \`\`\`bash
  for v in smolagents_code openai_solo tool_calling claude_code; do
    ~/.exgentic/agents/\$v/venv/bin/python -c "from importlib.metadata import version; print(f'\$v: pydantic={version(\"pydantic\")} pydantic-core={version(\"pydantic_core\")}')"
  done
  \`\`\`
- [ ] Relaunch \`exgentic batch evaluate\` on the DeepSeek-V3.2 + Kimi-K2.5 configs and confirm sessions start completing (score > 0 on first few).