### PR TITLE
fix(config): do not inherit run_id from ambient context

### DIFF
--- a/src/exgentic/core/types/evaluation.py
+++ b/src/exgentic/core/types/evaluation.py
@@ -14,7 +14,6 @@ from ...interfaces.registry import (
     load_agent,
     load_benchmark,
 )
-from ..context import try_get_context
 from .model_settings import ModelSettings
 
 
@@ -113,8 +112,12 @@ class BaseEvaluationConfig(BaseModel):
         payload["benchmark_kwargs"] = benchmark_kwargs
         payload["agent_kwargs"] = agent_kwargs
         if payload.get("run_id") is None and benchmark and agent:
-            ctx = try_get_context()
-            payload["run_id"] = (ctx.run_id if ctx else None) or _compute_run_id(
+            # Derive run_id deterministically from benchmark + agent + kwargs.
+            # Do NOT fall back to the ambient context's run_id — that lets a
+            # config validated inside another run's context inherit the wrong
+            # run_id, causing sessions to land under the wrong benchmark
+            # folder tree (issue #197).
+            payload["run_id"] = _compute_run_id(
                 benchmark=str(benchmark),
                 agent=str(agent),
                 benchmark_kwargs=benchmark_kwargs,

--- a/src/exgentic/core/types/evaluation.py
+++ b/src/exgentic/core/types/evaluation.py
@@ -112,11 +112,8 @@ class BaseEvaluationConfig(BaseModel):
         payload["benchmark_kwargs"] = benchmark_kwargs
         payload["agent_kwargs"] = agent_kwargs
         if payload.get("run_id") is None and benchmark and agent:
-            # Derive run_id deterministically from benchmark + agent + kwargs.
-            # Do NOT fall back to the ambient context's run_id — that lets a
-            # config validated inside another run's context inherit the wrong
-            # run_id, causing sessions to land under the wrong benchmark
-            # folder tree (issue #197).
+            # run_id is a deterministic function of benchmark + agent + kwargs;
+            # never fall back to the ambient context (leaks across configs).
             payload["run_id"] = _compute_run_id(
                 benchmark=str(benchmark),
                 agent=str(agent),

--- a/tests/api/test_api_run_config.py
+++ b/tests/api/test_api_run_config.py
@@ -152,6 +152,44 @@ def test_cli_commands_accept_overridable_fields():
             )
 
 
+def test_run_id_not_inherited_from_outer_context(tmp_path):
+    """A config validated inside another run's context must not inherit its run_id.
+
+    Regression test for #197: sessions were landing under the wrong benchmark
+    folder tree because RunConfig/SessionConfig without an explicit run_id
+    inherited the run_id of whatever context happened to be active at
+    model_validate() time.  run_id must be derived deterministically from
+    benchmark + agent + kwargs.
+    """
+    from exgentic.core.context import run_scope
+
+    outer = RunConfig(
+        benchmark="test_benchmark",
+        agent="test_agent",
+        output_dir=str(tmp_path / "outer"),
+        cache_dir=str(tmp_path / "cache"),
+        run_id="OUTER_RUN_ID",
+        benchmark_kwargs={"tasks": ["task-1"]},
+        agent_kwargs={"policy": "good_then_finish"},
+    )
+
+    with run_scope(run_id=outer.run_id, output_dir=outer.output_dir, cache_dir=outer.cache_dir):
+        # A different config — different benchmark_kwargs / agent_kwargs —
+        # validated while outer's context is active.  Its run_id must be
+        # derived from its OWN fields, not inherited from the outer context.
+        inner = RunConfig(
+            benchmark="test_benchmark",
+            agent="test_agent",
+            output_dir=str(tmp_path / "inner"),
+            benchmark_kwargs={"tasks": ["task-99"]},
+            agent_kwargs={"policy": "good_only"},
+        )
+
+    assert (
+        inner.run_id != outer.run_id
+    ), "inner.run_id leaked from outer context; sessions would be written to the wrong folder tree"
+
+
 def test_has_run_options_allows_overridable_fields():
     """Ensure has_run_options does not reject overridable fields."""
     from exgentic.interfaces.cli.options import has_run_options

--- a/tests/api/test_api_run_config.py
+++ b/tests/api/test_api_run_config.py
@@ -155,39 +155,83 @@ def test_cli_commands_accept_overridable_fields():
 def test_run_id_not_inherited_from_outer_context(tmp_path):
     """A config validated inside another run's context must not inherit its run_id.
 
-    Regression test for #197: sessions were landing under the wrong benchmark
-    folder tree because RunConfig/SessionConfig without an explicit run_id
-    inherited the run_id of whatever context happened to be active at
-    model_validate() time.  run_id must be derived deterministically from
-    benchmark + agent + kwargs.
+    Regression test: run_id must be a deterministic hash of
+    benchmark + agent + kwargs, never a leak from the ambient context.
     """
     from exgentic.core.context import run_scope
+    from exgentic.core.types.evaluation import _compute_run_id
 
     outer = RunConfig(
         benchmark="test_benchmark",
         agent="test_agent",
-        output_dir=str(tmp_path / "outer"),
-        cache_dir=str(tmp_path / "cache"),
-        run_id="OUTER_RUN_ID",
+        run_id="ambient-run-id-that-must-not-leak",
         benchmark_kwargs={"tasks": ["task-1"]},
         agent_kwargs={"policy": "good_then_finish"},
     )
 
-    with run_scope(run_id=outer.run_id, output_dir=outer.output_dir, cache_dir=outer.cache_dir):
-        # A different config — different benchmark_kwargs / agent_kwargs —
-        # validated while outer's context is active.  Its run_id must be
-        # derived from its OWN fields, not inherited from the outer context.
+    benchmark_kwargs = {"tasks": ["task-1"]}
+    agent_kwargs = {"policy": "good_only"}
+
+    with run_scope(run_id=outer.run_id, output_dir=str(tmp_path), cache_dir=str(tmp_path)):
         inner = RunConfig(
             benchmark="test_benchmark",
             agent="test_agent",
-            output_dir=str(tmp_path / "inner"),
-            benchmark_kwargs={"tasks": ["task-99"]},
-            agent_kwargs={"policy": "good_only"},
+            benchmark_kwargs=benchmark_kwargs,
+            agent_kwargs=agent_kwargs,
         )
 
-    assert (
-        inner.run_id != outer.run_id
-    ), "inner.run_id leaked from outer context; sessions would be written to the wrong folder tree"
+    expected = _compute_run_id(
+        benchmark="test_benchmark",
+        agent="test_agent",
+        benchmark_kwargs=benchmark_kwargs,
+        agent_kwargs=agent_kwargs,
+    )
+    assert inner.run_id == expected, "inner.run_id must be the deterministic hash of its own fields"
+    assert inner.run_id != outer.run_id
+
+
+def test_run_id_deterministic_across_contexts(tmp_path):
+    """Same (benchmark, agent, kwargs) yields the same run_id regardless of ambient context."""
+    from exgentic.core.context import run_scope
+
+    fields = {
+        "benchmark": "test_benchmark",
+        "agent": "test_agent",
+        "benchmark_kwargs": {"tasks": ["task-1"]},
+        "agent_kwargs": {"policy": "good_then_finish"},
+    }
+
+    outside = RunConfig(**fields)
+    with run_scope(run_id="some-other-run", output_dir=str(tmp_path), cache_dir=str(tmp_path)):
+        inside = RunConfig(**fields)
+
+    assert inside.run_id == outside.run_id
+
+
+def test_batch_configs_get_distinct_run_ids(tmp_path):
+    """Simulate the batch flow: multiple configs in one scope must get distinct run_ids."""
+    from exgentic.core.context import run_scope
+
+    base = {"benchmark": "test_benchmark", "agent": "test_agent", "output_dir": str(tmp_path)}
+
+    configs = [
+        RunConfig(**base, agent_kwargs={"policy": "good_then_finish", "finish_after": 1}),
+        RunConfig(**base, agent_kwargs={"policy": "good_then_finish", "finish_after": 2}),
+        RunConfig(**base, agent_kwargs={"policy": "good_only"}),
+    ]
+
+    # Re-validate each config inside a run_scope bound to the first config's
+    # run_id — this mimics core_batch_evaluate entering cfg.get_context() per
+    # config while the others are still being planned / validated.
+    with run_scope(run_id=configs[0].run_id, output_dir=str(tmp_path), cache_dir=str(tmp_path)):
+        revalidated = [RunConfig.model_validate(cfg.model_dump()) for cfg in configs]
+
+    run_ids = [cfg.run_id for cfg in revalidated]
+    assert len(set(run_ids)) == len(run_ids), f"run_ids must be distinct, got {run_ids}"
+
+    # And each config's on-disk run root (output_dir/run_id) must therefore be unique.
+    run_roots = {f"{cfg.output_dir}/{cfg.run_id}" for cfg in revalidated}
+    assert len(run_roots) == len(revalidated)
 
 
 def test_has_run_options_allows_overridable_fields():


### PR DESCRIPTION
## Summary

- When a `RunConfig`/`SessionConfig` was validated without an explicit `run_id` while another run's context was active, it inherited that context's `run_id` instead of deriving its own hash from `benchmark + agent + kwargs`. In batch flows this caused sessions to land under the wrong benchmark folder tree (e.g. an appworld session written under `swebench/...`).
- Fix: remove the context fallback in `BaseEvaluationConfig._normalize`. `run_id` is meant to be a deterministic function of benchmark + agent + their kwargs — always compute it that way.
- Adds a focused regression test.

Closes #197

## Test plan

- [x] `pytest tests/api/test_api_run_config.py -xvs` — 10 passed (new test fails on main, passes with fix)
- [x] `pytest tests/api/ tests/core/` — all green