### PR TITLE
fix(cli): aggregate batch status cost/score from session files (#190)

### DIFF
--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -264,18 +264,39 @@ def _recover_session_hashes(roots: list[Path], *, do_apply: bool) -> int:
 def _load_results_summary(
     path: str,
 ) -> tuple[str, str, str, int | None, int | None, int | None, int | None]:
-    if not path or not Path(path).is_file():
+    if not path:
         return "-", "-", "-", None, None, None, None
-    try:
-        payload = _load_config_file(path)
-    except Exception:
-        return "-", "-", "-", None, None, None, None
+    payload: dict = {}
+    if Path(path).is_file():
+        try:
+            payload = _load_config_file(path) or {}
+        except Exception:
+            payload = {}
     score = payload.get("benchmark_score")
     if score is None:
         score = payload.get("average_score")
     cost = payload.get("total_run_cost")
     if cost is None:
         cost = payload.get("total_agent_cost")
+    # Run-level results.json is only written at end of run, so during a live
+    # run its Score/Cost are stale. Prefer live session-level aggregates (#190).
+    live_cost = 0.0
+    live_scores: list[float] = []
+    found = False
+    for sp in (Path(path).parent / "sessions").glob("*/results.json"):
+        try:
+            sdata = json.loads(sp.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        found = True
+        live_cost += float(sdata.get("agent_cost") or 0) + float(sdata.get("benchmark_cost") or 0)
+        s = sdata.get("score")
+        if s is not None:
+            live_scores.append(float(s))
+    if found:
+        cost = live_cost
+        if live_scores:
+            score = sum(live_scores) / len(live_scores)
     models = payload.get("model_names")
     if models is None:
         models = payload.get("model_name")

--- a/tests/api/test_cli_batch.py
+++ b/tests/api/test_cli_batch.py
@@ -128,3 +128,94 @@ def test_batch_extract_writes_csv(tmp_path):
     assert len(rows) == 1
     assert rows[0]["benchmark_name"] == "Test Benchmark"
     assert rows[0]["benchmark_score"] == "1.0"
+
+
+def _write_session_results(run_root, session_id: str, payload: dict) -> None:
+    sdir = run_root / "sessions" / session_id
+    sdir.mkdir(parents=True, exist_ok=True)
+    (sdir / "results.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_batch_status_cost_is_stale_during_live_run(tmp_path):
+    """Regression test for Exgentic/exgentic#190.
+
+    `batch status` reads Score/Cost from run-level `{run_id}/results.json`,
+    which is only written at end of run. During a live run, fresh session-level
+    `sessions/{sid}/results.json` files exist on disk but are ignored, so the
+    Total Cost shown is a stale snapshot from the previous cleanly-exited run.
+    """
+    runner = CliRunner()
+    config_path = _write_config(tmp_path / "live.json", run_id="run-live")
+
+    run_root = tmp_path / "outputs" / "run-live"
+    run_root.mkdir(parents=True, exist_ok=True)
+
+    # Stale run-level aggregate left behind by a previous cleanly-exited run.
+    stale_payload = {
+        "benchmark_name": "Test Benchmark",
+        "agent_name": "Test Agent",
+        "benchmark_score": 0.10,
+        "total_run_cost": 41.92,
+        "total_agent_cost": 38.00,
+    }
+    (run_root / "results.json").write_text(json.dumps(stale_payload), encoding="utf-8")
+
+    # Fresh session-level results from the currently-in-flight run.
+    # Sum: 67.0 + 67.60 = 134.60
+    fresh_sessions = [
+        {"session_id": "s1", "score": 1.0, "agent_cost": 60.0, "benchmark_cost": 7.0},
+        {"session_id": "s2", "score": 0.5, "agent_cost": 60.67, "benchmark_cost": 6.93},
+    ]
+    expected_total = sum(s["agent_cost"] + s["benchmark_cost"] for s in fresh_sessions)
+    for s in fresh_sessions:
+        _write_session_results(run_root, s["session_id"], s)
+
+    result = runner.invoke(cli, ["batch", "status", "--config", config_path])
+    assert result.exit_code == 0, result.output
+
+    # Expected post-fix behavior: aggregate fresh session-level costs.
+    assert f"${expected_total:.2f}" in result.output, (
+        f"batch status should report the fresh aggregated Total Cost "
+        f"${expected_total:.2f} from session-level results.json files. "
+        f"Output:\n{result.output}"
+    )
+    # Bug: the stale run-level value leaks into the summary panel.
+    assert "$41.92" not in result.output, (
+        "batch status reported the stale run-level cost $41.92 instead of "
+        "aggregating fresh session-level results (#190).\n"
+        f"Output:\n{result.output}"
+    )
+
+
+def test_batch_status_cost_missing_when_run_level_absent(tmp_path):
+    """Regression test for Exgentic/exgentic#190.
+
+    On the first live run (before any clean exit has ever written the
+    run-level aggregate), `batch status` shows no Total Cost at all even
+    though fresh per-session costs are on disk.
+    """
+    runner = CliRunner()
+    config_path = _write_config(tmp_path / "nofinish.json", run_id="run-nofinish")
+
+    run_root = tmp_path / "outputs" / "run-nofinish"
+    run_root.mkdir(parents=True, exist_ok=True)
+
+    sessions = [
+        {"session_id": "s1", "score": 1.0, "agent_cost": 12.5, "benchmark_cost": 0.5},
+        {"session_id": "s2", "score": 0.0, "agent_cost": 20.0, "benchmark_cost": 2.0},
+    ]
+    expected_total = sum(s["agent_cost"] + s["benchmark_cost"] for s in sessions)
+    for s in sessions:
+        _write_session_results(run_root, s["session_id"], s)
+
+    # Sanity: no run-level results.json yet.
+    assert not (run_root / "results.json").exists()
+
+    result = runner.invoke(cli, ["batch", "status", "--config", config_path])
+    assert result.exit_code == 0, result.output
+
+    assert f"${expected_total:.2f}" in result.output, (
+        f"batch status should aggregate Total Cost ${expected_total:.2f} "
+        f"from session-level results.json files when the run-level "
+        f"aggregate is absent. Output:\n{result.output}"
+    )


### PR DESCRIPTION
## Summary

- Fixes #190: `batch status` showed stale `Score`/`Cost`/`Total Cost` during long-running `batch evaluate` invocations because it read the run-level `{run_id}/results.json`, which is only written at end of run.
- Walk `{run_root}/sessions/*/results.json` in `_load_results_summary` and prefer those live aggregates over the stale run-level payload. Same read-side pattern as the `Last` column from #182 — no changes to the write pipeline, no new state, no locking.
- Regression tests cover both the "stale run-level snapshot hides live cost" case and the "no run-level file exists yet" case.

## Test plan

- [x] `uv run pytest tests/api/test_cli_batch.py` — all 6 tests pass
- [x] New `test_batch_status_cost_is_stale_during_live_run` fails without the fix and passes with it
- [x] New `test_batch_status_cost_missing_when_run_level_absent` fails without the fix and passes with it