### PR TITLE
fix(otel): emit session_metrics and session_metadata on session span

### DIFF
--- a/docs/observability/semantic-conventions.md
+++ b/docs/observability/semantic-conventions.md
@@ -46,6 +46,8 @@ The table below documents every attribute actually emitted by the implementation
 | **Session (ROOT)** | `exgentic.score.success` | `SessionScore.success` | bool | Custom | No | Set on session close |
 | **Session (ROOT)** | `exgentic.score` | `SessionScore.score` | float | Custom | No | Set on session close |
 | **Session (ROOT)** | `exgentic.score.is_finished` | `SessionScore.is_finished` | bool | Custom | No | Set on session close |
+| **Session (ROOT)** | `exgentic.score.metrics.{key}` | `SessionScore.session_metrics[key]` | primitive or string (JSON) | Custom | No | One entry per metric; nested values JSON-encoded |
+| **Session (ROOT)** | `exgentic.score.metadata.{key}` | `SessionScore.session_metadata[key]` | primitive or string (JSON) | Custom | No | One entry per metadata field; nested values JSON-encoded |
 | **Session (ROOT)** | `exgentic.session.steps` | step counter | int | Custom | No | Set on session close |
 | **Session (ROOT)** | `exgentic.agent.agent_cost` | `AgentInstance.get_cost()` | string (JSON) | Custom | No | Set on session close |
 | **Session (ROOT)** | `exgentic.session.cost` | `Session.get_cost()` | string (JSON) | Custom | No | Set on session close |

--- a/src/exgentic/observers/handlers/otel.py
+++ b/src/exgentic/observers/handlers/otel.py
@@ -337,6 +337,7 @@ class OtelTracingObserver(Observer):
                 "exgentic.session.task_id": session.task_id,
             }
         )
+        self._set_score_extras(span_manager, score)
 
         self._set_cost_attr(span_manager, "exgentic.agent.agent_cost", lambda: agent.get_cost())
         self._set_cost_attr(span_manager, "exgentic.session.cost", lambda: session.get_cost())
@@ -374,6 +375,19 @@ class OtelTracingObserver(Observer):
     def _close_trailing_tool_span(span_manager: SessionSpanManager) -> None:
         if span_manager.depth == 2:
             span_manager.end_current_span()
+
+    @staticmethod
+    def _set_score_extras(span_manager: SessionSpanManager, score) -> None:
+        """Flatten score.session_metrics / session_metadata onto the session span."""
+        for prefix, attr in (
+            ("exgentic.score.metrics", "session_metrics"),
+            ("exgentic.score.metadata", "session_metadata"),
+        ):
+            data = getattr(score, attr, None) or {}
+            for key, value in data.items():
+                otel_value = to_otel_attribute_value(value)
+                if otel_value is not None:
+                    span_manager.set_attribute(f"{prefix}.{key}", otel_value)
 
     @staticmethod
     def _set_cost_attr(span_manager: SessionSpanManager, key: str, get_cost) -> None:

--- a/src/exgentic/observers/handlers/otel.py
+++ b/src/exgentic/observers/handlers/otel.py
@@ -337,7 +337,14 @@ class OtelTracingObserver(Observer):
                 "exgentic.session.task_id": session.task_id,
             }
         )
-        self._set_score_extras(span_manager, score)
+        for prefix, data in (
+            ("exgentic.score.metrics", score.session_metrics),
+            ("exgentic.score.metadata", score.session_metadata),
+        ):
+            for key, value in data.items():
+                otel_value = to_otel_attribute_value(value)
+                if otel_value is not None:
+                    span_manager.set_attribute(f"{prefix}.{key}", otel_value)
 
         self._set_cost_attr(span_manager, "exgentic.agent.agent_cost", lambda: agent.get_cost())
         self._set_cost_attr(span_manager, "exgentic.session.cost", lambda: session.get_cost())
@@ -375,19 +382,6 @@ class OtelTracingObserver(Observer):
     def _close_trailing_tool_span(span_manager: SessionSpanManager) -> None:
         if span_manager.depth == 2:
             span_manager.end_current_span()
-
-    @staticmethod
-    def _set_score_extras(span_manager: SessionSpanManager, score) -> None:
-        """Flatten score.session_metrics / session_metadata onto the session span."""
-        for prefix, attr in (
-            ("exgentic.score.metrics", "session_metrics"),
-            ("exgentic.score.metadata", "session_metadata"),
-        ):
-            data = getattr(score, attr, None) or {}
-            for key, value in data.items():
-                otel_value = to_otel_attribute_value(value)
-                if otel_value is not None:
-                    span_manager.set_attribute(f"{prefix}.{key}", otel_value)
 
     @staticmethod
     def _set_cost_attr(span_manager: SessionSpanManager, key: str, get_cost) -> None:

--- a/tests/observers/test_otel.py
+++ b/tests/observers/test_otel.py
@@ -103,6 +103,8 @@ class MockScore:
     success = True
     score = 0.95
     is_finished = True
+    session_metrics: ClassVar[dict] = {}
+    session_metadata: ClassVar[dict] = {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/observers/test_otel.py
+++ b/tests/observers/test_otel.py
@@ -831,6 +831,70 @@ class TestSessionSuccessAttributes:
         assert attrs.get("exgentic.score") == 0.95
         assert attrs.get("exgentic.score.is_finished") is True
 
+    def test_score_extras_flattened_onto_session_span(self, exporter, ctx, tmp_path):
+        """session_metrics and session_metadata are flattened onto the session span."""
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        t = provider.get_tracer("test")
+
+        obs = _create_observer_with_tracer(ctx, tmp_path, t)
+        obs, session, settings = _trigger_session_lifecycle(obs, t, ctx, tmp_path)
+
+        class RichScore(MockScore):
+            session_metrics: ClassVar[dict] = {"reward": 0.75, "db_check_db_match": True}
+            session_metadata: ClassVar[dict] = {
+                "reward_info": {
+                    "reward": 0.75,
+                    "nl_assertions": [
+                        {"assertion": "agent greeted user", "met": True},
+                        {"assertion": "agent confirmed order", "met": False},
+                    ],
+                },
+            }
+
+        with (
+            patch("exgentic.observers.handlers.otel.get_settings", return_value=settings),
+            patch("exgentic.observers.handlers.otel.flush_traces"),
+        ):
+            obs.on_session_success(session, RichScore(), MockAgent())
+
+        spans = exporter.get_finished_spans()
+        session_spans = [s for s in spans if "session" in s.name]
+        attrs = dict(session_spans[0].attributes)
+
+        # Primitive metric values pass through directly.
+        assert attrs.get("exgentic.score.metrics.reward") == 0.75
+        assert attrs.get("exgentic.score.metrics.db_check_db_match") is True
+
+        # Nested metadata is JSON-serialized so nothing is dropped.
+        reward_info_raw = attrs.get("exgentic.score.metadata.reward_info")
+        assert reward_info_raw is not None, "rich score metadata must be emitted"
+        parsed = json.loads(reward_info_raw)
+        assert parsed["reward"] == 0.75
+        assert parsed["nl_assertions"][0]["assertion"] == "agent greeted user"
+        assert parsed["nl_assertions"][1]["met"] is False
+
+    def test_score_extras_absent_when_empty(self, exporter, ctx, tmp_path):
+        """Scores without metrics/metadata emit no extra attributes and don't crash."""
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        t = provider.get_tracer("test")
+
+        obs = _create_observer_with_tracer(ctx, tmp_path, t)
+        obs, session, settings = _trigger_session_lifecycle(obs, t, ctx, tmp_path)
+
+        with (
+            patch("exgentic.observers.handlers.otel.get_settings", return_value=settings),
+            patch("exgentic.observers.handlers.otel.flush_traces"),
+        ):
+            obs.on_session_success(session, MockScore(), MockAgent())
+
+        spans = exporter.get_finished_spans()
+        session_spans = [s for s in spans if "session" in s.name]
+        attrs = dict(session_spans[0].attributes)
+        assert not any(k.startswith("exgentic.score.metrics.") for k in attrs)
+        assert not any(k.startswith("exgentic.score.metadata.") for k in attrs)
+
     def test_step_counter_set(self, exporter, ctx, tmp_path):
         """exgentic.session.steps reflects the number of steps."""
         provider = TracerProvider()


### PR DESCRIPTION
## Summary

- `OtelHandler.on_session_success` now flattens `score.session_metrics` and `score.session_metadata` onto the session span under `exgentic.score.metrics.*` and `exgentic.score.metadata.*`, reusing `to_otel_attribute_value` so nested dicts/lists (e.g. tau-bench's `reward_info` with `nl_assertions`) are JSON-serialized rather than silently dropped.
- Adds two unit tests: one asserting a rich score round-trips through the span (including a nested `nl_assertions` list), one asserting the empty-metadata case emits no extra attributes.

Before this change, only `score`, `success`, and `is_finished` made it into OTel traces — downstream consumers of full-suite runs lost all benchmark-specific evaluation detail.

Fixes #188

## Test plan

- [x] `uv run pytest tests/observers/test_otel.py` — 228 passed
- [x] Verified new test fails on `main` and passes with the fix applied