### PR TITLE
feat(batch status): add 'Last' column showing config activity freshness

### DIFF
--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -8,6 +8,7 @@ import glob
 import json
 import os
 import sys
+import time
 from pathlib import Path
 from typing import Any
 
@@ -77,6 +78,18 @@ def _short_config_path(path: str) -> str:
     if rel.startswith(".."):
         return Path(path).name
     return rel
+
+
+def _format_ago(sec: float) -> str:
+    if sec < 0:
+        sec = 0
+    if sec < 60:
+        return f"{int(sec)}s"
+    if sec < 3600:
+        return f"{int(sec / 60)}m"
+    if sec < 86400:
+        return f"{int(sec / 3600)}h"
+    return f"{int(sec / 86400)}d"
 
 
 def _truncate_leading(text: str, max_len: int) -> str:
@@ -401,6 +414,7 @@ def batch_status_cmd(
             "sessions": "-",
             "score": "-",
             "cost": "-",
+            "last_event": "-",
         }
         try:
             cfg = _load_run_like_config(config_path)
@@ -437,6 +451,16 @@ def batch_status_cmd(
             subset = run_status.subset_name
             if subset:
                 benchmark = f"{benchmark}/{subset}"
+            sessions_dir = Path(run_status.results_path).parent / "sessions"
+            latest = 0.0
+            for p in sessions_dir.rglob("*"):
+                try:
+                    m = p.stat().st_mtime
+                except OSError:
+                    continue
+                if m > latest:
+                    latest = m
+            last_event = _format_ago(time.time() - latest) if latest else "-"
             row.update(
                 {
                     "benchmark": benchmark,
@@ -445,6 +469,7 @@ def batch_status_cmd(
                     "sessions": sessions_str,
                     "score": score,
                     "cost": cost,
+                    "last_event": last_event,
                 }
             )
         except Exception:

--- a/src/exgentic/interfaces/cli/render.py
+++ b/src/exgentic/interfaces/cli/render.py
@@ -186,6 +186,7 @@ def render_batch_status(rows: list[dict[str, str]]) -> None:
     table.add_column("Sessions", justify="right", no_wrap=True)
     table.add_column("Score", justify="right", no_wrap=True)
     table.add_column("Cost", justify="right", no_wrap=True)
+    table.add_column("Last", justify="right", no_wrap=True, width=5)
 
     for row in rows:
         table.add_row(
@@ -196,6 +197,7 @@ def render_batch_status(rows: list[dict[str, str]]) -> None:
             row.get("sessions", "-"),
             row.get("score", "-"),
             row.get("cost", "-"),
+            row.get("last_event", "-"),
         )
 
     CONSOLE.print(table)


### PR DESCRIPTION
## Summary

Adds a new \`Last\` column to \`exgentic batch status\` showing the time since the most recent write anywhere under each config's run directory, as \`5s\` / \`12m\` / \`2h\` / \`1d\` / \`-\`. One-glance "is this config actually alive right now?" check without having to drop to shell \`find\`.

Fixes #181.

## Before

\`\`\`
#   Benchmark     Agent         Model         Sessions    Score       Cost
1   appworld/t…   claude_code   DeepSeek-V…      21/30        0      3.387
2   appworld/t…   openai_solo   DeepSeek-V…      10/30      0.1      5.024
...
\`\`\`

Can't tell which rows are actively being written to.

## After

\`\`\`
#   Benchmark     Agent         Model      Sessions    Score       Cost    Last
1   appworld/t…   claude_code   DeepSeek…     21/30        0      3.387      0s
2   appworld/t…   openai_solo   DeepSeek…     10/30      0.1      5.024     19m
3   appworld/t…   smolagents…   DeepSeek…     10/30        0      2.055      4m
...
14  tau2/airli…   claude_code   DeepSeek…      6/30      0.4      0.534     18h
\`\`\`

\`0s\` = session files being appended right now. \`18h\` = nothing has touched this config's run dir in 18h → either idle or stuck.

## Implementation

Per config, after the existing session-stats block in \`batch_status_cmd\`:

\`\`\`python
sessions_dir = Path(run_status.results_path).parent / \"sessions\"
latest = 0.0
for p in sessions_dir.rglob(\"*\"):
    try:
        m = p.stat().st_mtime
    except OSError:
        continue
    if m > latest:
        latest = m
last_event = _format_ago(time.time() - latest) if latest else \"-\"
\`\`\`

Plus a tiny \`_format_ago(sec)\` helper and one new column in \`render_batch_status\`.

## Design notes

**Why \"any file under sessions/\" not just \`trajectory.jsonl\`.** I tried the narrower scope first and it reported everything as days old even while 16 workers were clearly hammering the disk. In-flight sessions can spend minutes in setup (docker image pull, benchmark env boot, LiteLLM proxy start, MCP server handshake) before the first structured trajectory event lands. Freshness should reflect that real setup activity, not miss it. The cost of widening is small and the signal is much more honest.

**Why \`rglob\` not a curated file list.** Different agents write different hot files (\`agent.log\`, \`session.log\`, \`litellm_proxy.log\`, \`mcp/server.log\`, \`claude_code_config/**\`, \`trace.jsonl\`, etc.). A curated list would drift out of sync as agents evolve. \`rglob\` is agent-agnostic — any write updates the signal.

**Why stateless recomputation, not a daemon/cache.** \`batch status\` is already built as a stateless snapshot tool. Adding state-tracking would be a much larger change and introduce a staleness window of its own. Walking the filesystem on every invocation is honest and trivially correct.

**Why not tie to RUNNING status detection.** There's a pre-existing bug where \`batch status\` tries to show a \`Nrun\` suffix (README documents it, code in \`batch.py:411–426\` computes it) but it's always 0 — the session status machine never flags in-flight sessions as \`RUNNING\`. The \`Last\` column deliberately doesn't depend on that machinery so it works today, even while that bug is unfixed. It's worth its own issue to investigate \`Nrun\` separately.

## Cross-platform

\`Path.rglob\` + \`stat().st_mtime\` are stdlib with identical semantics on Linux, macOS, and Windows. No shell calls, no \`find\`, no \`os.walk\` portability gotchas, no date formatting libraries. Pure Python int math on a float delta.

## Performance

Profiled on ACE against an active batch with 50 configs × ~28k total files under \`sessions/\`:

\`\`\`
50 sessions dirs
28247 files walked in 0.98s
\`\`\`

Sub-second for a mature run. \`batch status\` already takes ~18s end-to-end (mostly uv + exgentic cold start), so the walk is a ~5% marginal add.

## Failure modes

- Missing \`sessions\` directory (brand-new config, no runs yet) → \`rglob\` yields nothing → \`latest == 0.0\` → renders as \`-\`.
- Permission-denied / broken-symlink / race-deleted file during walk → caught by \`OSError\`, skipped.
- Clock skew producing negative \`now - mtime\` → clamped to \`0\` inside \`_format_ago\`.
- Whole status block for a config raising → caught by the existing \`except Exception\` outer guard, row falls back to the config-path placeholder (unchanged behavior).

## Test plan

- [ ] Run \`exgentic batch status\` against a live batch — \`Last\` shows \`0s\` / seconds for actively-running configs.
- [ ] Run against a config with no sessions yet — renders \`-\`.
- [ ] Run against a fully-completed config untouched for days — renders \`Xd\`.
- [ ] On macOS and Windows: no portability issues (stdlib only).