### PR TITLE
fix(otel): scope PerSessionFileExporter to run_id to end batch-mode write amplification

### DIFF
--- a/src/exgentic/observers/handlers/otel.py
+++ b/src/exgentic/observers/handlers/otel.py
@@ -199,12 +199,12 @@ class OtelTracingObserver(Observer):
 
         from ...utils.paths import get_run_paths
 
-        run_root = get_run_paths().root
+        run_paths = get_run_paths()
         provider = trace.get_tracer_provider()
         if hasattr(provider, "add_span_processor"):
             from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
-            provider.add_span_processor(SimpleSpanProcessor(PerSessionFileExporter(run_root)))
+            provider.add_span_processor(SimpleSpanProcessor(PerSessionFileExporter(run_paths.root, run_paths.run_id)))
 
         self._run_attributes = {
             "exgentic.benchmark.slug_name": bench_entry.slug_name if bench_entry else run_config.benchmark,

--- a/src/exgentic/utils/otel.py
+++ b/src/exgentic/utils/otel.py
@@ -54,15 +54,30 @@ class FileSpanExporter(SpanExporter):
 
 
 class PerSessionFileExporter(SpanExporter):
-    """Routes spans to per-session ``otel_spans.jsonl`` files based on ``exgentic.session.id``."""
+    """Routes spans belonging to ``run_id`` into per-session files under ``run_root``.
 
-    def __init__(self, run_root: str | Path) -> None:
+    In batch mode the parent process registers one exporter per
+    :class:`RunConfig` on the global ``TracerProvider``, and OTEL fans
+    every emitted span out to every registered processor. Without the
+    ``run_id`` filter, every exporter would write every span into its
+    own ``run_root`` -- N-way write amplification plus cross-run trace
+    leakage. ``exgentic.run.id`` is set as a heritable attribute in
+    ``OtelTracingObserver.on_session_enter`` and propagated to every
+    descendant span via ``SessionSpanManager.start_span``, so the
+    routing key is always present on spans this exporter should own.
+    """
+
+    def __init__(self, run_root: str | Path, run_id: str) -> None:
         self._run_root = Path(run_root)
+        self._run_id = run_id
 
     def export(self, spans: Sequence) -> SpanExportResult:
         try:
             for span in spans:
-                sid = getattr(span, "attributes", {}).get("exgentic.session.id")
+                attrs = getattr(span, "attributes", {}) or {}
+                if attrs.get("exgentic.run.id") != self._run_id:
+                    continue
+                sid = attrs.get("exgentic.session.id")
                 if not sid:
                     continue
                 path = self._run_root / "sessions" / str(sid) / "otel_spans.jsonl"

--- a/tests/observers/test_otel.py
+++ b/tests/observers/test_otel.py
@@ -2955,10 +2955,13 @@ class TestPerSessionFileExporter:
     def test_routes_by_session_id(self, tmp_path):
         from exgentic.utils.otel import PerSessionFileExporter
 
-        exporter = PerSessionFileExporter(tmp_path)
+        exporter = PerSessionFileExporter(tmp_path, run_id="run-1")
 
         span = MagicMock()
-        span.attributes = {"exgentic.session.id": "sess-abc"}
+        span.attributes = {
+            "exgentic.run.id": "run-1",
+            "exgentic.session.id": "sess-abc",
+        }
         span.to_json.return_value = '{"name": "test"}'
 
         result = exporter.export([span])
@@ -2971,10 +2974,10 @@ class TestPerSessionFileExporter:
     def test_skips_spans_without_session_id(self, tmp_path):
         from exgentic.utils.otel import PerSessionFileExporter
 
-        exporter = PerSessionFileExporter(tmp_path)
+        exporter = PerSessionFileExporter(tmp_path, run_id="run-1")
 
         span = MagicMock()
-        span.attributes = {}
+        span.attributes = {"exgentic.run.id": "run-1"}  # no session id
         span.to_json.return_value = '{"name": "orphan"}'
 
         result = exporter.export([span])
@@ -2985,14 +2988,113 @@ class TestPerSessionFileExporter:
     def test_returns_failure_on_write_error(self, tmp_path):
         from exgentic.utils.otel import PerSessionFileExporter
 
-        exporter = PerSessionFileExporter(tmp_path)
+        exporter = PerSessionFileExporter(tmp_path, run_id="run-1")
 
         span = MagicMock()
-        span.attributes = {"exgentic.session.id": "sess-1"}
+        span.attributes = {
+            "exgentic.run.id": "run-1",
+            "exgentic.session.id": "sess-1",
+        }
         span.to_json.side_effect = RuntimeError("boom")
 
         result = exporter.export([span])
         assert result == SpanExportResult.FAILURE
+
+    # ------------------------------------------------------------------
+    # Regression: batch-mode write amplification (Exgentic/exgentic#185)
+    # ------------------------------------------------------------------
+
+    def test_drops_foreign_run_spans(self, tmp_path):
+        """An exporter scoped to run-A must drop spans tagged with run-B.
+
+        Reproduces #185: in batch mode one PerSessionFileExporter is
+        registered per RunConfig on the global TracerProvider, so every
+        exporter sees every emitted span. Without this filter each span
+        would be written once per config -- N-way write amplification plus
+        cross-run trace leakage.
+        """
+        from exgentic.utils.otel import PerSessionFileExporter
+
+        exporter = PerSessionFileExporter(tmp_path, run_id="run-A")
+
+        foreign = MagicMock()
+        foreign.attributes = {
+            "exgentic.run.id": "run-B",
+            "exgentic.session.id": "sess-1",
+        }
+        foreign.to_json.return_value = '{"name": "from-B"}'
+
+        result = exporter.export([foreign])
+        assert result == SpanExportResult.SUCCESS
+        # The exporter must NOT touch its run_root for foreign spans.
+        assert not (tmp_path / "sessions").exists()
+
+    def test_drops_spans_with_no_run_id(self, tmp_path):
+        """Spans missing ``exgentic.run.id`` don't belong to any run, drop them."""
+        from exgentic.utils.otel import PerSessionFileExporter
+
+        exporter = PerSessionFileExporter(tmp_path, run_id="run-A")
+
+        untagged = MagicMock()
+        untagged.attributes = {"exgentic.session.id": "sess-1"}
+        untagged.to_json.return_value = '{"name": "untagged"}'
+
+        exporter.export([untagged])
+        assert not (tmp_path / "sessions").exists()
+
+    def test_batch_mode_fanout_has_no_amplification(self, tmp_path):
+        """End-to-end reproduction of the batch-mode write amplification bug.
+
+        Simulates two concurrent RunConfigs (A and B) each owning its own
+        ``PerSessionFileExporter`` rooted in a distinct directory, both
+        attached to the same global ``TracerProvider`` — so both exporters
+        see every emitted span, exactly as in batch mode. We emit one span
+        belonging to run A and one belonging to run B, and assert each
+        ``run_root`` contains exactly its own span — no cross-contamination,
+        no duplication.
+
+        Before the fix, both run_roots would contain both spans (2-way writes
+        per span). On the unfiltered implementation this test fails because
+        ``run-A``'s tree ends up holding ``run-B``'s span and vice versa.
+        """
+        from exgentic.utils.otel import PerSessionFileExporter
+
+        root_a = tmp_path / "run-A"
+        root_b = tmp_path / "run-B"
+        exporter_a = PerSessionFileExporter(root_a, run_id="run-A")
+        exporter_b = PerSessionFileExporter(root_b, run_id="run-B")
+
+        span_a = MagicMock()
+        span_a.attributes = {
+            "exgentic.run.id": "run-A",
+            "exgentic.session.id": "sess-A1",
+        }
+        span_a.to_json.return_value = '{"name": "from-A"}'
+
+        span_b = MagicMock()
+        span_b.attributes = {
+            "exgentic.run.id": "run-B",
+            "exgentic.session.id": "sess-B1",
+        }
+        span_b.to_json.return_value = '{"name": "from-B"}'
+
+        # Global TracerProvider fan-out: every span hits every exporter.
+        for exporter in (exporter_a, exporter_b):
+            exporter.export([span_a, span_b])
+
+        # Run A's tree only sees run A's span.
+        a_files = list(root_a.rglob("otel_spans.jsonl"))
+        assert [p.relative_to(root_a) for p in a_files] == [Path("sessions/sess-A1/otel_spans.jsonl")]
+        a_content = a_files[0].read_text()
+        assert '"from-A"' in a_content
+        assert '"from-B"' not in a_content
+
+        # Run B's tree only sees run B's span.
+        b_files = list(root_b.rglob("otel_spans.jsonl"))
+        assert [p.relative_to(root_b) for p in b_files] == [Path("sessions/sess-B1/otel_spans.jsonl")]
+        b_content = b_files[0].read_text()
+        assert '"from-B"' in b_content
+        assert '"from-A"' not in b_content
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Fixes #185: in batch mode, `OtelTracingObserver.on_run_start` registers a `SimpleSpanProcessor(PerSessionFileExporter(run_root))` on the **global** `TracerProvider` for **every** `RunConfig`. OTEL fans each emitted span out to **every** registered processor, so in a 50-config batch every span gets written 50× — once into each config's `run_root`, producing aggressive cross-config trace leakage and 50× disk amplification.

## The fix

`PerSessionFileExporter` now takes a required `run_id` and drops any span whose `exgentic.run.id` attribute doesn't match. The filter invariant is **explicit in the constructor signature** rather than derived from path structure — cheaper to maintain, impossible to bypass by accident, and won't silently break if `RunPaths.root` ever changes its layout.

```diff
-    def __init__(self, run_root: str | Path) -> None:
+    def __init__(self, run_root: str | Path, run_id: str) -> None:
         self._run_root = Path(run_root)
+        self._run_id = run_id

     def export(self, spans: Sequence) -> SpanExportResult:
         try:
             for span in spans:
-                sid = getattr(span, \"attributes\", {}).get(\"exgentic.session.id\")
+                attrs = getattr(span, \"attributes\", {}) or {}
+                if attrs.get(\"exgentic.run.id\") != self._run_id:
+                    continue
+                sid = attrs.get(\"exgentic.session.id\")
```

Call site in `OtelTracingObserver.on_run_start`:

```diff
-        run_root = get_run_paths().root
+        run_paths = get_run_paths()
         provider = trace.get_tracer_provider()
         if hasattr(provider, \"add_span_processor\"):
             from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-            provider.add_span_processor(SimpleSpanProcessor(PerSessionFileExporter(run_root)))
+            provider.add_span_processor(
+                SimpleSpanProcessor(PerSessionFileExporter(run_paths.root, run_paths.run_id))
+            )
```

`exgentic.run.id` is already set as a heritable attribute in `OtelTracingObserver.on_session_enter` and propagated to every descendant span via `SessionSpanManager.start_span`, so the routing key is always present on spans this exporter should own. Adding N exporters is still the behavior (harmless), but each exporter self-filters so total write volume is back to 1× per span.

**Total change:** 3 functional source lines in `PerSessionFileExporter.export()`, +1 constructor param, +1 line at the one call site.

## Concrete evidence (pre-fix)

Observed on ACE during a 50-config batch:

```
204544160  54096  .../appworld_test_normal/claude_code/.../sessions/a34c71d8/otel_spans.jsonl
204544256  54096  .../tau2_telecom/tool_calling/.../sessions/a34c71d8/otel_spans.jsonl
```

Different inodes, identical size + mtime. First line of the tau2_telecom copy:

```json
{\"name\": \"execute_tool initial_observation\", ..., \"attributes\": {\"exgentic.benchmark.slug_name\": \"swebench\", ...}}
```

i.e. tau2 telecom's session directory contains swebench spans.

## Tests

`tests/observers/test_otel.py::TestPerSessionFileExporter`:

- `test_routes_by_session_id`, `test_skips_spans_without_session_id`, `test_returns_failure_on_write_error`: existing tests updated to thread a matching `run_id` through both the exporter and the span attributes (pre-existing tests were blind to the scoping requirement and would silently regress if the filter were removed again).
- `test_drops_foreign_run_spans` (new): an exporter scoped to `run-A` drops spans tagged with `run-B`.
- `test_drops_spans_with_no_run_id` (new): untagged spans don't belong to any run and must be dropped.
- `test_batch_mode_fanout_has_no_amplification` (new): end-to-end repro. Two exporters scoped to `run-A` and `run-B` both receive both A's and B's spans (as happens under a shared global provider), and each is asserted to write **exactly** its own span — no cross-contamination, no duplication.

All 6 tests pass on the fix; all 6 fail cleanly against the pre-fix exporter (whose `__init__` lacks `run_id`), so removing or weakening the filter in the future will light up every test in the class.

```
tests/observers/test_otel.py::TestPerSessionFileExporter::test_routes_by_session_id PASSED
tests/observers/test_otel.py::TestPerSessionFileExporter::test_skips_spans_without_session_id PASSED
tests/observers/test_otel.py::TestPerSessionFileExporter::test_returns_failure_on_write_error PASSED
tests/observers/test_otel.py::TestPerSessionFileExporter::test_drops_foreign_run_spans PASSED
tests/observers/test_otel.py::TestPerSessionFileExporter::test_drops_spans_with_no_run_id PASSED
tests/observers/test_otel.py::TestPerSessionFileExporter::test_batch_mode_fanout_has_no_amplification PASSED
6 passed in 0.78s
```

## Why explicit `run_id` rather than deriving it from `run_root.name`

An earlier iteration derived the filter key from `run_root.name` (which currently IS the run_id, since `RunPaths.root = output_dir / run_id`). That was 2–3 lines shorter but carried a **hidden coupling**: if `RunPaths.root` ever changes layout (e.g. to `output_dir / \"runs\" / run_id`), the filter silently breaks and `name` becomes `\"runs\"` — every span would be dropped and no test would catch it unless someone read the code carefully.

Making `run_id` an explicit required constructor param puts the filter invariant directly in the signature. The exporter documents what it owns; the reader doesn't have to reason about path conventions; the caller can't construct a mismatched exporter by accident.

## Out of scope (follow-ups)

- Removing the processor from the global provider at `on_run_success`/`on_run_error`. OTEL SDK doesn't expose a clean remove API, so the processors live for the rest of the parent-process lifetime — harmless now that they self-filter.
- Cleanup of existing 50×-duplicated span files already on disk can be scripted as a one-off after merge.

## Test plan

- [ ] `uv run pytest tests/observers/test_otel.py::TestPerSessionFileExporter -v` — 6 passed
- [ ] On a fresh batch run after merge, verify `otel_spans.jsonl` under one config only contains that config's spans (grep for `benchmark.slug_name`)
- [ ] Verify `exgentic batch status` `Last` column no longer shows all rows at <6s