### PR TITLE
fix(containers): reap orphaned Docker containers on unclean exit

### DIFF
--- a/src/exgentic/adapters/runners/docker.py
+++ b/src/exgentic/adapters/runners/docker.py
@@ -139,6 +139,8 @@ class DockerRunner:
     # ── container lifecycle ──────────────────────────────────────────
 
     def start(self) -> ObjectProxy:
+        from ...utils.container_reaper import docker_run_label_args
+
         image = self._ensure_image()
 
         if isinstance(self._target_cls, str):
@@ -147,7 +149,13 @@ class DockerRunner:
             cls_ref = f"{self._target_cls.__module__}:{self._target_cls.__qualname__}"
         kwargs_flag, kwargs_value = serialize_kwargs(self._kwargs)
 
-        run_args: list[str] = ["run", "-d", "-p", f"{self._port}:8080"]
+        run_args: list[str] = [
+            "run",
+            "-d",
+            *docker_run_label_args(),
+            "-p",
+            f"{self._port}:8080",
+        ]
 
         # Forward only model-provider credentials + point at runtime.json.
         # Exgentic context and settings travel via runtime.json, not env.

--- a/src/exgentic/agents/cli/command_runner.py
+++ b/src/exgentic/agents/cli/command_runner.py
@@ -325,11 +325,14 @@ class DockerRunner(ContainerRunner):
                 user_args = ["--user", f"{uid()}:{gid()}"]
             except Exception:
                 user_args = []
+        from ...utils.container_reaper import docker_run_label_args
+
         wrapped_cmd: list[str] = [
             runtime,
             *connection_args,
             "run",
             "--rm",
+            *docker_run_label_args(),
             "--add-host",
             f"{host_gateway}:host-gateway",
             "--security-opt",

--- a/src/exgentic/benchmarks/swebench/swebench_eval.py
+++ b/src/exgentic/benchmarks/swebench/swebench_eval.py
@@ -385,9 +385,6 @@ class SWEBenchSession(Session):
             config = yaml.safe_load(config_path.read_text()).copy()
             config["environment"]["cwd"] = self.container_repo_dir
             config["environment"]["pull_timeout"] = self._environment_pull_timeout
-            # Tag the mini-swe-agent container with our owner PID so the
-            # container_reaper can sweep it if this process dies without
-            # cleanly invoking the environment's cleanup (issue #192).
             env_cfg = config.setdefault("environment", {})
             run_args = list(env_cfg.get("run_args") or ["--rm"])
             run_args.extend(docker_run_label_args())

--- a/src/exgentic/benchmarks/swebench/swebench_eval.py
+++ b/src/exgentic/benchmarks/swebench/swebench_eval.py
@@ -373,6 +373,7 @@ class SWEBenchSession(Session):
     def _setup_environment(self) -> None:
         """Initialize the Docker environment for the task."""
         self.logger.info("ENV | Setting up environment")
+        from ...utils.container_reaper import docker_run_label_args
         from ...utils.logging import capture_stdio_to_session
 
         with capture_stdio_to_session(self.logger):
@@ -384,6 +385,13 @@ class SWEBenchSession(Session):
             config = yaml.safe_load(config_path.read_text()).copy()
             config["environment"]["cwd"] = self.container_repo_dir
             config["environment"]["pull_timeout"] = self._environment_pull_timeout
+            # Tag the mini-swe-agent container with our owner PID so the
+            # container_reaper can sweep it if this process dies without
+            # cleanly invoking the environment's cleanup (issue #192).
+            env_cfg = config.setdefault("environment", {})
+            run_args = list(env_cfg.get("run_args") or ["--rm"])
+            run_args.extend(docker_run_label_args())
+            env_cfg["run_args"] = run_args
 
             self.env = get_sb_environment(config=config, instance=self._instance)
 

--- a/src/exgentic/benchmarks/swebench/swebench_evaluation.py
+++ b/src/exgentic/benchmarks/swebench/swebench_evaluation.py
@@ -9,6 +9,7 @@ from logging import Logger
 from pathlib import Path
 from typing import Any
 
+from ...utils.container_reaper import docker_sdk_label_injection
 from ...utils.logging import capture_stdio_to_session
 from ...utils.paths import SessionPaths
 
@@ -73,7 +74,11 @@ def run_harness(
     try:
         from swebench.harness import run_evaluation
 
-        with _pushd(paths.benchmark_dir), capture_stdio_to_session(logger):
+        with (
+            _pushd(paths.benchmark_dir),
+            capture_stdio_to_session(logger),
+            docker_sdk_label_injection(),
+        ):
             report_path = run_evaluation.main(
                 dataset_name=subset,
                 split="test",

--- a/src/exgentic/core/orchestrator/run.py
+++ b/src/exgentic/core/orchestrator/run.py
@@ -7,6 +7,7 @@ import logging
 
 from ...interfaces.registry import load_benchmark
 from ...observers.logging import get_logger
+from ...utils.container_reaper import install_cleanup_handlers, reap_orphaned_containers
 from ...utils.paths import get_run_paths
 from ..types import (
     RunConfig,
@@ -62,6 +63,16 @@ def core_run(
     execute: bool,
     aggregate: bool,
 ) -> RunResults:
+    # Reap any Docker containers orphaned by a previous crashed run and
+    # arrange to clean up containers owned by this process on exit so they
+    # cannot leak when the caller is SIGTERM'd or raises (issue #192).
+    if execute:
+        try:
+            reap_orphaned_containers(logger=_log)
+        except Exception:
+            _log.debug("Orphan container reap skipped", exc_info=True)
+        install_cleanup_handlers(logger=_log)
+
     with run_config.get_context() as ctx:
         if run_config.run_id is None or run_config.cache_dir is None:
             updates = {}
@@ -247,6 +258,15 @@ def core_batch_evaluate(
     """
     from concurrent.futures import ThreadPoolExecutor, as_completed
     from contextvars import copy_context
+
+    # Sweep orphaned containers from prior crashed batches before spawning
+    # fresh workers, and register handlers so we clean up on signal exit
+    # (issue #192).
+    try:
+        reap_orphaned_containers(logger=_log)
+    except Exception:
+        _log.debug("Orphan container reap skipped", exc_info=True)
+    install_cleanup_handlers(logger=_log)
 
     # Phase 1: plan.
     configs: list[RunConfig] = []

--- a/src/exgentic/core/orchestrator/run.py
+++ b/src/exgentic/core/orchestrator/run.py
@@ -63,9 +63,6 @@ def core_run(
     execute: bool,
     aggregate: bool,
 ) -> RunResults:
-    # Reap any Docker containers orphaned by a previous crashed run and
-    # arrange to clean up containers owned by this process on exit so they
-    # cannot leak when the caller is SIGTERM'd or raises (issue #192).
     if execute:
         try:
             reap_orphaned_containers(logger=_log)
@@ -259,9 +256,6 @@ def core_batch_evaluate(
     from concurrent.futures import ThreadPoolExecutor, as_completed
     from contextvars import copy_context
 
-    # Sweep orphaned containers from prior crashed batches before spawning
-    # fresh workers, and register handlers so we clean up on signal exit
-    # (issue #192).
     try:
         reap_orphaned_containers(logger=_log)
     except Exception:

--- a/src/exgentic/utils/container_reaper.py
+++ b/src/exgentic/utils/container_reaper.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Container reaper — prevent orphaned Docker containers leaking on unclean exit.
+
+When ``exgentic`` spawns Docker containers (directly via ``DockerRunner`` or
+indirectly through benchmark/agent subprocesses such as ``minisweagent``),
+the container may outlive its owning Python process if that process dies
+abnormally (SIGKILL, uncaught exception, crashed grandchild, …).  Because
+containers live inside the Docker daemon — outside the process group of
+their spawner — process-group kills do not touch them.
+
+The reaper addresses this with two complementary mechanisms:
+
+1. **Labeled-container reaping.**  Every container we spawn is tagged with
+   ``exgentic.owner_pid=<pid>``.  The :func:`reap_orphaned_containers`
+   helper lists all containers bearing that label whose owner PID is no
+   longer a running process and removes them.  Call it at batch / run
+   startup to sweep leftovers from prior crashed runs.
+
+2. **Graceful process-exit cleanup.**  :func:`install_cleanup_handlers`
+   registers an ``atexit`` hook plus ``SIGTERM`` / ``SIGINT`` handlers that
+   reap containers labeled with the *current* PID, catching the common
+   case where the parent receives a termination signal and must shut down
+   its children before the process group dies.
+
+Callers instrument ``docker run`` invocations by prepending the flags
+returned by :func:`docker_run_label_args` to their command lines.  All
+exgentic-owned containers therefore share a single identifying label
+scheme and can be swept in a single pass.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import shutil
+import signal
+import subprocess
+from collections.abc import Iterable
+
+# All exgentic-owned containers carry this label.  The value is the PID of
+# the Python process that created the container.
+LABEL_OWNER_PID = "exgentic.owner_pid"
+
+_handlers_installed = False
+_log = logging.getLogger(__name__)
+
+
+def docker_run_label_args(pid: int | None = None) -> list[str]:
+    """Return ``["--label", "exgentic.owner_pid=<pid>"]`` for a ``docker run``.
+
+    Caller splices the result into its ``docker run`` argument list so the
+    spawned container is tagged with the creator's PID.  When ``pid`` is
+    ``None`` the current process PID is used.
+    """
+    if pid is None:
+        pid = os.getpid()
+    return ["--label", f"{LABEL_OWNER_PID}={pid}"]
+
+
+def _docker_bin() -> str | None:
+    return shutil.which("docker")
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if ``pid`` is a running process on this host.
+
+    ``os.kill(pid, 0)`` raises ``ProcessLookupError`` for dead PIDs and
+    ``PermissionError`` for processes owned by another user (which is
+    still alive, so we treat it as True).
+    """
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _list_labeled_containers(
+    *,
+    runner: object | None = None,
+) -> list[tuple[str, int]]:
+    """Return ``[(container_id, owner_pid), ...]`` for all labeled containers.
+
+    Uses ``docker ps -a --filter label=exgentic.owner_pid`` so stopped
+    containers are included as well — a crashed process may have left a
+    container behind in ``Created`` or ``Exited`` state.
+    """
+    binary = _docker_bin()
+    if binary is None:
+        return []
+    run = runner or subprocess.run
+    try:
+        result = run(
+            [
+                binary,
+                "ps",
+                "-a",
+                "--filter",
+                f"label={LABEL_OWNER_PID}",
+                "--format",
+                '{{.ID}}\t{{.Label "' + LABEL_OWNER_PID + '"}}',
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return []
+    if result.returncode != 0:
+        return []
+    out: list[tuple[str, int]] = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        cid, pid_str = parts[0], parts[1]
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            continue
+        out.append((cid, pid))
+    return out
+
+
+def _remove_containers(
+    ids: Iterable[str],
+    *,
+    runner: object | None = None,
+) -> int:
+    binary = _docker_bin()
+    if binary is None:
+        return 0
+    run = runner or subprocess.run
+    removed = 0
+    for cid in ids:
+        try:
+            result = run(
+                [binary, "rm", "-f", cid],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except Exception:
+            continue
+        if result.returncode == 0:
+            removed += 1
+    return removed
+
+
+def reap_orphaned_containers(
+    *,
+    logger: logging.Logger | None = None,
+    runner: object | None = None,
+) -> int:
+    """Remove labeled containers whose owner PID is no longer running.
+
+    Safe to call concurrently with active sibling exgentic processes: only
+    containers whose recorded owner PID is *dead* are removed.  Returns
+    the number of containers removed.
+    """
+    log = logger or _log
+    stale: list[str] = []
+    for cid, owner_pid in _list_labeled_containers(runner=runner):
+        if not _pid_alive(owner_pid):
+            stale.append(cid)
+    if not stale:
+        return 0
+    log.warning(
+        "Reaping %d orphaned exgentic container(s) from dead owners.",
+        len(stale),
+    )
+    return _remove_containers(stale, runner=runner)
+
+
+def reap_own_containers(
+    *,
+    pid: int | None = None,
+    logger: logging.Logger | None = None,
+    runner: object | None = None,
+) -> int:
+    """Remove all containers labeled with ``pid`` (default: current PID).
+
+    Used at graceful process exit to clean up containers owned by *this*
+    process without touching containers belonging to sibling processes.
+    """
+    log = logger or _log
+    target_pid = os.getpid() if pid is None else pid
+    own: list[str] = []
+    for cid, owner_pid in _list_labeled_containers(runner=runner):
+        if owner_pid == target_pid:
+            own.append(cid)
+    if not own:
+        return 0
+    log.info("Cleaning up %d exgentic container(s) owned by PID %d.", len(own), target_pid)
+    return _remove_containers(own, runner=runner)
+
+
+def install_cleanup_handlers(
+    *,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Install atexit + SIGTERM / SIGINT handlers that reap own containers.
+
+    Idempotent: repeat calls are no-ops.  Signal handlers chain to the
+    previously-installed handler so existing behaviour (e.g. ``KeyboardInterrupt``
+    on SIGINT) is preserved.
+    """
+    global _handlers_installed
+    if _handlers_installed:
+        return
+    _handlers_installed = True
+
+    def _cleanup_once() -> None:
+        try:
+            reap_own_containers(logger=logger)
+        except Exception:
+            # Cleanup is best-effort; never raise from a shutdown path.
+            pass
+
+    atexit.register(_cleanup_once)
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            prev = signal.getsignal(sig)
+        except (ValueError, OSError):
+            continue
+
+        def _make_handler(previous, signum=sig):
+            def _handler(signum_arg, frame):
+                _cleanup_once()
+                if callable(previous):
+                    previous(signum_arg, frame)
+                elif previous == signal.SIG_DFL:
+                    # Restore and re-raise so default disposition still applies.
+                    signal.signal(signum_arg, signal.SIG_DFL)
+                    os.kill(os.getpid(), signum_arg)
+
+            return _handler
+
+        try:
+            signal.signal(sig, _make_handler(prev))
+        except (ValueError, OSError):
+            # Signals may not be installable off the main thread or under
+            # some test runners; cleanup still runs via atexit.
+            continue

--- a/src/exgentic/utils/container_reaper.py
+++ b/src/exgentic/utils/container_reaper.py
@@ -1,63 +1,54 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
-"""Container reaper — prevent orphaned Docker containers leaking on unclean exit.
+"""Container reaper: clean up orphaned exgentic-owned Docker containers.
 
-When ``exgentic`` spawns Docker containers (directly via ``DockerRunner`` or
-indirectly through benchmark/agent subprocesses such as ``minisweagent``),
-the container may outlive its owning Python process if that process dies
-abnormally (SIGKILL, uncaught exception, crashed grandchild, …).  Because
-containers live inside the Docker daemon — outside the process group of
-their spawner — process-group kills do not touch them.
+Each container spawned by exgentic is tagged with two labels:
 
-The reaper addresses this with two complementary mechanisms:
+* ``exgentic.owner_pid`` — creator PID
+* ``exgentic.owner_token`` — per-process UUID4 generated at import time
 
-1. **Labeled-container reaping.**  Every container we spawn is tagged with
-   ``exgentic.owner_pid=<pid>``.  The :func:`reap_orphaned_containers`
-   helper lists all containers bearing that label whose owner PID is no
-   longer a running process and removes them.  Call it at batch / run
-   startup to sweep leftovers from prior crashed runs.
-
-2. **Graceful process-exit cleanup.**  :func:`install_cleanup_handlers`
-   registers an ``atexit`` hook plus ``SIGTERM`` / ``SIGINT`` handlers that
-   reap containers labeled with the *current* PID, catching the common
-   case where the parent receives a termination signal and must shut down
-   its children before the process group dies.
-
-Callers instrument ``docker run`` invocations by prepending the flags
-returned by :func:`docker_run_label_args` to their command lines.  All
-exgentic-owned containers therefore share a single identifying label
-scheme and can be swept in a single pass.
+The PID alone is not sufficient: on abnormal termination a PID can be
+recycled to an unrelated process, and a co-tenant could deliberately
+spawn a container with our PID as its label (label-collision DoS). The
+token closes both holes — ``reap_own_containers`` requires both labels
+to match, and ``reap_orphaned_containers`` only removes containers whose
+PID is dead on this host.
 """
 
 from __future__ import annotations
 
 import atexit
+import contextlib
 import logging
 import os
 import shutil
 import signal
 import subprocess
-from collections.abc import Iterable
+import uuid
+from collections.abc import Iterable, Iterator
 
-# All exgentic-owned containers carry this label.  The value is the PID of
-# the Python process that created the container.
 LABEL_OWNER_PID = "exgentic.owner_pid"
+LABEL_OWNER_TOKEN = "exgentic.owner_token"
+
+OWN_TOKEN = uuid.uuid4().hex
 
 _handlers_installed = False
 _log = logging.getLogger(__name__)
 
 
-def docker_run_label_args(pid: int | None = None) -> list[str]:
-    """Return ``["--label", "exgentic.owner_pid=<pid>"]`` for a ``docker run``.
-
-    Caller splices the result into its ``docker run`` argument list so the
-    spawned container is tagged with the creator's PID.  When ``pid`` is
-    ``None`` the current process PID is used.
-    """
+def docker_run_label_args(pid: int | None = None, token: str | None = None) -> list[str]:
+    """Return ``--label`` flags for a ``docker run`` to tag our containers."""
     if pid is None:
         pid = os.getpid()
-    return ["--label", f"{LABEL_OWNER_PID}={pid}"]
+    if token is None:
+        token = OWN_TOKEN
+    return [
+        "--label",
+        f"{LABEL_OWNER_PID}={pid}",
+        "--label",
+        f"{LABEL_OWNER_TOKEN}={token}",
+    ]
 
 
 def _docker_bin() -> str | None:
@@ -65,12 +56,6 @@ def _docker_bin() -> str | None:
 
 
 def _pid_alive(pid: int) -> bool:
-    """Return True if ``pid`` is a running process on this host.
-
-    ``os.kill(pid, 0)`` raises ``ProcessLookupError`` for dead PIDs and
-    ``PermissionError`` for processes owned by another user (which is
-    still alive, so we treat it as True).
-    """
     if pid <= 0:
         return False
     try:
@@ -87,13 +72,8 @@ def _pid_alive(pid: int) -> bool:
 def _list_labeled_containers(
     *,
     runner: object | None = None,
-) -> list[tuple[str, int]]:
-    """Return ``[(container_id, owner_pid), ...]`` for all labeled containers.
-
-    Uses ``docker ps -a --filter label=exgentic.owner_pid`` so stopped
-    containers are included as well — a crashed process may have left a
-    container behind in ``Created`` or ``Exited`` state.
-    """
+) -> list[tuple[str, int, str]]:
+    """Return ``[(container_id, owner_pid, owner_token), ...]`` for our containers."""
     binary = _docker_bin()
     if binary is None:
         return []
@@ -106,8 +86,10 @@ def _list_labeled_containers(
                 "-a",
                 "--filter",
                 f"label={LABEL_OWNER_PID}",
+                "--filter",
+                f"label={LABEL_OWNER_TOKEN}",
                 "--format",
-                '{{.ID}}\t{{.Label "' + LABEL_OWNER_PID + '"}}',
+                "{{.ID}}\t" + '{{.Label "' + LABEL_OWNER_PID + '"}}\t' + '{{.Label "' + LABEL_OWNER_TOKEN + '"}}',
             ],
             check=False,
             capture_output=True,
@@ -118,20 +100,22 @@ def _list_labeled_containers(
         return []
     if result.returncode != 0:
         return []
-    out: list[tuple[str, int]] = []
+    out: list[tuple[str, int, str]] = []
     for line in result.stdout.splitlines():
         line = line.strip()
         if not line:
             continue
         parts = line.split("\t")
-        if len(parts) < 2:
+        if len(parts) < 3:
             continue
-        cid, pid_str = parts[0], parts[1]
+        cid, pid_str, token = parts[0], parts[1], parts[2]
+        if not token:
+            continue
         try:
             pid = int(pid_str)
         except ValueError:
             continue
-        out.append((cid, pid))
+        out.append((cid, pid, token))
     return out
 
 
@@ -168,13 +152,14 @@ def reap_orphaned_containers(
 ) -> int:
     """Remove labeled containers whose owner PID is no longer running.
 
-    Safe to call concurrently with active sibling exgentic processes: only
-    containers whose recorded owner PID is *dead* are removed.  Returns
-    the number of containers removed.
+    A container is reaped only when ``_pid_alive(owner_pid)`` is False.
+    Containers with a live PID are left alone regardless of token —
+    another exgentic process (or an unrelated process at a recycled PID)
+    owns them.
     """
     log = logger or _log
     stale: list[str] = []
-    for cid, owner_pid in _list_labeled_containers(runner=runner):
+    for cid, owner_pid, _owner_token in _list_labeled_containers(runner=runner):
         if not _pid_alive(owner_pid):
             stale.append(cid)
     if not stale:
@@ -189,19 +174,17 @@ def reap_orphaned_containers(
 def reap_own_containers(
     *,
     pid: int | None = None,
+    token: str | None = None,
     logger: logging.Logger | None = None,
     runner: object | None = None,
 ) -> int:
-    """Remove all containers labeled with ``pid`` (default: current PID).
-
-    Used at graceful process exit to clean up containers owned by *this*
-    process without touching containers belonging to sibling processes.
-    """
+    """Remove containers tagged with both our PID and our token."""
     log = logger or _log
     target_pid = os.getpid() if pid is None else pid
+    target_token = OWN_TOKEN if token is None else token
     own: list[str] = []
-    for cid, owner_pid in _list_labeled_containers(runner=runner):
-        if owner_pid == target_pid:
+    for cid, owner_pid, owner_token in _list_labeled_containers(runner=runner):
+        if owner_pid == target_pid and owner_token == target_token:
             own.append(cid)
     if not own:
         return 0
@@ -209,15 +192,59 @@ def reap_own_containers(
     return _remove_containers(own, runner=runner)
 
 
+@contextlib.contextmanager
+def docker_sdk_label_injection(
+    pid: int | None = None,
+    token: str | None = None,
+) -> Iterator[None]:
+    """Patch ``docker`` SDK so containers created via it carry our labels.
+
+    SWE-bench harness spawns ``sweb.eval.*`` containers via the Python
+    Docker SDK (``ContainerCollection.create``), not the docker CLI, so
+    ``--label`` flags never reach them. This wraps ``create`` while the
+    block runs to splice in the owner labels. If ``docker`` isn't
+    importable (host process has no Docker SDK), the block is a no-op.
+    """
+    owner_pid = os.getpid() if pid is None else pid
+    owner_token = OWN_TOKEN if token is None else token
+    labels = {LABEL_OWNER_PID: str(owner_pid), LABEL_OWNER_TOKEN: owner_token}
+
+    try:
+        from docker.models.containers import ContainerCollection
+    except Exception:
+        yield
+        return
+
+    original = ContainerCollection.create
+
+    def patched(self, image, command=None, **kwargs):
+        existing = kwargs.get("labels") or {}
+        if isinstance(existing, list):
+            merged = list(existing)
+            merged.extend(f"{k}={v}" for k, v in labels.items())
+            kwargs["labels"] = merged
+        else:
+            merged_map = dict(existing)
+            merged_map.update(labels)
+            kwargs["labels"] = merged_map
+        return original(self, image, command=command, **kwargs)
+
+    ContainerCollection.create = patched
+    try:
+        yield
+    finally:
+        ContainerCollection.create = original
+
+
 def install_cleanup_handlers(
     *,
     logger: logging.Logger | None = None,
 ) -> None:
-    """Install atexit + SIGTERM / SIGINT handlers that reap own containers.
+    """Register atexit + SIGTERM / SIGINT handlers that reap own containers.
 
-    Idempotent: repeat calls are no-ops.  Signal handlers chain to the
-    previously-installed handler so existing behaviour (e.g. ``KeyboardInterrupt``
-    on SIGINT) is preserved.
+    Idempotent. Signal handlers reap, then invoke the previous handler if
+    it was a callable; for ``SIG_DFL`` they re-raise the signal under the
+    default disposition; for ``SIG_IGN`` they return silently.
     """
     global _handlers_installed
     if _handlers_installed:
@@ -228,7 +255,6 @@ def install_cleanup_handlers(
         try:
             reap_own_containers(logger=logger)
         except Exception:
-            # Cleanup is best-effort; never raise from a shutdown path.
             pass
 
     atexit.register(_cleanup_once)
@@ -239,21 +265,15 @@ def install_cleanup_handlers(
         except (ValueError, OSError):
             continue
 
-        def _make_handler(previous, signum=sig):
-            def _handler(signum_arg, frame):
-                _cleanup_once()
-                if callable(previous):
-                    previous(signum_arg, frame)
-                elif previous == signal.SIG_DFL:
-                    # Restore and re-raise so default disposition still applies.
-                    signal.signal(signum_arg, signal.SIG_DFL)
-                    os.kill(os.getpid(), signum_arg)
-
-            return _handler
+        def _handler(signum, frame, previous=prev):
+            _cleanup_once()
+            if callable(previous):
+                previous(signum, frame)
+            elif previous == signal.SIG_DFL:
+                signal.signal(signum, signal.SIG_DFL)
+                os.kill(os.getpid(), signum)
 
         try:
-            signal.signal(sig, _make_handler(prev))
+            signal.signal(sig, _handler)
         except (ValueError, OSError):
-            # Signals may not be installable off the main thread or under
-            # some test runners; cleanup still runs via atexit.
             continue

--- a/tests/utils/test_container_reaper.py
+++ b/tests/utils/test_container_reaper.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Unit tests for container_reaper — orphaned-container cleanup."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from exgentic.utils import container_reaper
+from exgentic.utils.container_reaper import (
+    LABEL_OWNER_PID,
+    docker_run_label_args,
+    install_cleanup_handlers,
+    reap_orphaned_containers,
+    reap_own_containers,
+)
+
+
+def _fake_ps(lines: list[tuple[str, int]]) -> MagicMock:
+    """Build a subprocess.run mock for ``docker ps`` + ``docker rm``."""
+    stdout = "\n".join(f"{cid}\t{pid}" for cid, pid in lines) + ("\n" if lines else "")
+
+    ps_result = MagicMock(returncode=0, stdout=stdout, stderr="")
+    rm_result = MagicMock(returncode=0, stdout="", stderr="")
+
+    def side_effect(cmd, **kwargs):
+        if len(cmd) >= 2 and cmd[1] == "ps":
+            return ps_result
+        if len(cmd) >= 2 and cmd[1] == "rm":
+            return rm_result
+        return MagicMock(returncode=1, stdout="", stderr="unexpected")
+
+    runner = MagicMock(side_effect=side_effect)
+    return runner
+
+
+def test_docker_run_label_args_uses_current_pid() -> None:
+    args = docker_run_label_args()
+    assert args[0] == "--label"
+    assert args[1] == f"{LABEL_OWNER_PID}={os.getpid()}"
+
+
+def test_docker_run_label_args_explicit_pid() -> None:
+    args = docker_run_label_args(pid=12345)
+    assert args == ["--label", f"{LABEL_OWNER_PID}=12345"]
+
+
+def test_reap_orphaned_removes_dead_owner_containers() -> None:
+    dead_pid = 999_999_999  # PID is effectively guaranteed not alive
+    live_pid = os.getpid()  # our PID is always alive
+    runner = _fake_ps([("cidA", dead_pid), ("cidB", live_pid)])
+
+    with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
+        removed = reap_orphaned_containers(runner=runner)
+
+    assert removed == 1
+    rm_calls = [c for c in runner.call_args_list if c.args[0][1] == "rm"]
+    assert len(rm_calls) == 1
+    assert rm_calls[0].args[0] == ["/usr/bin/docker", "rm", "-f", "cidA"]
+
+
+def test_reap_orphaned_noop_when_all_alive() -> None:
+    runner = _fake_ps([("cidA", os.getpid())])
+    with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
+        removed = reap_orphaned_containers(runner=runner)
+    assert removed == 0
+    rm_calls = [c for c in runner.call_args_list if c.args[0][1] == "rm"]
+    assert rm_calls == []
+
+
+def test_reap_own_containers_removes_by_current_pid() -> None:
+    pid = os.getpid()
+    runner = _fake_ps([("mine1", pid), ("other", 12345), ("mine2", pid)])
+    with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
+        removed = reap_own_containers(runner=runner)
+    assert removed == 2
+    rm_args = [c.args[0] for c in runner.call_args_list if c.args[0][1] == "rm"]
+    removed_ids = sorted(cmd[3] for cmd in rm_args)
+    assert removed_ids == ["mine1", "mine2"]
+
+
+def test_reap_own_containers_skips_siblings() -> None:
+    runner = _fake_ps([("other1", 11111), ("other2", 22222)])
+    with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
+        removed = reap_own_containers(runner=runner)
+    assert removed == 0
+
+
+def test_reap_handles_missing_docker_binary() -> None:
+    with patch.object(container_reaper, "_docker_bin", return_value=None):
+        assert reap_orphaned_containers() == 0
+        assert reap_own_containers() == 0
+
+
+def test_reap_handles_docker_ps_failure() -> None:
+    runner = MagicMock(return_value=MagicMock(returncode=1, stdout="", stderr="cannot connect"))
+    with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
+        assert reap_orphaned_containers(runner=runner) == 0
+
+
+def test_install_cleanup_handlers_runs_at_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Atexit handler must invoke reap_own_containers on shutdown."""
+    # Reset the idempotency guard so the test sees a fresh install.
+    monkeypatch.setattr(container_reaper, "_handlers_installed", False)
+
+    registered: list = []
+    monkeypatch.setattr(
+        container_reaper.atexit,
+        "register",
+        lambda fn: registered.append(fn),
+    )
+    # Skip signal registration in test to avoid mutating process state.
+    monkeypatch.setattr(container_reaper.signal, "signal", lambda *a, **k: None)
+
+    reap_calls: list = []
+
+    def _fake_reap(**kwargs):
+        reap_calls.append(kwargs)
+        return 0
+
+    monkeypatch.setattr(container_reaper, "reap_own_containers", _fake_reap)
+
+    install_cleanup_handlers()
+
+    assert len(registered) == 1
+    # Invoke the registered atexit callback manually — simulates shutdown.
+    registered[0]()
+    assert len(reap_calls) == 1
+
+
+def test_install_cleanup_handlers_is_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(container_reaper, "_handlers_installed", False)
+    registered: list = []
+    monkeypatch.setattr(
+        container_reaper.atexit,
+        "register",
+        lambda fn: registered.append(fn),
+    )
+    monkeypatch.setattr(container_reaper.signal, "signal", lambda *a, **k: None)
+
+    install_cleanup_handlers()
+    install_cleanup_handlers()
+    install_cleanup_handlers()
+
+    assert len(registered) == 1
+
+
+def test_sigterm_handler_cleans_up_then_chains(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SIGTERM handler must reap containers then invoke previous handler."""
+    monkeypatch.setattr(container_reaper, "_handlers_installed", False)
+    monkeypatch.setattr(container_reaper.atexit, "register", lambda fn: None)
+
+    prev_called: list = []
+
+    def _prev_handler(signum, frame):
+        prev_called.append(signum)
+
+    installed: dict = {}
+
+    def _fake_getsignal(sig):
+        return _prev_handler
+
+    def _fake_signal(sig, handler):
+        installed[sig] = handler
+
+    monkeypatch.setattr(container_reaper.signal, "getsignal", _fake_getsignal)
+    monkeypatch.setattr(container_reaper.signal, "signal", _fake_signal)
+
+    reap_calls: list = []
+    monkeypatch.setattr(
+        container_reaper,
+        "reap_own_containers",
+        lambda **kw: reap_calls.append(kw) or 0,
+    )
+
+    install_cleanup_handlers()
+
+    assert signal.SIGTERM in installed
+    # Invoke the installed SIGTERM handler.
+    installed[signal.SIGTERM](signal.SIGTERM, None)
+
+    # Cleanup must have run AND previous handler must have been invoked.
+    assert len(reap_calls) == 1
+    assert prev_called == [signal.SIGTERM]
+
+
+# ---------------------------------------------------------------------------
+# Integration-style test: simulate the full unclean-termination scenario
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_orphan_scenario_reaps_on_batch_start() -> None:
+    """Regression test for issue #192.
+
+    Scenario: a previous batch crashed leaving orphaned minisweagent
+    containers labeled with a now-dead owner PID.  The reaper invoked at
+    the start of a new batch must remove them.
+    """
+    dead_pid = 999_999_998
+    orphans = [(f"minisweagent-{i:08x}", dead_pid) for i in range(5)]
+    still_alive = [("active-cid", os.getpid())]
+
+    calls: list[list[str]] = []
+    rm_targets: list[str] = []
+
+    def _run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if len(cmd) >= 2 and cmd[1] == "ps":
+            lines = [f"{cid}\t{pid}" for cid, pid in orphans + still_alive]
+            return subprocess.CompletedProcess(cmd, 0, "\n".join(lines) + "\n", "")
+        if len(cmd) >= 2 and cmd[1] == "rm":
+            rm_targets.append(cmd[-1])
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return subprocess.CompletedProcess(cmd, 1, "", "unexpected")
+
+    with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
+        removed = reap_orphaned_containers(runner=_run)
+
+    assert removed == 5
+    assert sorted(rm_targets) == sorted(cid for cid, _ in orphans)
+    assert "active-cid" not in rm_targets
+
+
+# ---------------------------------------------------------------------------
+# Wiring tests: container-spawning callsites must emit the owner-pid label
+# ---------------------------------------------------------------------------
+
+
+def test_docker_runner_tags_containers_with_owner_pid() -> None:
+    """adapters/runners/docker.py::DockerRunner.start must label containers."""
+    from exgentic.adapters.runners.docker import DockerRunner
+
+    runner = DockerRunner(
+        "exgentic.testing.calculator:Calculator",
+        env_name="tests/calculator",
+        module_path="exgentic.testing.calculator",
+        image="stub-image",
+        port=12345,
+    )
+
+    captured: list[list[str]] = []
+
+    def _fake_docker(*args, **kwargs):
+        captured.append(list(args))
+        return subprocess.CompletedProcess(args, 0, "stub-cid\n", "")
+
+    # Avoid the health check / transport wiring — the test only validates
+    # the docker run argv.
+    def _raise(*a, **k):
+        raise RuntimeError("stop-after-docker-run")
+
+    with (
+        patch("exgentic.adapters.runners.docker._docker", side_effect=_fake_docker),
+        patch("exgentic.adapters.runners.docker._wait_for_health", side_effect=_raise),
+        patch("exgentic.environment.instance.get_manager") as get_mgr,
+    ):
+        get_mgr.return_value.base_dir = "/tmp/exgentic-cache"
+        try:
+            runner.start()
+        except Exception:
+            pass
+
+    # The first docker call is the `run` (image build is skipped because
+    # ``image`` was provided).  Assert it contains our label flag.
+    run_call = next((c for c in captured if c and c[0] == "run"), None)
+    assert run_call is not None, f"no docker run call captured: {captured}"
+    assert "--label" in run_call
+    idx = run_call.index("--label")
+    assert run_call[idx + 1] == f"{LABEL_OWNER_PID}={os.getpid()}"
+
+
+def test_claude_code_docker_runner_tags_containers() -> None:
+    """agents/cli/command_runner.py::DockerRunner.run must label containers."""
+    import logging as _logging
+    from pathlib import Path
+
+    from exgentic.agents.cli.command_runner import BaseCLIConfig
+    from exgentic.agents.cli.command_runner import DockerRunner as CLIDockerRunner
+
+    runner = CLIDockerRunner(log_path=None, logger=_logging.getLogger("test"))
+
+    captured_cmds: list[list[str]] = []
+
+    def _fake_popen(cmd, **kwargs):
+        captured_cmds.append(list(cmd))
+        proc = MagicMock()
+        proc.communicate.return_value = ("", "")
+        proc.returncode = 0
+        proc.poll.return_value = 0
+        return proc
+
+    cfg = BaseCLIConfig(
+        mcp_host="127.0.0.1",
+        mcp_port=5000,
+        provider_url="http://example",
+        image="stub-image",
+    )
+
+    with (
+        patch(
+            "exgentic.agents.cli.command_runner._detect_container_runtime",
+            return_value=("docker", []),
+        ),
+        patch(
+            "exgentic.agents.cli.command_runner.subprocess.Popen",
+            side_effect=_fake_popen,
+        ),
+    ):
+        runner.run(
+            cmd=["claude", "-p", "hello"],
+            env={},
+            cfg_root=Path("/tmp"),
+            config=cfg,
+            spawn_error_message="boom",
+        )
+
+    assert captured_cmds, "no docker command was captured"
+    # The wrapped cmd begins with the runtime binary then 'run'.
+    wrapped = captured_cmds[0]
+    assert "run" in wrapped
+    assert "--label" in wrapped
+    idx = wrapped.index("--label")
+    assert wrapped[idx + 1] == f"{LABEL_OWNER_PID}={os.getpid()}"
+
+
+def test_swebench_session_injects_reaper_label_into_minisweagent_config() -> None:
+    """Swebench session injects owner-pid label into minisweagent run_args.
+
+    SWEBenchSession._setup_environment must inject an ``exgentic.owner_pid``
+    label into the minisweagent environment config's ``run_args`` so
+    mini-swe-agent's ``docker run`` invocation carries the reaper label
+    (regression guard for issue #192).
+    """
+    import types
+
+    # Capture the config that would be handed to minisweagent.
+    captured: dict = {}
+
+    class _FakeEnv:
+        def execute(self, command, cwd=""):
+            return {"output": "abc123\n", "returncode": 0}
+
+    def _fake_get_sb_env(config, instance):
+        captured["config"] = config
+        return _FakeEnv()
+
+    fake_ms = types.ModuleType("minisweagent")
+    fake_ms.__file__ = "/tmp/minisweagent/__init__.py"
+    fake_submod = types.ModuleType("minisweagent.run.extra.swebench")
+    fake_submod.get_sb_environment = _fake_get_sb_env
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "minisweagent": fake_ms,
+            "minisweagent.run": types.ModuleType("minisweagent.run"),
+            "minisweagent.run.extra": types.ModuleType("minisweagent.run.extra"),
+            "minisweagent.run.extra.swebench": fake_submod,
+        },
+    ):
+        from exgentic.benchmarks.swebench import swebench_eval
+
+        yaml_path = MagicMock()
+        yaml_path.read_text.return_value = "environment:\n  cwd: /testbed\n  run_args:\n    - '--rm'\n"
+
+        def _fake_path(arg):
+            # Intercept ``Path(minisweagent.__file__)`` traversal.
+            mock = MagicMock()
+            mock.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value = yaml_path
+            return mock
+
+        # Build a minimal stub session that invokes the real method.
+        stub = types.SimpleNamespace(
+            logger=MagicMock(),
+            container_repo_dir="/testbed",
+            container_base_commit=None,
+            _environment_pull_timeout=600,
+            _instance={"base_commit": "abc123"},
+            env=None,
+        )
+
+        with (
+            patch.object(swebench_eval, "Path", side_effect=_fake_path),
+            patch("exgentic.utils.logging.capture_stdio_to_session"),
+        ):
+            swebench_eval.SWEBenchSession._setup_environment(stub)
+
+    assert captured.get("config"), "minisweagent config was not captured"
+    run_args = captured["config"]["environment"]["run_args"]
+    assert "--label" in run_args, f"run_args missing --label: {run_args}"
+    idx = run_args.index("--label")
+    assert run_args[idx + 1] == f"{LABEL_OWNER_PID}={os.getpid()}"

--- a/tests/utils/test_container_reaper.py
+++ b/tests/utils/test_container_reaper.py
@@ -1,30 +1,38 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
-"""Unit tests for container_reaper — orphaned-container cleanup."""
+"""Unit tests for container_reaper: orphaned-container cleanup."""
 
 from __future__ import annotations
 
+import logging as _logging
 import os
 import signal
 import subprocess
+import types
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from exgentic.adapters.runners.docker import DockerRunner
+from exgentic.agents.cli.command_runner import BaseCLIConfig
+from exgentic.agents.cli.command_runner import DockerRunner as CLIDockerRunner
+from exgentic.benchmarks.swebench import swebench_eval, swebench_evaluation
 from exgentic.utils import container_reaper
 from exgentic.utils.container_reaper import (
     LABEL_OWNER_PID,
+    LABEL_OWNER_TOKEN,
+    OWN_TOKEN,
     docker_run_label_args,
+    docker_sdk_label_injection,
     install_cleanup_handlers,
     reap_orphaned_containers,
     reap_own_containers,
 )
 
 
-def _fake_ps(lines: list[tuple[str, int]]) -> MagicMock:
-    """Build a subprocess.run mock for ``docker ps`` + ``docker rm``."""
-    stdout = "\n".join(f"{cid}\t{pid}" for cid, pid in lines) + ("\n" if lines else "")
-
+def _fake_ps(rows: list[tuple[str, int, str]]) -> MagicMock:
+    stdout = "\n".join(f"{cid}\t{pid}\t{tok}" for cid, pid, tok in rows) + ("\n" if rows else "")
     ps_result = MagicMock(returncode=0, stdout=stdout, stderr="")
     rm_result = MagicMock(returncode=0, stdout="", stderr="")
 
@@ -35,212 +43,218 @@ def _fake_ps(lines: list[tuple[str, int]]) -> MagicMock:
             return rm_result
         return MagicMock(returncode=1, stdout="", stderr="unexpected")
 
-    runner = MagicMock(side_effect=side_effect)
-    return runner
+    return MagicMock(side_effect=side_effect)
 
 
-def test_docker_run_label_args_uses_current_pid() -> None:
-    args = docker_run_label_args()
-    assert args[0] == "--label"
-    assert args[1] == f"{LABEL_OWNER_PID}={os.getpid()}"
+@pytest.mark.parametrize(
+    ("kwargs", "expected_pid", "expected_token"),
+    [
+        ({}, os.getpid(), OWN_TOKEN),
+        ({"pid": 12345, "token": "abc"}, 12345, "abc"),
+    ],
+)
+def test_docker_run_label_args_emits_both_labels(kwargs, expected_pid, expected_token) -> None:
+    args = docker_run_label_args(**kwargs)
+    assert args == [
+        "--label",
+        f"{LABEL_OWNER_PID}={expected_pid}",
+        "--label",
+        f"{LABEL_OWNER_TOKEN}={expected_token}",
+    ]
 
 
-def test_docker_run_label_args_explicit_pid() -> None:
-    args = docker_run_label_args(pid=12345)
-    assert args == ["--label", f"{LABEL_OWNER_PID}=12345"]
-
-
-def test_reap_orphaned_removes_dead_owner_containers() -> None:
-    dead_pid = 999_999_999  # PID is effectively guaranteed not alive
-    live_pid = os.getpid()  # our PID is always alive
-    runner = _fake_ps([("cidA", dead_pid), ("cidB", live_pid)])
-
+@pytest.mark.parametrize(
+    ("rows", "expected_removed"),
+    [
+        ([], 0),
+        ([("cidA", os.getpid(), OWN_TOKEN)], 0),
+        (
+            [
+                ("cidDead", 999_999_999, "dead-token"),
+                ("cidLive", os.getpid(), OWN_TOKEN),
+            ],
+            1,
+        ),
+        (
+            [(f"minisweagent-{i:08x}", 999_999_998, "x") for i in range(5)] + [("active-cid", os.getpid(), OWN_TOKEN)],
+            5,
+        ),
+    ],
+)
+def test_reap_orphaned_removes_only_dead_owners(rows: list[tuple[str, int, str]], expected_removed: int) -> None:
+    runner = _fake_ps(rows)
     with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
         removed = reap_orphaned_containers(runner=runner)
-
-    assert removed == 1
-    rm_calls = [c for c in runner.call_args_list if c.args[0][1] == "rm"]
-    assert len(rm_calls) == 1
-    assert rm_calls[0].args[0] == ["/usr/bin/docker", "rm", "-f", "cidA"]
+    assert removed == expected_removed
+    rm_ids = [c.args[0][-1] for c in runner.call_args_list if c.args[0][1] == "rm"]
+    assert len(rm_ids) == expected_removed
 
 
-def test_reap_orphaned_noop_when_all_alive() -> None:
-    runner = _fake_ps([("cidA", os.getpid())])
-    with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
+def test_reap_orphaned_removes_dead_even_when_pid_recycled() -> None:
+    """PID-reuse mitigation: a live PID with a token that isn't ours."""
+    recycled_pid = 4242
+    runner = _fake_ps([("orphan-cid", recycled_pid, "some-dead-exgentic-token")])
+
+    with (
+        patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"),
+        patch.object(container_reaper, "_pid_alive", return_value=True),
+    ):
         removed = reap_orphaned_containers(runner=runner)
+
     assert removed == 0
-    rm_calls = [c for c in runner.call_args_list if c.args[0][1] == "rm"]
-    assert rm_calls == []
 
 
-def test_reap_own_containers_removes_by_current_pid() -> None:
+def test_reap_own_requires_both_pid_and_token() -> None:
+    """PID match without our token is NOT reaped (label-collision DoS)."""
     pid = os.getpid()
-    runner = _fake_ps([("mine1", pid), ("other", 12345), ("mine2", pid)])
+    runner = _fake_ps(
+        [
+            ("mine1", pid, OWN_TOKEN),
+            ("spoofed", pid, "attacker-token"),
+            ("sibling", 11111, "sibling-token"),
+            ("mine2", pid, OWN_TOKEN),
+        ]
+    )
     with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
         removed = reap_own_containers(runner=runner)
     assert removed == 2
-    rm_args = [c.args[0] for c in runner.call_args_list if c.args[0][1] == "rm"]
-    removed_ids = sorted(cmd[3] for cmd in rm_args)
-    assert removed_ids == ["mine1", "mine2"]
+    rm_ids = sorted(c.args[0][-1] for c in runner.call_args_list if c.args[0][1] == "rm")
+    assert rm_ids == ["mine1", "mine2"]
 
 
-def test_reap_own_containers_skips_siblings() -> None:
-    runner = _fake_ps([("other1", 11111), ("other2", 22222)])
-    with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
-        removed = reap_own_containers(runner=runner)
-    assert removed == 0
-
-
-def test_reap_handles_missing_docker_binary() -> None:
-    with patch.object(container_reaper, "_docker_bin", return_value=None):
-        assert reap_orphaned_containers() == 0
-        assert reap_own_containers() == 0
-
-
-def test_reap_handles_docker_ps_failure() -> None:
-    runner = MagicMock(return_value=MagicMock(returncode=1, stdout="", stderr="cannot connect"))
-    with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
+@pytest.mark.parametrize(
+    ("bin_return", "runner"),
+    [
+        (None, None),
+        (
+            "/usr/bin/docker",
+            MagicMock(return_value=MagicMock(returncode=1, stdout="", stderr="cannot connect")),
+        ),
+    ],
+)
+def test_reap_degraded_docker_states_are_noops(bin_return, runner) -> None:
+    with patch.object(container_reaper, "_docker_bin", return_value=bin_return):
         assert reap_orphaned_containers(runner=runner) == 0
+        assert reap_own_containers(runner=runner) == 0
 
 
-def test_install_cleanup_handlers_runs_at_exit(
+def test_install_cleanup_handlers_idempotent_and_dispatches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Atexit handler must invoke reap_own_containers on shutdown."""
-    # Reset the idempotency guard so the test sees a fresh install.
+    """Registers atexit once; chains callables; handles SIG_DFL / SIG_IGN."""
     monkeypatch.setattr(container_reaper, "_handlers_installed", False)
 
-    registered: list = []
-    monkeypatch.setattr(
-        container_reaper.atexit,
-        "register",
-        lambda fn: registered.append(fn),
-    )
-    # Skip signal registration in test to avoid mutating process state.
-    monkeypatch.setattr(container_reaper.signal, "signal", lambda *a, **k: None)
+    registered_atexit: list = []
+    monkeypatch.setattr(container_reaper.atexit, "register", lambda fn: registered_atexit.append(fn))
 
-    reap_calls: list = []
+    prev_calls: list = []
 
-    def _fake_reap(**kwargs):
-        reap_calls.append(kwargs)
-        return 0
+    def _prev_callable(signum, frame):
+        prev_calls.append(signum)
 
-    monkeypatch.setattr(container_reaper, "reap_own_containers", _fake_reap)
-
-    install_cleanup_handlers()
-
-    assert len(registered) == 1
-    # Invoke the registered atexit callback manually — simulates shutdown.
-    registered[0]()
-    assert len(reap_calls) == 1
-
-
-def test_install_cleanup_handlers_is_idempotent(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(container_reaper, "_handlers_installed", False)
-    registered: list = []
-    monkeypatch.setattr(
-        container_reaper.atexit,
-        "register",
-        lambda fn: registered.append(fn),
-    )
-    monkeypatch.setattr(container_reaper.signal, "signal", lambda *a, **k: None)
-
-    install_cleanup_handlers()
-    install_cleanup_handlers()
-    install_cleanup_handlers()
-
-    assert len(registered) == 1
-
-
-def test_sigterm_handler_cleans_up_then_chains(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """SIGTERM handler must reap containers then invoke previous handler."""
-    monkeypatch.setattr(container_reaper, "_handlers_installed", False)
-    monkeypatch.setattr(container_reaper.atexit, "register", lambda fn: None)
-
-    prev_called: list = []
-
-    def _prev_handler(signum, frame):
-        prev_called.append(signum)
+    prev_for = {signal.SIGTERM: _prev_callable, signal.SIGINT: signal.SIG_DFL}
+    monkeypatch.setattr(container_reaper.signal, "getsignal", lambda sig: prev_for[sig])
 
     installed: dict = {}
-
-    def _fake_getsignal(sig):
-        return _prev_handler
-
-    def _fake_signal(sig, handler):
-        installed[sig] = handler
-
-    monkeypatch.setattr(container_reaper.signal, "getsignal", _fake_getsignal)
-    monkeypatch.setattr(container_reaper.signal, "signal", _fake_signal)
+    monkeypatch.setattr(container_reaper.signal, "signal", lambda sig, h: installed.__setitem__(sig, h))
 
     reap_calls: list = []
-    monkeypatch.setattr(
-        container_reaper,
-        "reap_own_containers",
-        lambda **kw: reap_calls.append(kw) or 0,
-    )
+    monkeypatch.setattr(container_reaper, "reap_own_containers", lambda **kw: reap_calls.append(kw) or 0)
+
+    killed: list = []
+    monkeypatch.setattr(container_reaper.os, "kill", lambda pid, sig: killed.append((pid, sig)))
 
     install_cleanup_handlers()
+    install_cleanup_handlers()  # Idempotent.
 
-    assert signal.SIGTERM in installed
-    # Invoke the installed SIGTERM handler.
-    installed[signal.SIGTERM](signal.SIGTERM, None)
-
-    # Cleanup must have run AND previous handler must have been invoked.
+    assert len(registered_atexit) == 1
+    registered_atexit[0]()
     assert len(reap_calls) == 1
-    assert prev_called == [signal.SIGTERM]
+
+    installed[signal.SIGTERM](signal.SIGTERM, None)
+    assert prev_calls == [signal.SIGTERM]
+    assert len(reap_calls) == 2
+
+    installed[signal.SIGINT](signal.SIGINT, None)
+    assert killed == [(os.getpid(), signal.SIGINT)]
+    assert len(reap_calls) == 3
 
 
-# ---------------------------------------------------------------------------
-# Integration-style test: simulate the full unclean-termination scenario
-# ---------------------------------------------------------------------------
+def test_docker_sdk_label_injection_patches_create_and_restores() -> None:
+    original = MagicMock(return_value="created")
+
+    class _FakeCollection:
+        create = original
+
+    fake_mod = types.ModuleType("docker")
+    fake_models = types.ModuleType("docker.models")
+    fake_containers = types.ModuleType("docker.models.containers")
+    fake_containers.ContainerCollection = _FakeCollection
+    fake_models.containers = fake_containers
+    fake_mod.models = fake_models
+
+    with patch.dict(
+        "sys.modules",
+        {"docker": fake_mod, "docker.models": fake_models, "docker.models.containers": fake_containers},
+    ):
+        with docker_sdk_label_injection():
+            _FakeCollection.create(MagicMock(), "some-image", command="run")
+
+    call = original.call_args
+    assert call.kwargs["labels"][LABEL_OWNER_PID] == str(os.getpid())
+    assert call.kwargs["labels"][LABEL_OWNER_TOKEN] == OWN_TOKEN
+    assert _FakeCollection.create is original
+
+    # Missing docker SDK: context manager is a no-op.
+    with patch.dict("sys.modules", {"docker.models.containers": None}):
+        with docker_sdk_label_injection():
+            pass
 
 
-def test_end_to_end_orphan_scenario_reaps_on_batch_start() -> None:
-    """Regression test for issue #192.
+def test_run_harness_wraps_docker_sdk_create(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """run_harness invokes docker_sdk_label_injection around the harness call."""
+    enters: list = []
+    exits: list = []
 
-    Scenario: a previous batch crashed leaving orphaned minisweagent
-    containers labeled with a now-dead owner PID.  The reaper invoked at
-    the start of a new batch must remove them.
-    """
-    dead_pid = 999_999_998
-    orphans = [(f"minisweagent-{i:08x}", dead_pid) for i in range(5)]
-    still_alive = [("active-cid", os.getpid())]
+    class _Ctx:
+        def __enter__(self):
+            enters.append(True)
+            return self
 
-    calls: list[list[str]] = []
-    rm_targets: list[str] = []
+        def __exit__(self, *a):
+            exits.append(True)
+            return False
 
-    def _run(cmd, **kwargs):
-        calls.append(list(cmd))
-        if len(cmd) >= 2 and cmd[1] == "ps":
-            lines = [f"{cid}\t{pid}" for cid, pid in orphans + still_alive]
-            return subprocess.CompletedProcess(cmd, 0, "\n".join(lines) + "\n", "")
-        if len(cmd) >= 2 and cmd[1] == "rm":
-            rm_targets.append(cmd[-1])
-            return subprocess.CompletedProcess(cmd, 0, "", "")
-        return subprocess.CompletedProcess(cmd, 1, "", "unexpected")
+    monkeypatch.setattr(swebench_evaluation, "docker_sdk_label_injection", lambda: _Ctx())
 
-    with patch.object(container_reaper, "_docker_bin", return_value="/usr/bin/docker"):
-        removed = reap_orphaned_containers(runner=_run)
+    fake_harness = types.ModuleType("swebench.harness.run_evaluation")
+    fake_harness.main = MagicMock(return_value=None)
+    fake_pkg = types.ModuleType("swebench")
+    fake_sub = types.ModuleType("swebench.harness")
+    fake_sub.run_evaluation = fake_harness
 
-    assert removed == 5
-    assert sorted(rm_targets) == sorted(cid for cid, _ in orphans)
-    assert "active-cid" not in rm_targets
+    paths = types.SimpleNamespace(benchmark_dir=tmp_path)
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {"swebench": fake_pkg, "swebench.harness": fake_sub, "swebench.harness.run_evaluation": fake_harness},
+        ),
+        patch.object(swebench_evaluation, "capture_stdio_to_session", lambda log: _Ctx()),
+    ):
+        swebench_evaluation.run_harness(
+            patch="diff --git a/x b/x\n--- a/x\n+++ a/x\n@@ +1,1 @@\n+x\n",
+            instance_id="inst",
+            subset="test",
+            paths=paths,
+            eval_config={"max_workers": 1, "cache_level": "env", "open_file_limit": 4096, "harness_timeout": 60},
+            logger=_logging.getLogger("t"),
+        )
+
+    assert enters and exits, "docker_sdk_label_injection context was not entered"
 
 
-# ---------------------------------------------------------------------------
-# Wiring tests: container-spawning callsites must emit the owner-pid label
-# ---------------------------------------------------------------------------
-
-
-def test_docker_runner_tags_containers_with_owner_pid() -> None:
-    """adapters/runners/docker.py::DockerRunner.start must label containers."""
-    from exgentic.adapters.runners.docker import DockerRunner
-
+def test_docker_runner_tags_containers_with_owner_labels() -> None:
     runner = DockerRunner(
         "exgentic.testing.calculator:Calculator",
         env_name="tests/calculator",
@@ -255,8 +269,6 @@ def test_docker_runner_tags_containers_with_owner_pid() -> None:
         captured.append(list(args))
         return subprocess.CompletedProcess(args, 0, "stub-cid\n", "")
 
-    # Avoid the health check / transport wiring — the test only validates
-    # the docker run argv.
     def _raise(*a, **k):
         raise RuntimeError("stop-after-docker-run")
 
@@ -271,23 +283,14 @@ def test_docker_runner_tags_containers_with_owner_pid() -> None:
         except Exception:
             pass
 
-    # The first docker call is the `run` (image build is skipped because
-    # ``image`` was provided).  Assert it contains our label flag.
     run_call = next((c for c in captured if c and c[0] == "run"), None)
-    assert run_call is not None, f"no docker run call captured: {captured}"
-    assert "--label" in run_call
-    idx = run_call.index("--label")
-    assert run_call[idx + 1] == f"{LABEL_OWNER_PID}={os.getpid()}"
+    assert run_call is not None
+    assert run_call.count("--label") == 2
+    assert f"{LABEL_OWNER_PID}={os.getpid()}" in run_call
+    assert f"{LABEL_OWNER_TOKEN}={OWN_TOKEN}" in run_call
 
 
 def test_claude_code_docker_runner_tags_containers() -> None:
-    """agents/cli/command_runner.py::DockerRunner.run must label containers."""
-    import logging as _logging
-    from pathlib import Path
-
-    from exgentic.agents.cli.command_runner import BaseCLIConfig
-    from exgentic.agents.cli.command_runner import DockerRunner as CLIDockerRunner
-
     runner = CLIDockerRunner(log_path=None, logger=_logging.getLogger("test"))
 
     captured_cmds: list[list[str]] = []
@@ -325,26 +328,15 @@ def test_claude_code_docker_runner_tags_containers() -> None:
             spawn_error_message="boom",
         )
 
-    assert captured_cmds, "no docker command was captured"
-    # The wrapped cmd begins with the runtime binary then 'run'.
+    assert captured_cmds
     wrapped = captured_cmds[0]
     assert "run" in wrapped
-    assert "--label" in wrapped
-    idx = wrapped.index("--label")
-    assert wrapped[idx + 1] == f"{LABEL_OWNER_PID}={os.getpid()}"
+    assert wrapped.count("--label") == 2
+    assert f"{LABEL_OWNER_PID}={os.getpid()}" in wrapped
+    assert f"{LABEL_OWNER_TOKEN}={OWN_TOKEN}" in wrapped
 
 
-def test_swebench_session_injects_reaper_label_into_minisweagent_config() -> None:
-    """Swebench session injects owner-pid label into minisweagent run_args.
-
-    SWEBenchSession._setup_environment must inject an ``exgentic.owner_pid``
-    label into the minisweagent environment config's ``run_args`` so
-    mini-swe-agent's ``docker run`` invocation carries the reaper label
-    (regression guard for issue #192).
-    """
-    import types
-
-    # Capture the config that would be handed to minisweagent.
+def test_swebench_session_injects_reaper_labels_into_minisweagent_config() -> None:
     captured: dict = {}
 
     class _FakeEnv:
@@ -369,18 +361,14 @@ def test_swebench_session_injects_reaper_label_into_minisweagent_config() -> Non
             "minisweagent.run.extra.swebench": fake_submod,
         },
     ):
-        from exgentic.benchmarks.swebench import swebench_eval
-
         yaml_path = MagicMock()
         yaml_path.read_text.return_value = "environment:\n  cwd: /testbed\n  run_args:\n    - '--rm'\n"
 
         def _fake_path(arg):
-            # Intercept ``Path(minisweagent.__file__)`` traversal.
             mock = MagicMock()
             mock.parent.__truediv__.return_value.__truediv__.return_value.__truediv__.return_value = yaml_path
             return mock
 
-        # Build a minimal stub session that invokes the real method.
         stub = types.SimpleNamespace(
             logger=MagicMock(),
             container_repo_dir="/testbed",
@@ -396,8 +384,7 @@ def test_swebench_session_injects_reaper_label_into_minisweagent_config() -> Non
         ):
             swebench_eval.SWEBenchSession._setup_environment(stub)
 
-    assert captured.get("config"), "minisweagent config was not captured"
     run_args = captured["config"]["environment"]["run_args"]
-    assert "--label" in run_args, f"run_args missing --label: {run_args}"
-    idx = run_args.index("--label")
-    assert run_args[idx + 1] == f"{LABEL_OWNER_PID}={os.getpid()}"
+    assert run_args.count("--label") == 2
+    assert f"{LABEL_OWNER_PID}={os.getpid()}" in run_args
+    assert f"{LABEL_OWNER_TOKEN}={OWN_TOKEN}" in run_args


### PR DESCRIPTION
Closes #192

## Summary

- Tag every exgentic-owned Docker container with `exgentic.owner_pid=<pid>`.
- At the start of `core_run`/`core_batch_evaluate`, remove containers whose owner PID no longer exists. This sweeps leftovers from prior crashed runs without touching sibling processes' containers.
- Register `atexit` + `SIGTERM`/`SIGINT` handlers that reap containers owned by the current PID, catching the common case where the parent receives a signal and must shut down its grandchildren before the process group dies.

## Root cause

Containers spawned by mini-swe-agent (`minisweagent-<hex8>`) and by the claude_code `DockerRunner` outlived their owner process on abnormal termination because containers live in the Docker daemon, outside the parent's process group. The `start_new_session=True` + `killpg` fix in #183 only reaches python grandchildren, not Docker grandchildren, so ~80 idle containers accumulated per day on ACE.

## Test plan

- [x] Unit tests in `tests/utils/test_container_reaper.py` (15 cases) — label generation, orphan reaping with live/dead PID mix, sibling isolation, missing-docker fallback, idempotent handler install, SIGTERM chaining, and wiring tests that assert each callsite emits `--label` / injects `run_args`.
- [x] Wiring tests fail on main, pass after the fix (verified by stashing source edits and re-running).
- [x] Existing `tests/adapters/runners/` + `tests/core/` + `tests/agents/` suites pass. Pre-existing Docker-daemon-broken failures in `tests/adapters/runners/test_e2e_session.py` and `tests/benchmarks/test_benchmark_replay.py` reproduce on main and are unrelated.