### PR TITLE
fix(venv runner): stabilize session startup under concurrency

### DIFF
--- a/src/exgentic/adapters/runners/venv.py
+++ b/src/exgentic/adapters/runners/venv.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import atexit
 import os
 import shutil
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -35,7 +36,7 @@ from ._utils import (
 from .service import HTTPTransport, _wait_for_health
 from .transport import ObjectProxy
 
-_HEALTH_TIMEOUT = 120.0
+_HEALTH_TIMEOUT = 360.0
 _TRANSPORT_TIMEOUT = 600.0
 
 
@@ -180,6 +181,7 @@ class VenvRunner:
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            start_new_session=True,
         )
         atexit.register(self._stop_process)
 
@@ -188,11 +190,12 @@ class VenvRunner:
             _wait_for_health(url, timeout=self._health_timeout)
         except TimeoutError:
             proc = self._process
+            stdout, stderr = b"", b""
             if proc is not None:
-                proc.terminate()
-                stdout, stderr = proc.communicate(timeout=5)
-            else:
-                stdout, stderr = b"", b""
+                try:
+                    stdout, stderr = proc.communicate(timeout=1)
+                except (subprocess.TimeoutExpired, Exception):
+                    pass
             self._stop_process()
             raise TimeoutError(
                 f"Venv service did not become healthy within {self._health_timeout}s.\n"
@@ -210,11 +213,25 @@ class VenvRunner:
             return
         proc = self._process
         self._process = None
+        # The subprocess was started with start_new_session=True so it leads
+        # its own process group. Signal the whole group so grandchildren
+        # (per-session LiteLLM proxies, docker helpers, MCP servers) are
+        # cleaned up atomically instead of orphaning.
         try:
-            proc.terminate()
+            pgid = os.getpgid(proc.pid)
+        except (OSError, ProcessLookupError):
+            pgid = None
+        try:
+            if pgid is not None:
+                os.killpg(pgid, signal.SIGTERM)
+            else:
+                proc.terminate()
             proc.wait(timeout=5)
         except Exception:
             try:
-                proc.kill()
+                if pgid is not None:
+                    os.killpg(pgid, signal.SIGKILL)
+                else:
+                    proc.kill()
             except Exception:
                 pass

--- a/src/exgentic/adapters/runners/venv.py
+++ b/src/exgentic/adapters/runners/venv.py
@@ -194,7 +194,7 @@ class VenvRunner:
             if proc is not None:
                 try:
                     stdout, stderr = proc.communicate(timeout=1)
-                except (subprocess.TimeoutExpired, Exception):
+                except subprocess.TimeoutExpired:
                     pass
             self._stop_process()
             raise TimeoutError(

--- a/src/exgentic/integrations/litellm/health.py
+++ b/src/exgentic/integrations/litellm/health.py
@@ -221,7 +221,7 @@ async def acheck_model_accessible(
 def check_model_accessible_sync(
     model: str,
     logger: logging.Logger,
-    timeout: float = 60.0,
+    timeout: float = 240.0,
     model_settings: ModelSettings | None = None,
 ) -> None:
     """Synchronous wrapper for model health check.

--- a/tests/adapters/runners/test_venv.py
+++ b/tests/adapters/runners/test_venv.py
@@ -6,10 +6,15 @@
 from __future__ import annotations
 
 import os
+import platform
 import shutil
+import subprocess
+import sys
+import time
 
 import pytest
 from exgentic.adapters.runners import with_runner
+from exgentic.adapters.runners.venv import VenvRunner
 
 from .conftest import Calculator
 
@@ -67,3 +72,50 @@ def test_echo(venv_calc):
 def test_different_pid(venv_calc):
     """Venv runner should run in a separate process."""
     assert venv_calc.pid() != os.getpid()
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="killpg reaping semantics differ on macOS /proc")
+def test_stop_process_reaps_grandchildren_via_killpg(tmp_path):
+    pid_file = tmp_path / "grandchild.pid"
+    script = (
+        "import os, sys\n"
+        f"pid_file = {str(pid_file)!r}\n"
+        "gpid = os.fork()\n"
+        "if gpid == 0:\n"
+        "    with open(pid_file, 'w') as f:\n"
+        "        f.write(str(os.getpid()))\n"
+        "        f.flush()\n"
+        "    os.execvp('sleep', ['sleep', '120'])\n"
+        "os.execvp('sleep', ['sleep', '120'])\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and not pid_file.exists():
+        time.sleep(0.05)
+    assert pid_file.exists(), "grandchild did not record its PID"
+    grandchild_pid = int(pid_file.read_text().strip())
+    assert _pid_alive(grandchild_pid)
+
+    runner = VenvRunner.__new__(VenvRunner)
+    runner._process = proc
+    runner._stop_process()
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and _pid_alive(grandchild_pid):
+        time.sleep(0.05)
+    assert not _pid_alive(grandchild_pid)


### PR DESCRIPTION
## Summary

Fixes two linked issues in \`VenvRunner\` that together produced hours-long \`exgentic batch evaluate\` runs with zero completions under \`--max-workers 16\`. Fixes #183.

### 1. Health-check inner/outer timeout mismatch

\`adapters/runners/venv.py:_HEALTH_TIMEOUT\` was \`120s\`. Inside the venv subprocess, \`serve_cmd\` constructs the agent instance before uvicorn starts listening, and the constructor calls \`integrations/litellm/health.py:check_model_accessible_sync\` with a hardcoded \`timeout=60.0\`. That 60s wrapper chops off the async retry loop beneath it — which was explicitly designed to be patient (8 retries × 5–30s backoff, total budget ~2–4 min) to handle flaky endpoints. Under 16-way concurrent Azure cold starts, a single \`acompletion(\"hi\")\` round-trip often takes 30–60s, so the second retry attempt never runs.

Fix: bump defaults.

\`\`\`diff
-_HEALTH_TIMEOUT = 120.0
+_HEALTH_TIMEOUT = 360.0
\`\`\`

\`\`\`diff
-    timeout: float = 60.0,
+    timeout: float = 240.0,
\`\`\`

The outer venv budget is now comfortably larger than the inner health check budget, so the retry loop gets to run to completion before the parent gives up.

### 2. Grandchildren leak on teardown

\`VenvRunner._stop_process\` used \`proc.terminate()\` on the serve subprocess, but that subprocess spawns grandchildren that are not in its process group:

- per-session \`litellm --port XXXX\` HTTP proxies
- docker containers for claude_code
- MCP servers, uvicorn workers

\`SIGTERM\` to the direct child doesn't propagate. When the runner exits, those descendants are reparented to init and become orphans. \`atexit.register\` only fires on clean interpreter exit — on the \`_wait_for_health\` timeout path, the partially-started tree is left alive.

In a 5-hour ACE test this accumulated **201 child processes from an initial 69**, threatening PID/fd exhaustion on the host.

Fix: make the serve subprocess a process-group leader, then group-kill on teardown.

\`\`\`diff
 self._process = subprocess.Popen(
     cmd,
     env=env,
     stdout=subprocess.PIPE,
     stderr=subprocess.PIPE,
+    start_new_session=True,
 )
\`\`\`

\`_stop_process\` now resolves \`os.getpgid(proc.pid)\` and sends \`os.killpg(pgid, SIGTERM)\`, escalating to \`SIGKILL\` on the fallback path. Falls back to \`proc.terminate()\` / \`proc.kill()\` if the pgid lookup races a dead process. Atomic tree teardown — litellm proxies, docker helpers, MCP servers all go together.

On the \`TimeoutError\` path in \`start()\`, I also replaced \`proc.terminate(); proc.communicate(timeout=5)\` with \`communicate(timeout=1)\` inside try/except, followed by the unified \`_stop_process\` path — so diagnostic stdout/stderr still gets captured without blocking cleanup on a stuck child.

## Validation

Applied both fixes on ACE, propagated the installed copies into all 8 agent+benchmark venvs via \`uv pip install --reinstall-package exgentic --no-deps\`, dropped \`--max-workers\` to 8, relaunched the same DeepSeek-V3.2/Kimi-K2.5 batch:

| Metric | Before (batch3, 5h) | After (batch5, 21min) |
|---|---|---|
| \`HealthCheckError\` | 322 (1.07/min) | 4 (0.19/min) — **~5.6× fewer per unit time** |
| Child processes | 69 → 201 (growing) | 24 (stable) |
| First real agent progress | never observed | \`claude_code\`/\`appworld\`/\`DeepSeek-V3.2\` session \`6a683c21\` reached **turn 14** (phone login → venmo payment approvals) |

Sessions are now making real progress — the remaining wait for completions is just agent turn latency × 200-ish max interactions per task, not the startup race.

The 4 remaining \`HealthCheckError\` over 21 min are likely residual Azure cold-start jitter at the edge of the new 240s budget; will investigate separately if they persist above noise.

## Test plan

- [ ] \`exgentic batch evaluate --max-workers 8\` with fresh agent venvs — \`HealthCheckError\` count should be near zero, not hundreds.
- [ ] \`exgentic batch evaluate --max-workers 16\` with fresh agent venvs — still within the new timeout budget; if this still fails we need to look at per-worker rate limits upstream.
- [ ] After a SIGINT of a running batch, \`pgrep -af \"/\.exgentic/.*(serve|litellm)\"\` should return zero — no orphaned grandchildren.
- [ ] Run the existing \`tests/adapters/runners/\` suite; no regressions expected since we only changed defaults + Popen flags + cleanup path.

## Out of scope (separate issues worth opening)

1. **\`batch status\` \`Nrun\` suffix never populates** — the README documents it, the code tries to show it (\`batch.py:411–426\`), but in-flight sessions never get flagged as \`SessionExecutionStatus.RUNNING\`. Orthogonal to this fix.
2. **\`batch evaluate\` has no in-process retry loop** — a task that hits a transient failure is recorded as failed for the rest of the run. The experiments repo \`run_all.sh\` wraps \`batch evaluate\` in a retry loop to compensate. Should be either documented or implemented natively.