### PR TITLE
fix(batch): register essential observers in _plan_config instead of use_defaults=False

### DIFF
--- a/src/exgentic/core/orchestrator/run.py
+++ b/src/exgentic/core/orchestrator/run.py
@@ -219,9 +219,34 @@ def _plan_config(run_config: RunConfig) -> tuple[RunConfig, Tracker, list[Sessio
         if updates:
             run_config = run_config.model_copy(update=updates)
 
-        # Quiet tracker — no console output during batch planning.
+        # Batch mode: register the full default observer set EXCEPT
+        # ConsoleLoggerObserver (would print a panel per config during
+        # planning -- dozens of noisy panels for a 50-config batch).
+        # ResultsObserver is essential: it writes sessions/{id}/results.json
+        # which batch status counts.  Omitting it silently orphans every
+        # session's outcome (#202).
+        from ...observers.handlers.configs import ConfigsObserver
+        from ...observers.handlers.file_logger import FileLoggerObserver
+        from ...observers.handlers.recap import RunRecapObserver
+        from ...observers.handlers.results import ResultsObserver
+        from ...observers.handlers.warnings import WarningsObserver
+        from ...utils.settings import get_settings as _get_settings
+
+        batch_observers: list[Observer] = [
+            ResultsObserver(),
+            ConfigsObserver(),
+            WarningsObserver(),
+            FileLoggerObserver(),
+            RunRecapObserver(console=False),
+        ]
+        if _get_settings().otel_enabled:
+            from ...observers.handlers.otel import OtelTracingObserver
+
+            batch_observers.append(OtelTracingObserver())
+
         tracker = Tracker(
             use_defaults=False,
+            observers=batch_observers,
             max_steps=run_config.max_steps,
             max_actions=run_config.max_actions,
         )

--- a/src/exgentic/core/orchestrator/run.py
+++ b/src/exgentic/core/orchestrator/run.py
@@ -219,12 +219,7 @@ def _plan_config(run_config: RunConfig) -> tuple[RunConfig, Tracker, list[Sessio
         if updates:
             run_config = run_config.model_copy(update=updates)
 
-        # Batch mode: register the full default observer set EXCEPT
-        # ConsoleLoggerObserver (would print a panel per config during
-        # planning -- dozens of noisy panels for a 50-config batch).
-        # ResultsObserver is essential: it writes sessions/{id}/results.json
-        # which batch status counts.  Omitting it silently orphans every
-        # session's outcome (#202).
+        # Skip ConsoleLoggerObserver — one panel per config during planning is noisy.
         from ...observers.handlers.configs import ConfigsObserver
         from ...observers.handlers.file_logger import FileLoggerObserver
         from ...observers.handlers.recap import RunRecapObserver

--- a/src/exgentic/core/orchestrator/tracker.py
+++ b/src/exgentic/core/orchestrator/tracker.py
@@ -62,6 +62,10 @@ class Tracker(Observer, Controller):
         return self._run_id
 
     @property
+    def observers(self) -> tuple[Observer, ...]:
+        return tuple(self._observers)
+
+    @property
     def session_results(self):
         if self._results is not None:
             return self._results.session_results()

--- a/tests/api/test_plan_config_observers.py
+++ b/tests/api/test_plan_config_observers.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Regression test for Exgentic/exgentic#202.
+
+``_plan_config`` builds a Tracker for batch-mode session execution.
+A regression in commit 4119b46 set ``use_defaults=False`` on that
+Tracker to suppress console noise during planning, which silently
+removed **all** default observers -- including ``ResultsObserver``,
+the one that writes ``sessions/{id}/results.json``. The result: every
+``exgentic batch evaluate`` run appeared to complete but recorded
+zero session-level results.
+
+These tests verify that the Tracker returned by ``_plan_config``
+has the essential observers registered, regardless of how console
+noise is suppressed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from exgentic.core.orchestrator.run import _plan_config
+from exgentic.core.types import RunConfig
+from exgentic.observers.handlers.results import ResultsObserver
+
+
+@pytest.fixture
+def run_config(tmp_path):
+    return RunConfig(
+        benchmark="test_benchmark",
+        agent="test_agent",
+        output_dir=str(tmp_path / "output"),
+        cache_dir=str(tmp_path / "cache"),
+        num_tasks=1,
+        benchmark_kwargs={"tasks": ["task-1"]},
+        agent_kwargs={"policy": "good_then_finish", "finish_after": 2},
+    )
+
+
+def test_plan_config_tracker_has_results_observer(run_config):
+    """The Tracker returned by _plan_config must include ResultsObserver.
+
+    Without it, sessions complete but no results.json is written --
+    batch status shows zero progress forever.
+    """
+    _, tracker, _ = _plan_config(run_config)
+
+    results_observers = [o for o in tracker._observers if isinstance(o, ResultsObserver)]
+    assert len(results_observers) == 1, (
+        f"Expected exactly 1 ResultsObserver, found {len(results_observers)}. "
+        f"Observers: {[type(o).__name__ for o in tracker._observers]}"
+    )
+
+
+def test_plan_config_tracker_has_nonzero_observers(run_config):
+    """The Tracker must have at least the core observers (results, configs, warnings, file logger)."""
+    _, tracker, _ = _plan_config(run_config)
+
+    assert len(tracker._observers) >= 4, (
+        f"Expected at least 4 observers, found {len(tracker._observers)}: "
+        f"{[type(o).__name__ for o in tracker._observers]}"
+    )
+
+
+def test_plan_config_tracker_excludes_console_logger(run_config):
+    """ConsoleLoggerObserver should NOT be registered in batch mode.
+
+    That's the whole reason for the 'quiet tracker' -- 50 console
+    panels during planning is noisy. But suppressing it must not
+    suppress ResultsObserver.
+    """
+    from exgentic.observers.handlers.logger import ConsoleLoggerObserver
+
+    _, tracker, _ = _plan_config(run_config)
+
+    console_observers = [o for o in tracker._observers if isinstance(o, ConsoleLoggerObserver)]
+    assert len(console_observers) == 0, (
+        "ConsoleLoggerObserver should not be registered in batch mode "
+        "(it produces a panel per config during planning)"
+    )

--- a/tests/api/test_plan_config_observers.py
+++ b/tests/api/test_plan_config_observers.py
@@ -4,12 +4,12 @@
 """Regression test for Exgentic/exgentic#202.
 
 ``_plan_config`` builds a Tracker for batch-mode session execution.
-A regression in commit 4119b46 set ``use_defaults=False`` on that
-Tracker to suppress console noise during planning, which silently
-removed **all** default observers -- including ``ResultsObserver``,
-the one that writes ``sessions/{id}/results.json``. The result: every
-``exgentic batch evaluate`` run appeared to complete but recorded
-zero session-level results.
+A prior change set ``use_defaults=False`` on that Tracker to suppress
+console noise during planning, which silently removed **all** default
+observers -- including ``ResultsObserver``, the one that writes
+``sessions/{id}/results.json``. The result: every ``exgentic batch
+evaluate`` run appeared to complete but recorded zero session-level
+results.
 
 These tests verify that the Tracker returned by ``_plan_config``
 has the essential observers registered, regardless of how console
@@ -18,9 +18,12 @@ noise is suppressed.
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from exgentic.core.orchestrator.run import _plan_config
 from exgentic.core.types import RunConfig
+from exgentic.observers.handlers.logger import ConsoleLoggerObserver
 from exgentic.observers.handlers.results import ResultsObserver
 
 
@@ -45,10 +48,10 @@ def test_plan_config_tracker_has_results_observer(run_config):
     """
     _, tracker, _ = _plan_config(run_config)
 
-    results_observers = [o for o in tracker._observers if isinstance(o, ResultsObserver)]
+    results_observers = [o for o in tracker.observers if isinstance(o, ResultsObserver)]
     assert len(results_observers) == 1, (
         f"Expected exactly 1 ResultsObserver, found {len(results_observers)}. "
-        f"Observers: {[type(o).__name__ for o in tracker._observers]}"
+        f"Observers: {[type(o).__name__ for o in tracker.observers]}"
     )
 
 
@@ -56,9 +59,9 @@ def test_plan_config_tracker_has_nonzero_observers(run_config):
     """The Tracker must have at least the core observers (results, configs, warnings, file logger)."""
     _, tracker, _ = _plan_config(run_config)
 
-    assert len(tracker._observers) >= 4, (
-        f"Expected at least 4 observers, found {len(tracker._observers)}: "
-        f"{[type(o).__name__ for o in tracker._observers]}"
+    assert len(tracker.observers) >= 4, (
+        f"Expected at least 4 observers, found {len(tracker.observers)}: "
+        f"{[type(o).__name__ for o in tracker.observers]}"
     )
 
 
@@ -69,12 +72,43 @@ def test_plan_config_tracker_excludes_console_logger(run_config):
     panels during planning is noisy. But suppressing it must not
     suppress ResultsObserver.
     """
-    from exgentic.observers.handlers.logger import ConsoleLoggerObserver
-
     _, tracker, _ = _plan_config(run_config)
 
-    console_observers = [o for o in tracker._observers if isinstance(o, ConsoleLoggerObserver)]
+    console_observers = [o for o in tracker.observers if isinstance(o, ConsoleLoggerObserver)]
     assert len(console_observers) == 0, (
         "ConsoleLoggerObserver should not be registered in batch mode "
         "(it produces a panel per config during planning)"
+    )
+
+
+def test_plan_config_tracker_registers_otel_when_enabled(run_config):
+    """OtelTracingObserver must be registered when ``otel_enabled`` is True."""
+    from exgentic.observers.handlers.otel import OtelTracingObserver
+
+    with patch(
+        "exgentic.utils.settings.get_settings",
+        return_value=MagicMock(otel_enabled=True),
+    ):
+        _, tracker, _ = _plan_config(run_config)
+
+    otel_observers = [o for o in tracker.observers if isinstance(o, OtelTracingObserver)]
+    assert len(otel_observers) == 1, (
+        f"Expected OtelTracingObserver when otel_enabled=True, got " f"{[type(o).__name__ for o in tracker.observers]}"
+    )
+
+
+def test_plan_config_tracker_skips_otel_when_disabled(run_config):
+    """OtelTracingObserver must NOT be registered when ``otel_enabled`` is False."""
+    from exgentic.observers.handlers.otel import OtelTracingObserver
+
+    with patch(
+        "exgentic.utils.settings.get_settings",
+        return_value=MagicMock(otel_enabled=False),
+    ):
+        _, tracker, _ = _plan_config(run_config)
+
+    otel_observers = [o for o in tracker.observers if isinstance(o, OtelTracingObserver)]
+    assert otel_observers == [], (
+        f"OtelTracingObserver should not be registered when otel_enabled=False, got "
+        f"{[type(o).__name__ for o in tracker.observers]}"
     )


### PR DESCRIPTION
## Summary

Fixes #202: \`exgentic batch evaluate\` has been silently producing zero session results since commit \`4119b46\` (Apr 12). Every session runs its full agent loop and benchmark scoring, but no \`sessions/{id}/results.json\` is ever written -- so \`batch status\` shows zero new completions forever.

## Root cause

\`_plan_config\` in \`src/exgentic/core/orchestrator/run.py\` creates a \`Tracker(use_defaults=False)\` to suppress \`ConsoleLoggerObserver\` console panels during the planning loop (which would print one panel per config -- noisy for 50-config batches). But \`use_defaults=False\` also suppresses **all** default observers, including \`ResultsObserver\` (which writes session results) and every other observer that does real work.

The same Tracker is returned from \`_plan_config\` and reused for the entire session execution phase. With zero observers, no session lifecycle event is ever handled.

## Fix

Keep \`use_defaults=False\` but explicitly register the full essential observer set, skipping only \`ConsoleLoggerObserver\`:

\`\`\`python
batch_observers: list[Observer] = [
    ResultsObserver(),
    ConfigsObserver(),
    WarningsObserver(),
    FileLoggerObserver(),
    RunRecapObserver(console=False),
]
if _get_settings().otel_enabled:
    batch_observers.append(OtelTracingObserver())

tracker = Tracker(
    use_defaults=False,
    observers=batch_observers,
    max_steps=run_config.max_steps,
    max_actions=run_config.max_actions,
)
\`\`\`

This preserves the "quiet planning" intent (no ConsoleLoggerObserver panels) while keeping every observer that does real work.

## Tests

\`tests/api/test_plan_config_observers.py\` -- 3 new:

- **\`test_plan_config_tracker_has_results_observer\`**: verifies exactly 1 \`ResultsObserver\` is registered. On pre-fix code: \`AssertionError: Expected exactly 1 ResultsObserver, found 0. Observers: []\`
- **\`test_plan_config_tracker_has_nonzero_observers\`**: at least 4 core observers must be present. Pre-fix: \`assert 0 >= 4\`
- **\`test_plan_config_tracker_excludes_console_logger\`**: \`ConsoleLoggerObserver\` must NOT be registered in batch mode.

All 3 pass on the fix; 2 fail on the regression.

## Validation

This fix was applied locally (uncommitted) and validated across **batches 11-20** on ACE (Apr 14-16). With the fix:
- Sessions went from 195 -> 1470 (of 1500 target)
- \`batch status\` correctly reported completions in real time
- Cost aggregation (#191) worked because session-level \`results.json\` files were actually being written

Without the fix (batch10), zero session-level \`results.json\` files were ever written in batch mode.

## Test plan

- [ ] \`uv run pytest tests/api/test_plan_config_observers.py -v\` -- 3 passed
- [ ] \`exgentic batch evaluate --config ... --num-tasks 5\` produces session-level \`results.json\` for completed sessions
- [ ] \`exgentic batch status\` shows non-zero completions during and after a batch run

Fixes #202.