### PR TITLE
feat(otel): emit comprehensive tools list on session span

### DIFF
--- a/docs/observability/semantic-conventions.md
+++ b/docs/observability/semantic-conventions.md
@@ -41,6 +41,7 @@ The table below documents every attribute actually emitted by the implementation
 | **Session (ROOT)** | `exgentic.session.action.{name}.is_message` | `ActionType.is_message` | bool | Custom | No | |
 | **Session (ROOT)** | `exgentic.session.action.{name}.is_finish` | `ActionType.is_finish` | bool | Custom | No | |
 | **Session (ROOT)** | `exgentic.session.tools` | `Session.actions` | string (JSON) | Custom | No | Comprehensive JSON list of all tools available at session start (name, description, is_message, is_finish) |
+| **Session (ROOT)** | `gen_ai.tool.definitions` | `Session.actions` | string (JSON) | OTel GenAI (Development) | No | Standard JSON list of tool definitions; each entry has `type: "function"` plus name/description/is_message/is_finish |
 | **Session (ROOT)** | `exgentic.context.{key}` | `Session.context[key]` | string | Custom | No | One entry per context key |
 | **Session (ROOT)** | `exgentic.session.agent.id` | `AgentInstance.agent_id` | string | Custom | No | |
 | **Session (ROOT)** | `exgentic.session.agent.path` | `AgentInstance.paths.agent_dir` | string | Custom | No | |

--- a/docs/observability/semantic-conventions.md
+++ b/docs/observability/semantic-conventions.md
@@ -20,6 +20,23 @@ Session Span (ROOT)
 
 ---
 
+## Tool observability lifecycle
+
+An agent's tool usage is observable at four distinct stages, each emitted on a different span:
+
+| Stage | Span | Attribute | Source |
+|-------|------|-----------|--------|
+| 1. Configured capability | Session (ROOT) | `exgentic.session.tools` | `Session.actions` (framework-level) |
+| 2. Offered to LLM | LLM inference | `gen_ai.tool.definitions` | `LitellmKwargs.tools` (per-call) |
+| 3. Chosen by LLM | LLM inference | `gen_ai.output.messages[].tool_calls` | provider response |
+| 4. Execution result | execute_tool | `gen_ai.tool.result` | `Observation` |
+
+Stage 1 reflects what the agent is configured with — stable over the session. Stage 2 is what was actually sent to the model for a specific inference — may be filtered, reformatted per provider, or vary between calls (e.g., `is_finish` withheld until late). Stages 2–4 are opt-in (`EXGENTIC_OTEL_RECORD_CONTENT=true`).
+
+All LLM calls in exgentic are routed through LiteLLM, so stages 2–3 are guaranteed to emit on every inference.
+
+---
+
 ## Attribute reference
 
 The table below documents every attribute actually emitted by the implementation, organised by span type.

--- a/docs/observability/semantic-conventions.md
+++ b/docs/observability/semantic-conventions.md
@@ -40,8 +40,7 @@ The table below documents every attribute actually emitted by the implementation
 | **Session (ROOT)** | `exgentic.session.action.{name}.description` | `ActionType.description` | string | Custom | No | |
 | **Session (ROOT)** | `exgentic.session.action.{name}.is_message` | `ActionType.is_message` | bool | Custom | No | |
 | **Session (ROOT)** | `exgentic.session.action.{name}.is_finish` | `ActionType.is_finish` | bool | Custom | No | |
-| **Session (ROOT)** | `exgentic.session.tools` | `Session.actions` | string (JSON) | Custom | No | Comprehensive JSON list of all tools available at session start (name, description, is_message, is_finish) |
-| **Session (ROOT)** | `gen_ai.tool.definitions` | `Session.actions` | string (JSON) | OTel GenAI (Development) | No | Standard JSON list of tool definitions; each entry has `type: "function"` plus name/description/is_message/is_finish |
+| **Session (ROOT)** | `exgentic.session.tools` | `Session.actions` | string (JSON) | Custom | No | Comprehensive JSON list of all tools available at session start (name, description, is_message, is_finish). The per-action flat attributes (`exgentic.session.action.{name}.*`) above are deprecated-in-spirit and will be consolidated into this attribute in a follow-up. |
 | **Session (ROOT)** | `exgentic.context.{key}` | `Session.context[key]` | string | Custom | No | One entry per context key |
 | **Session (ROOT)** | `exgentic.session.agent.id` | `AgentInstance.agent_id` | string | Custom | No | |
 | **Session (ROOT)** | `exgentic.session.agent.path` | `AgentInstance.paths.agent_dir` | string | Custom | No | |

--- a/docs/observability/semantic-conventions.md
+++ b/docs/observability/semantic-conventions.md
@@ -40,6 +40,7 @@ The table below documents every attribute actually emitted by the implementation
 | **Session (ROOT)** | `exgentic.session.action.{name}.description` | `ActionType.description` | string | Custom | No | |
 | **Session (ROOT)** | `exgentic.session.action.{name}.is_message` | `ActionType.is_message` | bool | Custom | No | |
 | **Session (ROOT)** | `exgentic.session.action.{name}.is_finish` | `ActionType.is_finish` | bool | Custom | No | |
+| **Session (ROOT)** | `exgentic.session.tools` | `Session.actions` | string (JSON) | Custom | No | Comprehensive JSON list of all tools available at session start (name, description, is_message, is_finish) |
 | **Session (ROOT)** | `exgentic.context.{key}` | `Session.context[key]` | string | Custom | No | One entry per context key |
 | **Session (ROOT)** | `exgentic.session.agent.id` | `AgentInstance.agent_id` | string | Custom | No | |
 | **Session (ROOT)** | `exgentic.session.agent.path` | `AgentInstance.paths.agent_dir` | string | Custom | No | |

--- a/src/exgentic/observers/handlers/otel.py
+++ b/src/exgentic/observers/handlers/otel.py
@@ -253,8 +253,6 @@ class OtelTracingObserver(Observer):
             if task is not None:
                 span_manager.set_attribute("exgentic.session.task", task)
 
-        tools_list = []
-        standard_tools = []
         for action in session.actions:
             prefix = f"exgentic.session.action.{action.name}"
             span_manager.set_attributes(
@@ -265,28 +263,16 @@ class OtelTracingObserver(Observer):
                     f"{prefix}.is_finish": action.is_finish,
                 }
             )
-            tools_list.append(
-                {
-                    "name": action.name,
-                    "description": action.description,
-                    "is_message": action.is_message,
-                    "is_finish": action.is_finish,
-                }
-            )
-            standard_tools.append(
-                {
-                    "type": "function",
-                    "name": action.name,
-                    "description": action.description,
-                    "is_message": action.is_message,
-                    "is_finish": action.is_finish,
-                }
-            )
-        span_manager.set_attribute("exgentic.session.tools", json.dumps(tools_list, default=str))
-        span_manager.set_attribute(
-            "gen_ai.tool.definitions",
-            json.dumps(standard_tools, default=str),
-        )
+        tools_list = [
+            {
+                "name": action.name,
+                "description": action.description,
+                "is_message": action.is_message,
+                "is_finish": action.is_finish,
+            }
+            for action in session.actions
+        ]
+        span_manager.set_attribute("exgentic.session.tools", _serialize_to_json(tools_list))
 
         for k, v in session.context.items():
             otel_value = to_otel_attribute_value(v)

--- a/src/exgentic/observers/handlers/otel.py
+++ b/src/exgentic/observers/handlers/otel.py
@@ -253,6 +253,7 @@ class OtelTracingObserver(Observer):
             if task is not None:
                 span_manager.set_attribute("exgentic.session.task", task)
 
+        tools_list = []
         for action in session.actions:
             prefix = f"exgentic.session.action.{action.name}"
             span_manager.set_attributes(
@@ -263,6 +264,15 @@ class OtelTracingObserver(Observer):
                     f"{prefix}.is_finish": action.is_finish,
                 }
             )
+            tools_list.append(
+                {
+                    "name": action.name,
+                    "description": action.description,
+                    "is_message": action.is_message,
+                    "is_finish": action.is_finish,
+                }
+            )
+        span_manager.set_attribute("exgentic.session.tools", json.dumps(tools_list, default=str))
 
         for k, v in session.context.items():
             otel_value = to_otel_attribute_value(v)

--- a/src/exgentic/observers/handlers/otel.py
+++ b/src/exgentic/observers/handlers/otel.py
@@ -254,6 +254,7 @@ class OtelTracingObserver(Observer):
                 span_manager.set_attribute("exgentic.session.task", task)
 
         tools_list = []
+        standard_tools = []
         for action in session.actions:
             prefix = f"exgentic.session.action.{action.name}"
             span_manager.set_attributes(
@@ -272,7 +273,20 @@ class OtelTracingObserver(Observer):
                     "is_finish": action.is_finish,
                 }
             )
+            standard_tools.append(
+                {
+                    "type": "function",
+                    "name": action.name,
+                    "description": action.description,
+                    "is_message": action.is_message,
+                    "is_finish": action.is_finish,
+                }
+            )
         span_manager.set_attribute("exgentic.session.tools", json.dumps(tools_list, default=str))
+        span_manager.set_attribute(
+            "gen_ai.tool.definitions",
+            json.dumps(standard_tools, default=str),
+        )
 
         for k, v in session.context.items():
             otel_value = to_otel_attribute_value(v)

--- a/tests/observers/test_otel.py
+++ b/tests/observers/test_otel.py
@@ -2116,11 +2116,7 @@ class TestSessionSpanSemanticConventions:
         assert session_span.attributes["exgentic.session.action.test_action.is_finish"] is False
 
     def test_session_span_tools_list_comprehensive(self, ctx, tmp_path):
-        """Session span emits a comprehensive JSON tools list from Session.actions.
-
-        Verifies both the exgentic-specific ``exgentic.session.tools`` attribute
-        and the OTel GenAI standard ``gen_ai.tool.definitions`` attribute.
-        """
+        """Session span emits a comprehensive JSON tools list from Session.actions."""
 
         class ActA:
             name = "search"
@@ -2138,35 +2134,16 @@ class TestSessionSpanSemanticConventions:
             actions: ClassVar = [ActA(), ActB()]
 
         session_span, _, _ = _full_lifecycle_spans(ctx, tmp_path, session=SessionWithActions())
-        raw = session_span.attributes["exgentic.session.tools"]
-        tools = json.loads(raw)
+        tools = json.loads(session_span.attributes["exgentic.session.tools"])
         assert isinstance(tools, list)
-        names = [t["name"] for t in tools]
-        assert names == ["search", "submit"]
-        submit = next(t for t in tools if t["name"] == "submit")
-        assert submit["description"] == "Submit final answer"
-        assert submit["is_finish"] is True
-        assert submit["is_message"] is False
-
-        # OTel GenAI standard attribute: gen_ai.tool.definitions
-        assert "gen_ai.tool.definitions" in session_span.attributes
-        raw_std = session_span.attributes["gen_ai.tool.definitions"]
-        std_tools = json.loads(raw_std)
-        assert isinstance(std_tools, list)
-        assert len(std_tools) == 2
-        std_names = [t["name"] for t in std_tools]
-        assert std_names == ["search", "submit"]
-        for entry in std_tools:
-            assert entry["type"] == "function"
-            assert "name" in entry
-            assert "description" in entry
-            assert "is_message" in entry
-            assert "is_finish" in entry
-        std_submit = next(t for t in std_tools if t["name"] == "submit")
-        assert std_submit["type"] == "function"
-        assert std_submit["description"] == "Submit final answer"
-        assert std_submit["is_finish"] is True
-        assert std_submit["is_message"] is False
+        assert [t["name"] for t in tools] == ["search", "submit"]
+        expected = {
+            "search": {"description": "Search the knowledge source", "is_message": False, "is_finish": False},
+            "submit": {"description": "Submit final answer", "is_message": False, "is_finish": True},
+        }
+        for tool in tools:
+            for field, value in expected[tool["name"]].items():
+                assert tool[field] == value
 
     def test_session_span_context_attributes(self, ctx, tmp_path):
         """exgentic.context.{key} emitted for each context key."""

--- a/tests/observers/test_otel.py
+++ b/tests/observers/test_otel.py
@@ -2116,7 +2116,11 @@ class TestSessionSpanSemanticConventions:
         assert session_span.attributes["exgentic.session.action.test_action.is_finish"] is False
 
     def test_session_span_tools_list_comprehensive(self, ctx, tmp_path):
-        """Session span emits a comprehensive JSON tools list from Session.actions."""
+        """Session span emits a comprehensive JSON tools list from Session.actions.
+
+        Verifies both the exgentic-specific ``exgentic.session.tools`` attribute
+        and the OTel GenAI standard ``gen_ai.tool.definitions`` attribute.
+        """
 
         class ActA:
             name = "search"
@@ -2143,6 +2147,26 @@ class TestSessionSpanSemanticConventions:
         assert submit["description"] == "Submit final answer"
         assert submit["is_finish"] is True
         assert submit["is_message"] is False
+
+        # OTel GenAI standard attribute: gen_ai.tool.definitions
+        assert "gen_ai.tool.definitions" in session_span.attributes
+        raw_std = session_span.attributes["gen_ai.tool.definitions"]
+        std_tools = json.loads(raw_std)
+        assert isinstance(std_tools, list)
+        assert len(std_tools) == 2
+        std_names = [t["name"] for t in std_tools]
+        assert std_names == ["search", "submit"]
+        for entry in std_tools:
+            assert entry["type"] == "function"
+            assert "name" in entry
+            assert "description" in entry
+            assert "is_message" in entry
+            assert "is_finish" in entry
+        std_submit = next(t for t in std_tools if t["name"] == "submit")
+        assert std_submit["type"] == "function"
+        assert std_submit["description"] == "Submit final answer"
+        assert std_submit["is_finish"] is True
+        assert std_submit["is_message"] is False
 
     def test_session_span_context_attributes(self, ctx, tmp_path):
         """exgentic.context.{key} emitted for each context key."""

--- a/tests/observers/test_otel.py
+++ b/tests/observers/test_otel.py
@@ -2115,6 +2115,35 @@ class TestSessionSpanSemanticConventions:
         assert session_span.attributes["exgentic.session.action.test_action.is_message"] is False
         assert session_span.attributes["exgentic.session.action.test_action.is_finish"] is False
 
+    def test_session_span_tools_list_comprehensive(self, ctx, tmp_path):
+        """Session span emits a comprehensive JSON tools list from Session.actions."""
+
+        class ActA:
+            name = "search"
+            description = "Search the knowledge source"
+            is_message = False
+            is_finish = False
+
+        class ActB:
+            name = "submit"
+            description = "Submit final answer"
+            is_message = False
+            is_finish = True
+
+        class SessionWithActions(MockSession):
+            actions: ClassVar = [ActA(), ActB()]
+
+        session_span, _, _ = _full_lifecycle_spans(ctx, tmp_path, session=SessionWithActions())
+        raw = session_span.attributes["exgentic.session.tools"]
+        tools = json.loads(raw)
+        assert isinstance(tools, list)
+        names = [t["name"] for t in tools]
+        assert names == ["search", "submit"]
+        submit = next(t for t in tools if t["name"] == "submit")
+        assert submit["description"] == "Submit final answer"
+        assert submit["is_finish"] is True
+        assert submit["is_message"] is False
+
     def test_session_span_context_attributes(self, ctx, tmp_path):
         """exgentic.context.{key} emitted for each context key."""
         session_span, _, _ = _full_lifecycle_spans(ctx, tmp_path)


### PR DESCRIPTION
## Summary
- Adds `exgentic.session.tools` attribute to the session ROOT span, holding a JSON-encoded list of every tool available at session start (name, description, is_message, is_finish).
- Existing per-tool flat attributes (`exgentic.session.action.{name}.*`) are preserved for backwards compatibility; this is purely additive.
- Documents the new attribute in `docs/observability/semantic-conventions.md`.

Closes #195

## Test plan
- [x] New unit test `TestSessionSpanSemanticConventions::test_session_span_tools_list_comprehensive` asserts the JSON list is emitted with all fields.
- [x] `uv run pytest tests/observers/test_otel.py` — 229 passed.