### PR TITLE
perf(scan): parallelize per-session loop + drop rglob walks (>100x faster batch status)

### DIFF
--- a/src/exgentic/core/types/run.py
+++ b/src/exgentic/core/types/run.py
@@ -94,6 +94,16 @@ class Integration(BaseModel):
     entry_point: str
 
 
+_MAX_SCAN_WORKERS = 32
+"""Upper bound on threads used to fan out per-session status reads.
+
+Per-session checks are 4 stat/read calls each. On NFS, ~32 concurrent
+in-flight reads is enough to saturate metadata throughput on the trees
+we've measured; going wider gives diminishing returns and risks
+contention with concurrent batch evaluate workers.
+"""
+
+
 class RunStatus(BaseModel):
     """Snapshot of the current run status and existing session artifacts."""
 
@@ -137,6 +147,14 @@ class RunStatus(BaseModel):
         run_config: RunConfig,
         session_configs: list[SessionConfig],
     ) -> RunStatus:
+        """Build a :class:`RunStatus` by scanning each session's artifacts.
+
+        The per-session checks (``SessionStatus.from_config``) are pure I/O
+        against shared storage — 4 stat/read calls each on NFS — and
+        independent across sessions, so we fan them out via a
+        ``ThreadPoolExecutor``. ``pool.map`` preserves input order, so the
+        downstream ``RunPlan`` zips correctly with the input task order.
+        """
         from ...utils.paths import get_run_paths
 
         context_config = run_config
@@ -153,12 +171,7 @@ class RunStatus(BaseModel):
                 context_config = run_config.model_copy(update=updates)
         with context_config.get_context():
             run_paths = get_run_paths()
-            # Per-session status checks are pure I/O against shared storage
-            # (4 stat/read calls each on NFS) and independent across sessions.
-            # On a 4600-session tree this list comp serially burned 3-8 min;
-            # threading drops it to ~10s. pool.map preserves order, so the
-            # downstream RunPlan zips correctly with the input task order.
-            max_workers = min(32, len(session_configs)) or 1
+            max_workers = max(1, min(_MAX_SCAN_WORKERS, len(session_configs)))
             scan = partial(SessionStatus.from_config, run_paths=run_paths)
             with ThreadPoolExecutor(max_workers=max_workers) as pool:
                 statuses = list(pool.map(scan, session_configs))

--- a/src/exgentic/core/types/run.py
+++ b/src/exgentic/core/types/run.py
@@ -95,13 +95,6 @@ class Integration(BaseModel):
 
 
 _MAX_SCAN_WORKERS = 32
-"""Upper bound on threads used to fan out per-session status reads.
-
-Per-session checks are 4 stat/read calls each. On NFS, ~32 concurrent
-in-flight reads is enough to saturate metadata throughput on the trees
-we've measured; going wider gives diminishing returns and risks
-contention with concurrent batch evaluate workers.
-"""
 
 
 class RunStatus(BaseModel):
@@ -149,11 +142,8 @@ class RunStatus(BaseModel):
     ) -> RunStatus:
         """Build a :class:`RunStatus` by scanning each session's artifacts.
 
-        The per-session checks (``SessionStatus.from_config``) are pure I/O
-        against shared storage — 4 stat/read calls each on NFS — and
-        independent across sessions, so we fan them out via a
-        ``ThreadPoolExecutor``. ``pool.map`` preserves input order, so the
-        downstream ``RunPlan`` zips correctly with the input task order.
+        Per-session checks fan out via a ``ThreadPoolExecutor``; ``pool.map``
+        preserves input order so :class:`RunPlan` zips correctly downstream.
         """
         from ...utils.paths import get_run_paths
 

--- a/src/exgentic/core/types/run.py
+++ b/src/exgentic/core/types/run.py
@@ -7,6 +7,8 @@ import hashlib
 import json
 import logging
 import random
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
@@ -151,13 +153,15 @@ class RunStatus(BaseModel):
                 context_config = run_config.model_copy(update=updates)
         with context_config.get_context():
             run_paths = get_run_paths()
-            statuses = [
-                SessionStatus.from_config(
-                    session_config,
-                    run_paths=run_paths,
-                )
-                for session_config in session_configs
-            ]
+            # Per-session status checks are pure I/O against shared storage
+            # (4 stat/read calls each on NFS) and independent across sessions.
+            # On a 4600-session tree this list comp serially burned 3-8 min;
+            # threading drops it to ~10s. pool.map preserves order, so the
+            # downstream RunPlan zips correctly with the input task order.
+            max_workers = min(32, len(session_configs)) or 1
+            scan = partial(SessionStatus.from_config, run_paths=run_paths)
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                statuses = list(pool.map(scan, session_configs))
             task_ids = [str(item.task_id) for item in session_configs]
             completed = sum(1 for item in statuses if item.status == SessionExecutionStatus.COMPLETED)
             running = sum(1 for item in statuses if item.status == SessionExecutionStatus.RUNNING)

--- a/src/exgentic/core/types/session_inventory.py
+++ b/src/exgentic/core/types/session_inventory.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Single source of truth for filesystem scans of a session tree.
+
+Multiple callers (``batch status``, ``_load_results_summary``, future
+aggregation paths) need to walk ``sessions/*/results.json`` for the same
+underlying data: the parsed payload and the file's mtime. Each used to
+glob and stat independently; for a 4600-session tree on NFS that meant
+two-to-three full walks per ``batch status`` invocation.
+
+``scan_sessions`` does the walk once, in parallel, and returns typed
+:class:`SessionRecord` snapshots. Consumers compose pure functions over
+the records — no further I/O required.
+"""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_MAX_SCAN_WORKERS = 32
+"""Upper bound on threads used to fan out per-session results reads."""
+
+
+@dataclass(frozen=True)
+class SessionRecord:
+    """Filesystem snapshot of a single session's results artifact.
+
+    Holds everything any consumer needs from a session directory after a
+    single read: the parsed ``results.json`` payload and its mtime. Not
+    a status enum — that's :class:`SessionStatus`'s job, which factors in
+    lock files and the orchestrator's state machine.
+    """
+
+    session_dir: Path
+    results_path: Path
+    results: dict[str, Any] | None
+    """Parsed ``results.json``; ``None`` if missing or unparseable."""
+    mtime: float | None
+    """``results.json`` mtime; ``None`` if the file is missing."""
+
+
+def scan_sessions(
+    sessions_dir: Path,
+    *,
+    max_workers: int = _MAX_SCAN_WORKERS,
+) -> list[SessionRecord]:
+    """Walk ``sessions_dir/*/results.json`` once, in parallel.
+
+    Returns one :class:`SessionRecord` per existing ``results.json``.
+    Sessions without a ``results.json`` are not included — callers that
+    care about missing sessions should consult :class:`SessionStatus`.
+
+    The walk is order-unstable: callers that care about input/output
+    correspondence (the orchestrator) should use
+    ``RunStatus.from_session_configs`` instead, which keeps task-id
+    ordering. Callers here (status display, live aggregation) reduce
+    the records and don't depend on order.
+    """
+    paths = list(sessions_dir.glob("*/results.json"))
+    if not paths:
+        return []
+    workers = max(1, min(max_workers, len(paths)))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        return list(pool.map(_read_session_record, paths))
+
+
+def _read_session_record(results_path: Path) -> SessionRecord:
+    try:
+        results: dict[str, Any] | None = json.loads(results_path.read_text(encoding="utf-8"))
+        if not isinstance(results, dict):
+            results = None
+    except Exception:
+        results = None
+    try:
+        mtime: float | None = results_path.stat().st_mtime
+    except OSError:
+        mtime = None
+    return SessionRecord(
+        session_dir=results_path.parent,
+        results_path=results_path,
+        results=results,
+        mtime=mtime,
+    )

--- a/src/exgentic/core/types/session_inventory.py
+++ b/src/exgentic/core/types/session_inventory.py
@@ -1,18 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
-"""Single source of truth for filesystem scans of a session tree.
-
-Multiple callers (``batch status``, ``_load_results_summary``, future
-aggregation paths) need to walk ``sessions/*/results.json`` for the same
-underlying data: the parsed payload and the file's mtime. Each used to
-glob and stat independently; for a 4600-session tree on NFS that meant
-two-to-three full walks per ``batch status`` invocation.
-
-``scan_sessions`` does the walk once, in parallel, and returns typed
-:class:`SessionRecord` snapshots. Consumers compose pure functions over
-the records — no further I/O required.
-"""
+"""Single-walk parallel scan of a session tree's results.json files."""
 
 from __future__ import annotations
 
@@ -23,25 +12,20 @@ from pathlib import Path
 from typing import Any
 
 _MAX_SCAN_WORKERS = 32
-"""Upper bound on threads used to fan out per-session results reads."""
 
 
 @dataclass(frozen=True)
 class SessionRecord:
-    """Filesystem snapshot of a single session's results artifact.
+    """Parsed ``results.json`` and its mtime for one session.
 
-    Holds everything any consumer needs from a session directory after a
-    single read: the parsed ``results.json`` payload and its mtime. Not
-    a status enum — that's :class:`SessionStatus`'s job, which factors in
-    lock files and the orchestrator's state machine.
+    Distinct from :class:`SessionStatus`, which is the orchestrator's
+    state-machine view (RUNNING/COMPLETED/INCOMPLETE/MISSING).
     """
 
     session_dir: Path
     results_path: Path
     results: dict[str, Any] | None
-    """Parsed ``results.json``; ``None`` if missing or unparseable."""
     mtime: float | None
-    """``results.json`` mtime; ``None`` if the file is missing."""
 
 
 def scan_sessions(
@@ -49,17 +33,9 @@ def scan_sessions(
     *,
     max_workers: int = _MAX_SCAN_WORKERS,
 ) -> list[SessionRecord]:
-    """Walk ``sessions_dir/*/results.json`` once, in parallel.
+    """Parallel walk of ``sessions_dir/*/results.json``.
 
-    Returns one :class:`SessionRecord` per existing ``results.json``.
-    Sessions without a ``results.json`` are not included — callers that
-    care about missing sessions should consult :class:`SessionStatus`.
-
-    The walk is order-unstable: callers that care about input/output
-    correspondence (the orchestrator) should use
-    ``RunStatus.from_session_configs`` instead, which keeps task-id
-    ordering. Callers here (status display, live aggregation) reduce
-    the records and don't depend on order.
+    Order is unspecified. Sessions without a ``results.json`` are skipped.
     """
     paths = list(sessions_dir.glob("*/results.json"))
     if not paths:

--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -216,7 +216,10 @@ def _apply_patch(payload: dict[str, Any], updates: dict[str, Any]) -> None:
 
 
 def _update_session_ids_in_dir(session_dir: Path, new_id: str) -> None:
-    for json_path in session_dir.rglob("*.json"):
+    # Top-level only: config.json and results.json carry session_id. Deeper
+    # files (litellm cache logs, etc.) don't, and rglob over them on NFS is
+    # wasteful.
+    for json_path in session_dir.glob("*.json"):
         try:
             payload = _load_config_file(str(json_path))
         except Exception:
@@ -251,9 +254,9 @@ def _recover_session_hashes(roots: list[Path], *, do_apply: bool) -> int:
         sessions_root = root / "sessions"
         if not sessions_root.exists():
             raise click.ClickException(f"sessions dir not found: {sessions_root}")
-        for cfg_path in sessions_root.rglob("config.json"):
-            if cfg_path.parent.parent != sessions_root:
-                continue
+        # Session config.json files live at sessions/{id}/config.json; the
+        # one-level glob avoids walking every nested benchmark/agent log dir.
+        for cfg_path in sessions_root.glob("*/config.json"):
             session_dir = cfg_path.parent
             old_id = session_dir.name
             config = _load_config_file(str(cfg_path))
@@ -473,8 +476,13 @@ def batch_status_cmd(
             if subset:
                 benchmark = f"{benchmark}/{subset}"
             sessions_dir = Path(run_status.results_path).parent / "sessions"
+            # Stat each session's results.json — that's the file we update on
+            # every observer write, so its mtime is the true "last activity"
+            # signal. Avoids rglob walking every trajectory/log file (which on
+            # NFS dominates wall time) while staying accurate during long-
+            # running sessions.
             latest = 0.0
-            for p in sessions_dir.rglob("*"):
+            for p in sessions_dir.glob("*/results.json"):
                 try:
                     m = p.stat().st_mtime
                 except OSError:
@@ -777,9 +785,9 @@ def batch_patch_cmd(
         if not sessions_root.exists():
             raise click.ClickException(f"sessions dir not found: {sessions_root}")
         changes = 0
-        for cfg_path in sessions_root.rglob("config.json"):
-            if cfg_path.parent.parent != sessions_root:
-                continue
+        # Session config.json files live at sessions/{id}/config.json; the
+        # one-level glob avoids walking every nested benchmark/agent log dir.
+        for cfg_path in sessions_root.glob("*/config.json"):
             session_dir = cfg_path.parent
             old_id = session_dir.name
             config = _load_config_file(str(cfg_path))

--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -218,18 +218,12 @@ def _apply_patch(payload: dict[str, Any], updates: dict[str, Any]) -> None:
 
 
 def _iter_session_files(sessions_root: Path, filename: str) -> Iterator[Path]:
-    """Yield ``sessions_root/{id}/{filename}`` for each session subdirectory.
-
-    A one-level glob avoids walking nested benchmark/agent log dirs, which
-    dominates wall time on NFS for large session trees.
-    """
+    """Yield ``sessions_root/{id}/{filename}``; one-level glob (NFS-friendly)."""
     return sessions_root.glob(f"*/{filename}")
 
 
 def _update_session_ids_in_dir(session_dir: Path, new_id: str) -> None:
-    # Top-level only: config.json and results.json carry session_id. Deeper
-    # files (litellm cache logs, etc.) don't, and rglob over them on NFS is
-    # wasteful.
+    # Top-level only — only config.json/results.json carry session_id.
     for json_path in session_dir.glob("*.json"):
         try:
             payload = _load_config_file(str(json_path))
@@ -475,10 +469,7 @@ def batch_status_cmd(
             sessions_str = " ".join(parts)
 
             sessions_dir = Path(run_status.results_path).parent / "sessions"
-            # One walk feeds both consumers below — _load_results_summary's
-            # live aggregation and the last_event timestamp.
             session_records = scan_sessions(sessions_dir)
-
             score, cost, models, *_ = _load_results_summary(run_status.results_path, session_records=session_records)
             model = run_status.model_name or models
             if model != "-":
@@ -491,8 +482,6 @@ def batch_status_cmd(
             subset = run_status.subset_name
             if subset:
                 benchmark = f"{benchmark}/{subset}"
-            # results.json mtime is the true last-activity signal — observers
-            # touch it on every write, so it's accurate during long sessions.
             mtimes = [r.mtime for r in session_records if r.mtime is not None]
             last_event = _format_ago(time.time() - max(mtimes)) if mtimes else "-"
             row.update(

--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -17,6 +17,7 @@ import rich_click as click
 
 from ....core.types import RunConfig, SessionConfig
 from ....core.types.session import SessionExecutionStatus, SessionOutcomeStatus
+from ....core.types.session_inventory import SessionRecord, scan_sessions
 from ....utils.paths import get_run_paths, get_session_paths
 from ...lib.api import aggregate, execute, status
 from ..options import (
@@ -287,6 +288,8 @@ def _recover_session_hashes(roots: list[Path], *, do_apply: bool) -> int:
 
 def _load_results_summary(
     path: str,
+    *,
+    session_records: list[SessionRecord] | None = None,
 ) -> tuple[str, str, str, int | None, int | None, int | None, int | None]:
     if not path:
         return "-", "-", "-", None, None, None, None
@@ -304,17 +307,17 @@ def _load_results_summary(
         cost = payload.get("total_agent_cost")
     # Run-level results.json is only written at end of run, so during a live
     # run its Score/Cost are stale. Prefer live session-level aggregates (#190).
+    if session_records is None:
+        session_records = scan_sessions(Path(path).parent / "sessions")
     live_cost = 0.0
     live_scores: list[float] = []
     found = False
-    for sp in (Path(path).parent / "sessions").glob("*/results.json"):
-        try:
-            sdata = json.loads(sp.read_text(encoding="utf-8"))
-        except Exception:
+    for r in session_records:
+        if r.results is None:
             continue
         found = True
-        live_cost += float(sdata.get("agent_cost") or 0) + float(sdata.get("benchmark_cost") or 0)
-        s = sdata.get("score")
+        live_cost += float(r.results.get("agent_cost") or 0) + float(r.results.get("benchmark_cost") or 0)
+        s = r.results.get("score")
         if s is not None:
             live_scores.append(float(s))
     if found:
@@ -471,7 +474,14 @@ def batch_status_cmd(
                 parts.append(f"{errors}err")
             sessions_str = " ".join(parts)
 
-            score, cost, models, *_ = _load_results_summary(run_status.results_path)
+            sessions_dir = Path(run_status.results_path).parent / "sessions"
+            # One walk feeds both consumers below — _load_results_summary's
+            # live aggregation and the last_event timestamp.
+            session_records = scan_sessions(sessions_dir)
+
+            score, cost, models, *_ = _load_results_summary(
+                run_status.results_path, session_records=session_records
+            )
             model = run_status.model_name or models
             if model != "-":
                 # Strip common prefixes for readability.
@@ -483,19 +493,10 @@ def batch_status_cmd(
             subset = run_status.subset_name
             if subset:
                 benchmark = f"{benchmark}/{subset}"
-            sessions_dir = Path(run_status.results_path).parent / "sessions"
-            # results.json is what observers touch on every write, so its
-            # mtime is the true last-activity signal — accurate even during
-            # long-running sessions.
-            latest = 0.0
-            for p in _iter_session_files(sessions_dir, "results.json"):
-                try:
-                    m = p.stat().st_mtime
-                except OSError:
-                    continue
-                if m > latest:
-                    latest = m
-            last_event = _format_ago(time.time() - latest) if latest else "-"
+            # results.json mtime is the true last-activity signal — observers
+            # touch it on every write, so it's accurate during long sessions.
+            mtimes = [r.mtime for r in session_records if r.mtime is not None]
+            last_event = _format_ago(time.time() - max(mtimes)) if mtimes else "-"
             row.update(
                 {
                     "benchmark": benchmark,

--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -479,9 +479,7 @@ def batch_status_cmd(
             # live aggregation and the last_event timestamp.
             session_records = scan_sessions(sessions_dir)
 
-            score, cost, models, *_ = _load_results_summary(
-                run_status.results_path, session_records=session_records
-            )
+            score, cost, models, *_ = _load_results_summary(run_status.results_path, session_records=session_records)
             model = run_status.model_name or models
             if model != "-":
                 # Strip common prefixes for readability.

--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -9,6 +9,7 @@ import json
 import os
 import sys
 import time
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -215,6 +216,15 @@ def _apply_patch(payload: dict[str, Any], updates: dict[str, Any]) -> None:
         cursor[parts[-1]] = value
 
 
+def _iter_session_files(sessions_root: Path, filename: str) -> Iterator[Path]:
+    """Yield ``sessions_root/{id}/{filename}`` for each session subdirectory.
+
+    A one-level glob avoids walking nested benchmark/agent log dirs, which
+    dominates wall time on NFS for large session trees.
+    """
+    return sessions_root.glob(f"*/{filename}")
+
+
 def _update_session_ids_in_dir(session_dir: Path, new_id: str) -> None:
     # Top-level only: config.json and results.json carry session_id. Deeper
     # files (litellm cache logs, etc.) don't, and rglob over them on NFS is
@@ -254,9 +264,7 @@ def _recover_session_hashes(roots: list[Path], *, do_apply: bool) -> int:
         sessions_root = root / "sessions"
         if not sessions_root.exists():
             raise click.ClickException(f"sessions dir not found: {sessions_root}")
-        # Session config.json files live at sessions/{id}/config.json; the
-        # one-level glob avoids walking every nested benchmark/agent log dir.
-        for cfg_path in sessions_root.glob("*/config.json"):
+        for cfg_path in _iter_session_files(sessions_root, "config.json"):
             session_dir = cfg_path.parent
             old_id = session_dir.name
             config = _load_config_file(str(cfg_path))
@@ -476,13 +484,11 @@ def batch_status_cmd(
             if subset:
                 benchmark = f"{benchmark}/{subset}"
             sessions_dir = Path(run_status.results_path).parent / "sessions"
-            # Stat each session's results.json — that's the file we update on
-            # every observer write, so its mtime is the true "last activity"
-            # signal. Avoids rglob walking every trajectory/log file (which on
-            # NFS dominates wall time) while staying accurate during long-
-            # running sessions.
+            # results.json is what observers touch on every write, so its
+            # mtime is the true last-activity signal — accurate even during
+            # long-running sessions.
             latest = 0.0
-            for p in sessions_dir.glob("*/results.json"):
+            for p in _iter_session_files(sessions_dir, "results.json"):
                 try:
                     m = p.stat().st_mtime
                 except OSError:
@@ -785,9 +791,7 @@ def batch_patch_cmd(
         if not sessions_root.exists():
             raise click.ClickException(f"sessions dir not found: {sessions_root}")
         changes = 0
-        # Session config.json files live at sessions/{id}/config.json; the
-        # one-level glob avoids walking every nested benchmark/agent log dir.
-        for cfg_path in sessions_root.glob("*/config.json"):
+        for cfg_path in _iter_session_files(sessions_root, "config.json"):
             session_dir = cfg_path.parent
             old_id = session_dir.name
             config = _load_config_file(str(cfg_path))

--- a/tests/api/test_run_status_parallel.py
+++ b/tests/api/test_run_status_parallel.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Regression tests for the parallel scan in RunStatus.from_session_configs.
+
+This is the central choke-point for `batch status`, `batch evaluate`'s
+plan phase, and `batch aggregate`. A reordering bug would silently
+mismatch task IDs against statuses; integration tests would still pass
+because the *count* is right, but downstream RunPlan would zip wrong
+tasks to wrong statuses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from exgentic.core.types import RunConfig
+from exgentic.core.types.run import RunStatus
+from exgentic.core.types.session import SessionExecutionStatus
+
+
+def test_from_session_configs_preserves_input_order(tmp_path: Path):
+    cfg = RunConfig(
+        benchmark="test_benchmark",
+        agent="test_agent",
+        output_dir=str(tmp_path / "outputs"),
+        cache_dir=str(tmp_path / "cache"),
+        run_id="ordering-run",
+        # 64 tasks > the parallel pool size (32) — guarantees real parallel
+        # execution rather than a single-batch shortcut.
+        num_tasks=64,
+        benchmark_kwargs={"tasks": [f"task-{i:03d}" for i in range(64)]},
+        agent_kwargs={"policy": "good_then_finish", "finish_after": 1},
+    )
+
+    with cfg.get_context():
+        session_configs = cfg.get_session_configs()
+        run_status = RunStatus.from_session_configs(cfg, session_configs)
+
+    # No session has been executed → all MISSING.
+    assert all(s.status == SessionExecutionStatus.MISSING for s in run_status.session_statuses)
+
+    # Critical invariant: status[i].task_id == session_configs[i].task_id.
+    for sc, status in zip(session_configs, run_status.session_statuses):
+        assert status.task_id == str(sc.task_id), (
+            f"Order desync: input {sc.task_id!r} -> status.task_id {status.task_id!r}"
+        )
+
+    # And task_ids field on RunStatus matches the input order too.
+    assert run_status.task_ids == [str(sc.task_id) for sc in session_configs]
+
+
+def test_from_session_configs_empty(tmp_path: Path):
+    """Empty input must not raise (max_workers guard)."""
+    cfg = RunConfig(
+        benchmark="test_benchmark",
+        agent="test_agent",
+        output_dir=str(tmp_path / "outputs"),
+        cache_dir=str(tmp_path / "cache"),
+        run_id="empty-run",
+        num_tasks=0,
+        benchmark_kwargs={"tasks": []},
+        agent_kwargs={"policy": "good_then_finish", "finish_after": 1},
+    )
+
+    with cfg.get_context():
+        run_status = RunStatus.from_session_configs(cfg, [])
+
+    assert run_status.session_statuses == []
+    assert run_status.task_ids == []
+    assert run_status.total_tasks == 0

--- a/tests/api/test_run_status_parallel.py
+++ b/tests/api/test_run_status_parallel.py
@@ -41,7 +41,7 @@ def test_from_session_configs_preserves_input_order(tmp_path: Path):
     assert all(s.status == SessionExecutionStatus.MISSING for s in run_status.session_statuses)
 
     # Critical invariant: status[i].task_id == session_configs[i].task_id.
-    for sc, status in zip(session_configs, run_status.session_statuses):
+    for sc, status in zip(session_configs, run_status.session_statuses, strict=True):
         assert status.task_id == str(sc.task_id), (
             f"Order desync: input {sc.task_id!r} -> status.task_id {status.task_id!r}"
         )

--- a/tests/api/test_run_status_parallel.py
+++ b/tests/api/test_run_status_parallel.py
@@ -1,14 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
-"""Regression tests for the parallel scan in RunStatus.from_session_configs.
-
-This is the central choke-point for `batch status`, `batch evaluate`'s
-plan phase, and `batch aggregate`. A reordering bug would silently
-mismatch task IDs against statuses; integration tests would still pass
-because the *count* is right, but downstream RunPlan would zip wrong
-tasks to wrong statuses.
-"""
+"""Ordering invariant for the parallel scan in RunStatus.from_session_configs."""
 
 from __future__ import annotations
 
@@ -26,9 +19,7 @@ def test_from_session_configs_preserves_input_order(tmp_path: Path):
         output_dir=str(tmp_path / "outputs"),
         cache_dir=str(tmp_path / "cache"),
         run_id="ordering-run",
-        # 64 tasks > the parallel pool size (32) — guarantees real parallel
-        # execution rather than a single-batch shortcut.
-        num_tasks=64,
+        num_tasks=64,  # > pool size of 32 forces real parallelism
         benchmark_kwargs={"tasks": [f"task-{i:03d}" for i in range(64)]},
         agent_kwargs={"policy": "good_then_finish", "finish_after": 1},
     )
@@ -37,21 +28,13 @@ def test_from_session_configs_preserves_input_order(tmp_path: Path):
         session_configs = cfg.get_session_configs()
         run_status = RunStatus.from_session_configs(cfg, session_configs)
 
-    # No session has been executed → all MISSING.
     assert all(s.status == SessionExecutionStatus.MISSING for s in run_status.session_statuses)
-
-    # Critical invariant: status[i].task_id == session_configs[i].task_id.
     for sc, status in zip(session_configs, run_status.session_statuses, strict=True):
-        assert status.task_id == str(sc.task_id), (
-            f"Order desync: input {sc.task_id!r} -> status.task_id {status.task_id!r}"
-        )
-
-    # And task_ids field on RunStatus matches the input order too.
+        assert status.task_id == str(sc.task_id)
     assert run_status.task_ids == [str(sc.task_id) for sc in session_configs]
 
 
 def test_from_session_configs_empty(tmp_path: Path):
-    """Empty input must not raise (max_workers guard)."""
     cfg = RunConfig(
         benchmark="test_benchmark",
         agent="test_agent",

--- a/tests/core/test_session_inventory.py
+++ b/tests/core/test_session_inventory.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Tests for the SessionRecord / scan_sessions module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from exgentic.core.types.session_inventory import scan_sessions
+
+
+def _write_session(sessions_dir: Path, session_id: str, payload: dict | None) -> Path:
+    """Create sessions_dir/{session_id}/results.json with payload (or skip the file)."""
+    session_dir = sessions_dir / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    if payload is not None:
+        (session_dir / "results.json").write_text(json.dumps(payload), encoding="utf-8")
+    return session_dir
+
+
+def test_empty_sessions_dir(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    assert scan_sessions(sessions_dir) == []
+
+
+def test_missing_sessions_dir(tmp_path: Path):
+    """Missing directory must not raise — returns empty list."""
+    assert scan_sessions(tmp_path / "nonexistent") == []
+
+
+def test_skips_sessions_without_results_json(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    _write_session(sessions_dir, "with-results", {"score": 1.0})
+    _write_session(sessions_dir, "no-results", None)
+    records = scan_sessions(sessions_dir)
+    ids = {r.session_dir.name for r in records}
+    assert ids == {"with-results"}
+
+
+def test_parses_results_payload(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions"
+    _write_session(sessions_dir, "s1", {"score": 0.42, "agent_cost": 1.5})
+    [r] = scan_sessions(sessions_dir)
+    assert r.results == {"score": 0.42, "agent_cost": 1.5}
+    assert r.results_path == sessions_dir / "s1" / "results.json"
+    assert r.session_dir == sessions_dir / "s1"
+    assert r.mtime is not None
+
+
+def test_corrupt_json_yields_record_with_none_results(tmp_path: Path):
+    """Unparseable results.json must not crash the scan."""
+    sessions_dir = tmp_path / "sessions"
+    session_dir = sessions_dir / "broken"
+    session_dir.mkdir(parents=True)
+    (session_dir / "results.json").write_text("not json", encoding="utf-8")
+    [r] = scan_sessions(sessions_dir)
+    assert r.results is None
+    assert r.mtime is not None  # file still stat-able
+
+
+def test_non_dict_json_yields_none_results(tmp_path: Path):
+    """A JSON list/string/number at the root is invalid for results.json."""
+    sessions_dir = tmp_path / "sessions"
+    session_dir = sessions_dir / "list-payload"
+    session_dir.mkdir(parents=True)
+    (session_dir / "results.json").write_text("[1, 2, 3]", encoding="utf-8")
+    [r] = scan_sessions(sessions_dir)
+    assert r.results is None
+
+
+def test_parallel_scan_returns_all_records(tmp_path: Path):
+    """64 sessions > pool size (32) — exercises real parallel execution."""
+    sessions_dir = tmp_path / "sessions"
+    for i in range(64):
+        _write_session(sessions_dir, f"s{i:02d}", {"score": i / 100})
+    records = scan_sessions(sessions_dir)
+    assert len(records) == 64
+    scores = sorted(r.results["score"] for r in records)
+    assert scores == [i / 100 for i in range(64)]

--- a/tests/core/test_session_inventory.py
+++ b/tests/core/test_session_inventory.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
-"""Tests for the SessionRecord / scan_sessions module."""
-
 from __future__ import annotations
 
 import json
@@ -12,7 +10,6 @@ from exgentic.core.types.session_inventory import scan_sessions
 
 
 def _write_session(sessions_dir: Path, session_id: str, payload: dict | None) -> Path:
-    """Create sessions_dir/{session_id}/results.json with payload (or skip the file)."""
     session_dir = sessions_dir / session_id
     session_dir.mkdir(parents=True, exist_ok=True)
     if payload is not None:
@@ -27,7 +24,6 @@ def test_empty_sessions_dir(tmp_path: Path):
 
 
 def test_missing_sessions_dir(tmp_path: Path):
-    """Missing directory must not raise — returns empty list."""
     assert scan_sessions(tmp_path / "nonexistent") == []
 
 
@@ -51,18 +47,16 @@ def test_parses_results_payload(tmp_path: Path):
 
 
 def test_corrupt_json_yields_record_with_none_results(tmp_path: Path):
-    """Unparseable results.json must not crash the scan."""
     sessions_dir = tmp_path / "sessions"
     session_dir = sessions_dir / "broken"
     session_dir.mkdir(parents=True)
     (session_dir / "results.json").write_text("not json", encoding="utf-8")
     [r] = scan_sessions(sessions_dir)
     assert r.results is None
-    assert r.mtime is not None  # file still stat-able
+    assert r.mtime is not None
 
 
 def test_non_dict_json_yields_none_results(tmp_path: Path):
-    """A JSON list/string/number at the root is invalid for results.json."""
     sessions_dir = tmp_path / "sessions"
     session_dir = sessions_dir / "list-payload"
     session_dir.mkdir(parents=True)
@@ -72,9 +66,8 @@ def test_non_dict_json_yields_none_results(tmp_path: Path):
 
 
 def test_parallel_scan_returns_all_records(tmp_path: Path):
-    """64 sessions > pool size (32) — exercises real parallel execution."""
     sessions_dir = tmp_path / "sessions"
-    for i in range(64):
+    for i in range(64):  # > pool size of 32 forces real parallelism
         _write_session(sessions_dir, f"s{i:02d}", {"score": i / 100})
     records = scan_sessions(sessions_dir)
     assert len(records) == 64


### PR DESCRIPTION
Closes #210. Supersedes #209 and #211.

## Why

Two problems compound on the results-tree scan:

**Slow hot path.** Every results-scan caller — \`batch status\`, \`batch evaluate\`'s plan phase, \`batch aggregate\`, the lib \`status()\` helper — funnels into \`RunStatus.from_session_configs\`, which serially calls \`SessionStatus.from_config\` (4 NFS stat/read calls each) per session. On a 4600-session tree this list-comp burns 3-8 minutes before any worker spawns in \`batch evaluate\`, and the same penalty is paid by every status/aggregate invocation.

**Duplicated walks.** \`batch_status_cmd\` walked \`sessions/*/results.json\` *three* times: once via \`SessionStatus.from_config\` (status), once via \`_load_results_summary\` (live cost/score aggregation), and once via an \`rglob(\"*\")\` for last-event mtime. The work and the code were both duplicated.

## What

Three changes:

1. **Parallelize the inner per-session loop** in \`RunStatus.from_session_configs\` with a \`ThreadPoolExecutor\` (max 32). \`pool.map\` preserves input order, so downstream \`RunPlan\` zips correctly with the input task order. Every caller inherits the speedup with zero call-site changes.

2. **Single source of truth for results scans.** New \`core/types/session_inventory\` module with:
   - \`SessionRecord\` — frozen dataclass holding parsed \`results.json\` + mtime for one session. Distinct from \`SessionStatus\` (orchestrator's state machine view).
   - \`scan_sessions(sessions_dir)\` — one parallel walk returning \`list[SessionRecord]\`.
   
   Refactor \`_load_results_summary\` and \`batch_status_cmd\` to consume records from a single \`scan_sessions\` call, collapsing two duplicated walks into one. The \`last_event\` loop becomes \`max(mtimes)\`; live aggregation iterates the same records.

3. **Drop two over-broad rglobs** in admin \`batch patch\` helpers (\`rglob(\"config.json\")\` → \`glob(\"*/config.json\")\`, \`rglob(\"*.json\")\` → \`glob(\"*.json\")\`). Same justification: the structure is known.

## Measurement

50 OSS configs, 4600 sessions, NFS-backed run tree:

| | \`exgentic batch status\` |
|---|---|
| Before | 10–25 min |
| After | **~7 s** (>100x) |

Output is byte-for-byte identical against the same tree.

## Tests

- \`tests/core/test_session_inventory.py\` (7 tests): empty dir, missing dir, skip-without-results, parsed payload, corrupt JSON, non-dict JSON, 64-session parallel scan.
- \`tests/api/test_run_status_parallel.py\` (2 tests): input order preserved through the parallel scan + empty-input edge case.
- Existing \`tests/api/test_cli_batch.py\` (6 tests) and \`tests/core/test_session_status.py\` (11 tests) pass unchanged.
- \`tests/api/test_cli_compare.py\` failures pre-exist on \`main\` and are unrelated.

## Risk

- \`SessionStatus.from_config\` is pure I/O when \`run_paths\` is provided (the caller does); no thread-unsafe shared state.
- \`SessionRecord\` is intentionally separate from \`SessionStatus\`. Records are for consumers that want the parsed payload; status is for the orchestrator's RUNNING/COMPLETED/etc. state. Keeping them apart preserves the orchestrator's subtle lock-acquire semantics untouched.
- Hardcoded \`max_workers=32\` (named \`_MAX_SCAN_WORKERS\` constant) — leaving as a follow-up if production tuning is needed.