### PR TITLE
perf(scan): parallelize RunStatus.from_session_configs (closes #210)

### DIFF
--- a/src/exgentic/core/types/run.py
+++ b/src/exgentic/core/types/run.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import logging
 import random
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
@@ -151,13 +152,19 @@ class RunStatus(BaseModel):
                 context_config = run_config.model_copy(update=updates)
         with context_config.get_context():
             run_paths = get_run_paths()
-            statuses = [
-                SessionStatus.from_config(
-                    session_config,
-                    run_paths=run_paths,
+            # Per-session status checks are pure I/O against shared storage
+            # (4 stat/read calls each on NFS) and independent across sessions.
+            # On a 4600-session tree this list comp serially burned 3-8 min;
+            # threading drops it to ~10s. pool.map preserves order, so the
+            # downstream RunPlan zips correctly with the input task order.
+            max_workers = min(32, len(session_configs)) or 1
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                statuses = list(
+                    pool.map(
+                        lambda sc: SessionStatus.from_config(sc, run_paths=run_paths),
+                        session_configs,
+                    )
                 )
-                for session_config in session_configs
-            ]
             task_ids = [str(item.task_id) for item in session_configs]
             completed = sum(1 for item in statuses if item.status == SessionExecutionStatus.COMPLETED)
             running = sum(1 for item in statuses if item.status == SessionExecutionStatus.RUNNING)

--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -216,7 +216,10 @@ def _apply_patch(payload: dict[str, Any], updates: dict[str, Any]) -> None:
 
 
 def _update_session_ids_in_dir(session_dir: Path, new_id: str) -> None:
-    for json_path in session_dir.rglob("*.json"):
+    # Top-level only: config.json and results.json carry session_id. Deeper
+    # files (litellm cache logs, etc.) don't, and rglob over them on NFS is
+    # wasteful.
+    for json_path in session_dir.glob("*.json"):
         try:
             payload = _load_config_file(str(json_path))
         except Exception:
@@ -251,9 +254,9 @@ def _recover_session_hashes(roots: list[Path], *, do_apply: bool) -> int:
         sessions_root = root / "sessions"
         if not sessions_root.exists():
             raise click.ClickException(f"sessions dir not found: {sessions_root}")
-        for cfg_path in sessions_root.rglob("config.json"):
-            if cfg_path.parent.parent != sessions_root:
-                continue
+        # Session config.json files live at sessions/{id}/config.json; the
+        # one-level glob avoids walking every nested benchmark/agent log dir.
+        for cfg_path in sessions_root.glob("*/config.json"):
             session_dir = cfg_path.parent
             old_id = session_dir.name
             config = _load_config_file(str(cfg_path))
@@ -777,9 +780,9 @@ def batch_patch_cmd(
         if not sessions_root.exists():
             raise click.ClickException(f"sessions dir not found: {sessions_root}")
         changes = 0
-        for cfg_path in sessions_root.rglob("config.json"):
-            if cfg_path.parent.parent != sessions_root:
-                continue
+        # Session config.json files live at sessions/{id}/config.json; the
+        # one-level glob avoids walking every nested benchmark/agent log dir.
+        for cfg_path in sessions_root.glob("*/config.json"):
             session_dir = cfg_path.parent
             old_id = session_dir.name
             config = _load_config_file(str(cfg_path))

--- a/tests/api/test_run_status_parallel.py
+++ b/tests/api/test_run_status_parallel.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Regression test: RunStatus.from_session_configs preserves input order
+even when its inner per-session loop is computed in parallel.
+
+This is the central choke-point for `batch status`, `batch evaluate`'s
+plan phase, and `batch aggregate`. A reordering bug would silently
+mismatch task IDs against statuses; the integration tests would still
+pass because the *count* is right, but downstream RunPlan would zip
+wrong tasks to wrong statuses.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from exgentic.core.types import RunConfig
+from exgentic.core.types.run import RunStatus
+from exgentic.core.types.session import SessionExecutionStatus
+
+
+def test_from_session_configs_preserves_input_order(tmp_path: Path):
+    cfg = RunConfig(
+        benchmark="test_benchmark",
+        agent="test_agent",
+        output_dir=str(tmp_path / "outputs"),
+        cache_dir=str(tmp_path / "cache"),
+        run_id="ordering-run",
+        # 64 tasks > the parallel pool size (32) — guarantees real parallel
+        # execution rather than a single-batch shortcut.
+        num_tasks=64,
+        benchmark_kwargs={"tasks": [f"task-{i:03d}" for i in range(64)]},
+        agent_kwargs={"policy": "good_then_finish", "finish_after": 1},
+    )
+
+    with cfg.get_context():
+        session_configs = cfg.get_session_configs()
+        run_status = RunStatus.from_session_configs(cfg, session_configs)
+
+    # No session has been executed → all MISSING.
+    assert all(s.status == SessionExecutionStatus.MISSING for s in run_status.session_statuses)
+
+    # Critical invariant: status[i].task_id == session_configs[i].task_id.
+    for sc, status in zip(session_configs, run_status.session_statuses):
+        assert status.task_id == str(sc.task_id), (
+            f"Order desync: input {sc.task_id!r} -> status.task_id {status.task_id!r}"
+        )
+
+    # And task_ids field on RunStatus matches the input order too.
+    assert run_status.task_ids == [str(sc.task_id) for sc in session_configs]
+
+
+def test_from_session_configs_empty(tmp_path: Path):
+    """Empty input must not raise (max_workers guard)."""
+    cfg = RunConfig(
+        benchmark="test_benchmark",
+        agent="test_agent",
+        output_dir=str(tmp_path / "outputs"),
+        cache_dir=str(tmp_path / "cache"),
+        run_id="empty-run",
+        num_tasks=0,
+        benchmark_kwargs={"tasks": []},
+        agent_kwargs={"policy": "good_then_finish", "finish_after": 1},
+    )
+
+    with cfg.get_context():
+        run_status = RunStatus.from_session_configs(cfg, [])
+
+    assert run_status.session_statuses == []
+    assert run_status.task_ids == []
+    assert run_status.total_tasks == 0


### PR DESCRIPTION
Closes #210.

## Why

Every results-scan caller — \`batch status\`, \`batch evaluate\`'s plan phase, \`batch aggregate\`, the lib api \`status()\` helper — eventually funnels into \`RunStatus.from_session_configs\`, which serially calls \`SessionStatus.from_config\` (4 NFS stat/read calls each) per session. On a 4600-session tree this list-comp burns 3-8 minutes before any worker spawns in \`batch evaluate\`, and the same penalty is paid by every status/aggregate invocation.

Rather than re-implementing parallelism at each call site, push it into the central helper.

## What

1. **Parallelize the inner loop** in \`RunStatus.from_session_configs\` with a \`ThreadPoolExecutor\` (max 32). \`pool.map\` preserves input order, so the downstream \`RunPlan\` zips correctly with the input task order.
2. **Drop two over-broad rglobs** in the admin \`batch patch\` helpers: \`sessions_root.rglob(\"config.json\")\` → \`sessions_root.glob(\"*/config.json\")\`, and \`session_dir.rglob(\"*.json\")\` → \`session_dir.glob(\"*.json\")\`. Same justification as #209.
3. **Regression test** asserting input order is preserved through the parallel scan (64 sessions > pool size, guarantees real parallelism), plus an empty-input edge case.

## Measurement

50 OSS configs, 4600 sessions, NFS-backed run tree:

| | \`batch status\` |
|---|---|
| Before | 10–25 min |
| After (this PR alone) | **~12 s** |

Output is byte-for-byte identical against the same tree.

## Tests

- New: \`tests/api/test_run_status_parallel.py\` (2 tests, ordering + empty input).
- Existing: \`tests/api/test_cli_batch.py\` (6 tests) and \`tests/core/test_session_status.py\` (11 tests) all pass unchanged.
- \`tests/api/test_cli_compare.py\` failures pre-exist on \`main\` and are unrelated.

## Risk

- \`SessionStatus.from_config\` is pure I/O when \`run_paths\` is provided (the caller does); no thread-unsafe shared state.
- Once #209 also merges, \`batch status\` has inner+outer parallelism; may need to lower the outer pool — noted in #210.

## Relationship to #209

Independent. #209 parallelized the *outer* per-config loop in \`batch status\` only. This PR parallelizes the *inner* per-session loop in the shared core helper, so it benefits every caller (\`batch evaluate\` plan, \`batch aggregate\`, lib api). Either order of merge is fine.