### PR TITLE
feat(litellm): allow custom api_base and extra_headers via env vars

### DIFF
--- a/src/exgentic/integrations/litellm/health.py
+++ b/src/exgentic/integrations/litellm/health.py
@@ -6,7 +6,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import os
 from enum import Enum
 from typing import TYPE_CHECKING
 
@@ -190,6 +192,14 @@ async def acheck_model_accessible(
     is_exponential = model_settings.retry_strategy == RetryStrategy.EXPONENTIAL_BACKOFF
 
     last_exc: BaseException | None = None
+    extra_kwargs: dict = {}
+    api_base = os.environ.get("LITELLM_API_BASE")
+    if api_base:
+        extra_kwargs["api_base"] = api_base
+        extra_kwargs["api_key"] = os.environ.get("OPENAI_API_KEY") or "dummy"
+    extra_headers_raw = os.environ.get("LITELLM_EXTRA_HEADERS")
+    if extra_headers_raw:
+        extra_kwargs["extra_headers"] = json.loads(extra_headers_raw)
     for attempt in range(1 + num_retries):
         try:
             await litellm.acompletion(
@@ -197,6 +207,7 @@ async def acheck_model_accessible(
                 messages=[{"role": "user", "content": "hi"}],
                 max_tokens=1,
                 caching=False,
+                **extra_kwargs,
             )
             return
         except Exception as exc:

--- a/src/exgentic/integrations/litellm/proxy.py
+++ b/src/exgentic/integrations/litellm/proxy.py
@@ -159,6 +159,13 @@ class LitellmProxy:
             litellm_params["max_tokens"] = self.model_settings.max_tokens
         if self.model_settings.top_p is not None:
             litellm_params["top_p"] = self.model_settings.top_p
+        api_base = os.environ.get("LITELLM_API_BASE")
+        if api_base:
+            litellm_params["api_base"] = api_base
+            litellm_params["api_key"] = os.environ.get("OPENAI_API_KEY") or "dummy"
+        extra_headers_raw = os.environ.get("LITELLM_EXTRA_HEADERS")
+        if extra_headers_raw:
+            litellm_params["extra_headers"] = json.loads(extra_headers_raw)
         return litellm_params
 
     def _build_config_data(self) -> dict[str, object]:


### PR DESCRIPTION
Adds support for LITELLM_API_BASE and LITELLM_EXTRA_HEADERS environment variables, picked up by both the LiteLLM proxy config and the model accessibility health check. This unblocks OpenAI-compatible backends that require non-standard auth headers (e.g. RITS / 3scale apicast gateways which expect a bespoke RITS_API_KEY header rather than the Authorization: Bearer convention).

The LITELLM_ prefix matches the existing _FORWARD_PREFIXES whitelist in adapters/runners/_utils.py, so the values reach the agent subprocess without further changes to the env-forwarding policy.