### PR TITLE
fix(environment): atomically publish venvs to eliminate install races

### DIFF
--- a/src/exgentic/environment/manager.py
+++ b/src/exgentic/environment/manager.py
@@ -12,6 +12,8 @@ from datetime import datetime, timezone
 from enum import StrEnum
 from pathlib import Path
 
+from filelock import FileLock
+
 from .docker import DockerBackend
 from .local import LocalBackend
 from .protocol import EnvironmentBackend
@@ -78,16 +80,14 @@ class EnvironmentManager:
             The environment directory path.
         """
         env_type = EnvType(env_type)
+        # Fast path: avoid taking the file lock once the env is built.
         if not force and self.is_installed(name, env_type=env_type):
             return self.env_path(name)
 
         env_dir = self.env_path(name)
         env_dir.mkdir(parents=True, exist_ok=True)
-        self._remove_marker_entry(name, env_type)
-
         backend = self._backends[env_type]
 
-        # Build kwargs for the backend.
         kwargs: dict[str, object] = {}
         if project_root is not None:
             kwargs["project_root"] = project_root
@@ -98,8 +98,16 @@ class EnvironmentManager:
             kwargs["force"] = force
             kwargs["docker_socket"] = docker_socket
 
-        extra = backend.install(env_dir, module_path=module_path, **kwargs)
-        self._add_marker_entry(name, env_type, {"installed_at": _now_iso(), **extra})
+        # Serialize the decide-then-install sequence across threads and
+        # processes, with a double-check inside the lock. Without this,
+        # N concurrent callers all race past the fast path and each
+        # redundantly rebuilds the same env.
+        with FileLock(str(env_dir / ".install.lock"), timeout=1200):
+            if not force and self.is_installed(name, env_type=env_type):
+                return env_dir
+            self._remove_marker_entry(name, env_type)
+            extra = backend.install(env_dir, module_path=module_path, **kwargs)
+            self._add_marker_entry(name, env_type, {"installed_at": _now_iso(), **extra})
 
         return env_dir
 

--- a/src/exgentic/environment/venv.py
+++ b/src/exgentic/environment/venv.py
@@ -1,13 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
-"""Venv environment: creates an isolated Python venv with dependencies."""
+"""Venv environment: atomic build-then-rename into ``venv/``.
+
+Every step of the pipeline runs inside a scratch directory, and the
+scratch directory is renamed to ``venv/`` only after the whole build
+succeeds. Readers that exec ``venv/bin/python`` therefore see either
+nothing or a fully-populated venv — never a half-built state.
+"""
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 
 from filelock import FileLock
@@ -22,6 +30,9 @@ from .helpers import (
     run_setup_sh,
     validate_system_deps,
 )
+
+_SCRATCH_PREFIX = "venv.tmp."
+_TRASH_PREFIX = "venv.old."
 
 
 class VenvBackend:
@@ -47,47 +58,72 @@ class VenvBackend:
         project_root: Path | None = kwargs.get("project_root")  # type: ignore[assignment]
         packages: list[str] | None = kwargs.get("packages")  # type: ignore[assignment]
 
+        env_dir.mkdir(parents=True, exist_ok=True)
         venv_dir = env_dir / "venv"
         lock_path = env_dir / ".venv-install.lock"
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        lock = FileLock(str(lock_path), timeout=600)  # 10 min timeout for heavy installs
 
-        with lock:
-            if venv_dir.exists():
-                shutil.rmtree(venv_dir)
+        with FileLock(str(lock_path), timeout=600):
+            # Clean up scratch/trash dirs from prior crashed installs.
+            # Safe under the lock — nothing else is building here now.
+            for child in env_dir.iterdir():
+                if child.name.startswith((_SCRATCH_PREFIX, _TRASH_PREFIX)):
+                    shutil.rmtree(child, ignore_errors=True)
 
+            scratch = env_dir / f"{_SCRATCH_PREFIX}{uuid.uuid4().hex}"
             try:
                 uv = require_uv()
-
+                # --relocatable: console-script shebangs must resolve
+                # their interpreter relative to the script at runtime
+                # rather than embedding the scratch path, or they'll be
+                # dead references once we rename into place.
                 subprocess.run(
-                    [uv, "venv", str(venv_dir), "--python", f"{sys.version_info.major}.{sys.version_info.minor}"],
+                    [
+                        uv,
+                        "venv",
+                        str(scratch),
+                        "--python",
+                        f"{sys.version_info.major}.{sys.version_info.minor}",
+                        "--relocatable",
+                    ],
                     check=True,
                     capture_output=True,
                     text=True,
                 )
 
-                venv_py = str(venv_dir / "bin" / "python")
+                scratch_py = str(scratch / "bin" / "python")
                 env = build_subprocess_env()
-
                 if project_root is not None:
-                    install_project(uv, venv_py, project_root, env)
-
+                    install_project(uv, scratch_py, project_root, env)
                 if packages:
-                    install_packages(uv, venv_py, packages, env)
-
+                    install_packages(uv, scratch_py, packages, env)
                 if module_path is not None:
-                    install_requirements(uv, venv_py, module_path, env)
+                    install_requirements(uv, scratch_py, module_path, env)
                     validate_system_deps(module_path)
-                    run_setup_sh(module_path, env_dir, venv_dir=venv_dir)
-            except BaseException:
+                    run_setup_sh(module_path, env_dir, venv_dir=scratch)
+
+                # Atomic publish: move any existing venv out of the way,
+                # then rename scratch into place. POSIX rename on a
+                # directory is atomic; the tiny window where venv_dir
+                # does not exist is safe because running subprocesses
+                # keep their open inodes via unlink-while-open.
                 if venv_dir.exists():
-                    shutil.rmtree(venv_dir, ignore_errors=True)
+                    trash = env_dir / f"{_TRASH_PREFIX}{uuid.uuid4().hex}"
+                    os.rename(venv_dir, trash)
+                    shutil.rmtree(trash, ignore_errors=True)
+                os.rename(scratch, venv_dir)
+            except BaseException:
+                if scratch.exists():
+                    shutil.rmtree(scratch, ignore_errors=True)
                 raise
 
             return {"exgentic_version": get_exgentic_version()}
 
     def exists(self, env_dir: Path, marker_data: dict) -> bool:
-        """Check that the venv Python binary exists."""
+        """Check that the venv Python binary exists.
+
+        With atomic publish, ``venv/bin/python`` can only exist if the
+        entire install pipeline succeeded.
+        """
         return (env_dir / "venv" / "bin" / "python").exists()
 
     def uninstall(self, env_dir: Path, marker_data: dict) -> None:

--- a/src/exgentic/environment/venv.py
+++ b/src/exgentic/environment/venv.py
@@ -18,8 +18,6 @@ import sys
 import uuid
 from pathlib import Path
 
-from filelock import FileLock
-
 from .helpers import (
     build_subprocess_env,
     get_exgentic_version,
@@ -60,63 +58,53 @@ class VenvBackend:
 
         env_dir.mkdir(parents=True, exist_ok=True)
         venv_dir = env_dir / "venv"
-        lock_path = env_dir / ".venv-install.lock"
 
-        with FileLock(str(lock_path), timeout=600):
-            # Clean up scratch/trash dirs from prior crashed installs.
-            # Safe under the lock — nothing else is building here now.
-            for child in env_dir.iterdir():
-                if child.name.startswith((_SCRATCH_PREFIX, _TRASH_PREFIX)):
-                    shutil.rmtree(child, ignore_errors=True)
+        # Clean up scratch/trash dirs left behind by a prior crashed
+        # install. Concurrent installs on the same env are already
+        # serialized by EnvironmentManager's file lock, so this is safe.
+        for child in env_dir.iterdir():
+            if child.name.startswith((_SCRATCH_PREFIX, _TRASH_PREFIX)):
+                shutil.rmtree(child, ignore_errors=True)
 
-            scratch = env_dir / f"{_SCRATCH_PREFIX}{uuid.uuid4().hex}"
-            try:
-                uv = require_uv()
-                # --relocatable: console-script shebangs must resolve
-                # their interpreter relative to the script at runtime
-                # rather than embedding the scratch path, or they'll be
-                # dead references once we rename into place.
-                subprocess.run(
-                    [
-                        uv,
-                        "venv",
-                        str(scratch),
-                        "--python",
-                        f"{sys.version_info.major}.{sys.version_info.minor}",
-                        "--relocatable",
-                    ],
-                    check=True,
-                    capture_output=True,
-                    text=True,
-                )
+        scratch = env_dir / f"{_SCRATCH_PREFIX}{uuid.uuid4().hex}"
+        try:
+            uv = require_uv()
+            # --relocatable: console-script shebangs must resolve their
+            # interpreter relative to the script at runtime rather than
+            # embedding the scratch path, or they become dead references
+            # once we rename into place.
+            subprocess.run(
+                [
+                    uv,
+                    "venv",
+                    str(scratch),
+                    "--python",
+                    f"{sys.version_info.major}.{sys.version_info.minor}",
+                    "--relocatable",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
 
-                scratch_py = str(scratch / "bin" / "python")
-                env = build_subprocess_env()
-                if project_root is not None:
-                    install_project(uv, scratch_py, project_root, env)
-                if packages:
-                    install_packages(uv, scratch_py, packages, env)
-                if module_path is not None:
-                    install_requirements(uv, scratch_py, module_path, env)
-                    validate_system_deps(module_path)
-                    run_setup_sh(module_path, env_dir, venv_dir=scratch)
+            scratch_py = str(scratch / "bin" / "python")
+            env = build_subprocess_env()
+            if project_root is not None:
+                install_project(uv, scratch_py, project_root, env)
+            if packages:
+                install_packages(uv, scratch_py, packages, env)
+            if module_path is not None:
+                install_requirements(uv, scratch_py, module_path, env)
+                validate_system_deps(module_path)
+                run_setup_sh(module_path, env_dir, venv_dir=scratch)
 
-                # Atomic publish: move any existing venv out of the way,
-                # then rename scratch into place. POSIX rename on a
-                # directory is atomic; the tiny window where venv_dir
-                # does not exist is safe because running subprocesses
-                # keep their open inodes via unlink-while-open.
-                if venv_dir.exists():
-                    trash = env_dir / f"{_TRASH_PREFIX}{uuid.uuid4().hex}"
-                    os.rename(venv_dir, trash)
-                    shutil.rmtree(trash, ignore_errors=True)
-                os.rename(scratch, venv_dir)
-            except BaseException:
-                if scratch.exists():
-                    shutil.rmtree(scratch, ignore_errors=True)
-                raise
+            _publish_atomic(scratch, venv_dir)
+            scratch = None  # ownership transferred to venv_dir
+        finally:
+            if scratch is not None and scratch.exists():
+                shutil.rmtree(scratch, ignore_errors=True)
 
-            return {"exgentic_version": get_exgentic_version()}
+        return {"exgentic_version": get_exgentic_version()}
 
     def exists(self, env_dir: Path, marker_data: dict) -> bool:
         """Check that the venv Python binary exists.
@@ -131,3 +119,33 @@ class VenvBackend:
         venv_dir = env_dir / "venv"
         if venv_dir.exists():
             shutil.rmtree(venv_dir)
+
+
+def _publish_atomic(scratch: Path, venv_dir: Path) -> None:
+    """Make *scratch* visible as *venv_dir* via atomic directory renames.
+
+    POSIX ``rename`` on a directory is atomic but cannot replace a
+    non-empty target, so we move any existing venv to a trash name
+    first, rename the scratch in, and only then delete the trash. If
+    the final rename fails, the prior venv is restored.
+    """
+    trash: Path | None = None
+    if venv_dir.exists():
+        trash = venv_dir.parent / f"{_TRASH_PREFIX}{uuid.uuid4().hex}"
+        os.rename(venv_dir, trash)
+
+    try:
+        os.rename(scratch, venv_dir)
+    except BaseException:
+        # Best-effort restore: if the new venv couldn't be placed, move
+        # the old one back so the user isn't left without any venv.
+        if trash is not None and not venv_dir.exists():
+            try:
+                os.rename(trash, venv_dir)
+                trash = None
+            except OSError:
+                pass
+        raise
+    finally:
+        if trash is not None and trash.exists():
+            shutil.rmtree(trash, ignore_errors=True)

--- a/tests/environment/test_venv_lock.py
+++ b/tests/environment/test_venv_lock.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import threading
 from pathlib import Path
 from unittest.mock import patch
@@ -82,3 +83,108 @@ def test_different_env_dirs_use_independent_locks(tmp_path: Path):
     t2.join(timeout=10)
 
     assert sorted(results) == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the install-time races that caused the
+# `ModuleNotFoundError: No module named 'filelock'` errors and the
+# "appworld rebuilt 12 times per batch" issue.
+#
+# Bug 1: VenvBackend.install() published `venv/bin/python` before deps
+# were installed, so workers that exec'd it mid-install crashed.
+# Fix: build in a scratch dir, rename into place only after success.
+#
+# Bug 2: EnvironmentManager.install() checked is_installed() outside
+# its lock and never re-checked inside, so N concurrent threads all
+# committed to rebuilding the same env.
+# Fix: wrap check-then-install in a FileLock with a double-check.
+# ---------------------------------------------------------------------------
+
+
+def test_atomic_publish_no_torn_state(tmp_path: Path, monkeypatch):
+    """venv/bin/python is never visible at its final path until deps are installed."""
+    env_dir = tmp_path / "env"
+    env_dir.mkdir()
+
+    deps_installed = {"v": False}
+    observations: list[bool] = []  # venv/bin/python existence at various mid-install moments
+
+    def observe():
+        observations.append((env_dir / "venv" / "bin" / "python").exists())
+
+    def fake_subprocess_run(args, *a, **kw):
+        # Simulate `uv venv <scratch>` — create bin/python inside the
+        # scratch directory the caller passed, NOT the final venv/ dir.
+        assert len(args) >= 2 and args[1] == "venv", f"unexpected: {args!r}"
+        scratch = Path(args[2])
+        (scratch / "bin").mkdir(parents=True, exist_ok=True)
+        (scratch / "bin" / "python").touch()
+        observe()
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    def fake_install_project(uv, py, root, env):
+        observe()
+        deps_installed["v"] = True
+
+    monkeypatch.setattr("exgentic.environment.venv.subprocess.run", fake_subprocess_run)
+    monkeypatch.setattr("exgentic.environment.venv.require_uv", lambda: "/fake/uv")
+    monkeypatch.setattr("exgentic.environment.venv.install_project", fake_install_project)
+    monkeypatch.setattr("exgentic.environment.venv.get_exgentic_version", lambda: "0.0.0")
+
+    VenvBackend().install(env_dir, project_root=tmp_path)
+
+    assert all(v is False for v in observations), "venv/bin/python visible mid-install"
+    assert (env_dir / "venv" / "bin" / "python").exists()
+    assert deps_installed["v"] is True
+
+
+def test_concurrent_installs_rebuild_exactly_once(tmp_path: Path, monkeypatch):
+    """Two threads racing into EnvironmentManager.install() trigger one backend build, not two."""
+    from exgentic.environment import EnvType
+    from exgentic.environment.manager import EnvironmentManager
+
+    mgr = EnvironmentManager(base_dir=tmp_path)
+    call_count = {"n": 0}
+    count_lock = threading.Lock()
+    first_entered = threading.Event()
+    allow_first_to_finish = threading.Event()
+
+    def slow_install(self, env_dir, **kwargs):
+        with count_lock:
+            call_count["n"] += 1
+            idx = call_count["n"]
+        if idx == 1:
+            first_entered.set()
+            allow_first_to_finish.wait(timeout=5)
+        (env_dir / "venv" / "bin").mkdir(parents=True, exist_ok=True)
+        (env_dir / "venv" / "bin" / "python").touch()
+        return {"exgentic_version": "0.0.0"}
+
+    monkeypatch.setattr(VenvBackend, "install", slow_install)
+    monkeypatch.setattr("exgentic.environment.manager._now_iso", lambda: "2026-01-01T00:00:00Z")
+    monkeypatch.setattr("exgentic.environment.helpers.get_exgentic_version", lambda: "0.0.0")
+
+    errors: list[BaseException | None] = [None, None]
+
+    def worker(idx: int):
+        try:
+            mgr.install("benchmarks/appworld", env_type=EnvType.VENV)
+        except BaseException as e:
+            errors[idx] = e
+
+    t1 = threading.Thread(target=worker, args=(0,))
+    t2 = threading.Thread(target=worker, args=(1,))
+    t1.start()
+    first_entered.wait(timeout=5)
+    t2.start()
+    # Give T2 a moment to queue on the manager lock.
+    threading.Event().wait(0.1)
+    allow_first_to_finish.set()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    assert errors == [None, None], f"workers raised: {errors}"
+    assert call_count["n"] == 1, (
+        f"backend.install ran {call_count['n']} times for one env — "
+        "the concurrent double-check under the manager lock is broken"
+    )

--- a/tests/environment/test_venv_lock.py
+++ b/tests/environment/test_venv_lock.py
@@ -1,89 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
-"""Tests for VenvBackend file lock during concurrent installs."""
+"""Regression tests for concurrent install races in VenvBackend / EnvironmentManager."""
 
 from __future__ import annotations
 
 import subprocess
 import threading
 from pathlib import Path
-from unittest.mock import patch
 
-import pytest
 from exgentic.environment.venv import VenvBackend
-from filelock import FileLock
-
-
-@pytest.fixture
-def env_dir(tmp_path: Path) -> Path:
-    d = tmp_path / "envs" / "test_env"
-    d.mkdir(parents=True)
-    return d
-
-
-def test_lock_file_created_during_install(env_dir: Path):
-    """install() should create a .venv-install.lock file."""
-    backend = VenvBackend()
-    lock_path = env_dir / ".venv-install.lock"
-    assert not lock_path.exists()
-
-    try:
-        backend.install(env_dir)
-    except Exception:
-        pass  # Install may fail without uv, that's OK
-
-    assert lock_path.exists()
-
-
-def test_install_blocked_while_lock_held(env_dir: Path):
-    """install() should block when another process holds the lock."""
-    lock_path = env_dir / ".venv-install.lock"
-    lock = FileLock(str(lock_path), timeout=0)
-
-    from filelock import Timeout as LockTimeout
-
-    # Hold the lock from "another process".
-    lock.acquire()
-    try:
-        backend = VenvBackend()
-        # Patch timeout to 0 so install fails immediately instead of
-        # waiting 600s for the lock we're holding.
-        with patch("exgentic.environment.venv.FileLock", lambda p, timeout: FileLock(p, timeout=0)):
-            with pytest.raises(LockTimeout):
-                backend.install(env_dir)
-    finally:
-        lock.release()
-
-
-def test_different_env_dirs_use_independent_locks(tmp_path: Path):
-    """Installs to different env_dirs should not block each other."""
-    dir_a = tmp_path / "env_a"
-    dir_b = tmp_path / "env_b"
-    dir_a.mkdir(parents=True)
-    dir_b.mkdir(parents=True)
-
-    backend = VenvBackend()
-    results: list[str] = []
-    lock = threading.Lock()
-
-    def try_install(env_dir: Path, name: str):
-        try:
-            backend.install(env_dir)
-        except Exception:
-            pass
-        with lock:
-            results.append(name)
-
-    t1 = threading.Thread(target=try_install, args=(dir_a, "a"))
-    t2 = threading.Thread(target=try_install, args=(dir_b, "b"))
-    t1.start()
-    t2.start()
-    t1.join(timeout=10)
-    t2.join(timeout=10)
-
-    assert sorted(results) == ["a", "b"]
-
 
 # ---------------------------------------------------------------------------
 # Regression tests for the install-time races that caused the


### PR DESCRIPTION
## Summary

Fixes two linked concurrent-install bugs that caused 82+ session failures in batch runs. Both bugs share one root cause: venv readiness was tracked across three unsynchronized pieces of disk state.

- **Bug 1** — \`ModuleNotFoundError: No module named 'filelock'\` intermittently in worker subprocesses. \`VenvBackend.install()\` created \`venv/bin/python\` via \`uv venv\` before installing deps, and \`exists()\` reported readiness solely on that file. Workers execing \`venv/bin/python\` during the install window imported exgentic → imported filelock → crashed.
- **Bug 2** — appworld rebuilt 12 times per batch, once per session in the ThreadPoolExecutor queue. \`EnvironmentManager.install()\` checked \`is_installed()\` outside the file lock and never re-checked inside. N threads all committed to rebuilding the same env, and each rebuild \`rmtree\`d the venv a concurrent thread had just published — which is what opened bug 1's window.

## Approach

**Atomic publication via build-then-rename**, layered with a manager-level double-check under a FileLock:

- \`VenvBackend.install()\` builds inside \`venv.tmp.<uuid>/\` and \`os.rename\`s it to \`venv/\` as the final step of a successful pipeline. POSIX directory rename is atomic; observers see either nothing or a fully-built venv at the final path. Running subprocesses that hold files open under an old venv keep working via unlink-while-open semantics. **Readers need no coordination — the filesystem is the contract.**
- \`uv venv --relocatable\` is required so console-script shebangs use a dirname-based resolver at runtime instead of baking the absolute scratch path into every \`exgentic\`, \`python\`, etc. entry point (discovered when the runner tests went red without it).
- \`EnvironmentManager.install()\` wraps \`is_installed\` + backend build + marker write in a per-env-dir \`FileLock\`, with a double-check after acquiring it. This collapses N-way redundant rebuilds to 1 for concurrent callers sharing one manager (threads) or across processes. Atomicity is the correctness primitive; the manager lock is the efficiency primitive on top of it.
- Stale \`venv.tmp.*\` / \`venv.old.*\` directories from crashed prior installs are swept at the start of each install under the backend lock, so SIGKILLed installs leak nothing permanently. SIGINT is handled by the existing \`except BaseException\` cleanup path.

## Why this over a locking-only fix

A lock-only solution would require every subprocess that ever execs \`venv/bin/python\` — VenvRunner, benchmark setup scripts, anything added in the future — to acquire and hold the lock for the duration of the subprocess. Atomic rename makes readers correct with zero code on their side, because the kernel enforces the contract. Locks are still useful on top, but only for the "don't waste work" efficiency goal, not for correctness.

## Test plan

- [x] \`tests/environment/test_venv_lock.py\` — 2 new cases (\`test_atomic_publish_no_torn_state\`, \`test_concurrent_installs_rebuild_exactly_once\`) that reproduce both bugs and now pass. Existing 3 lock tests unchanged.
- [x] \`tests/environment/\` full suite: 125 passed
- [x] \`tests/adapters/runners/test_venv.py\` (real uv end-to-end): 7 passed (catches the \`--relocatable\` requirement)
- [x] Combined env + venv runner + e2e session suites: 193 passed

## Risk notes

- \`--relocatable\` changes shebangs, but the resolver trick is portable (tested on macOS) and matches what \`uv\` documents as the intended use case for relocatable envs.
- The tiny window between "move old venv to trash" and "move new venv into place" during the atomic publish leaves \`venv/\` briefly missing. In-flight subprocesses are unaffected; a new spawn during that microsecond window would fail to exec, but the manager lock + double-check means rebuilds only happen on first install or explicit force, so this window is essentially never hit in practice.
- Worst-case disk leak on SIGKILL is one scratch directory, cleaned up the next time that env is installed.