### PR TITLE
feat(litellm): expose litellm_params_extra everywhere we talk to LiteLLM

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -156,6 +156,10 @@ exgentic evaluate \
 --set agent.model.num_retries=3
 --set agent.model.retry_after=1.0
 --set agent.model.retry_strategy=constant
+
+# Non-standard backend params (api_base, custom auth headers, etc.)
+# See docs/custom-models.md → "Non-standard backends"
+--set agent.litellm_params_extra='{"api_base":"https://gw.example/v1","extra_headers":{"X-Backend-Auth":"$KEY"}}'
 ```
 
 ---

--- a/docs/custom-models.md
+++ b/docs/custom-models.md
@@ -195,6 +195,79 @@ results = evaluate(
 
 ---
 
+## Non-standard backends (custom headers, custom auth)
+
+Some OpenAI-compatible gateways require auth to ride in a custom HTTP header (e.g. `X-Backend-Auth: <token>`) instead of the standard `Authorization: Bearer <token>`. Setting `OPENAI_API_BASE` alone isn't enough in that case — LiteLLM also needs to know to send the custom header.
+
+For these backends, every Exgentic agent and benchmark accepts a `litellm_params_extra` dict that is forwarded to LiteLLM verbatim. It accepts any key LiteLLM's per-model `litellm_params` block accepts: `api_base`, `api_key`, `extra_headers`, an alias-vs-actual `model` split, etc.
+
+### CLI
+
+```bash
+exgentic evaluate --benchmark gsm8k --agent tool_calling \
+  --model openai/my-model \
+  --set agent.litellm_params_extra='{"api_base":"https://gateway.example/v1","api_key":"$BACKEND_KEY","extra_headers":{"X-Backend-Auth":"$BACKEND_KEY"}}'
+```
+
+The value after `=` is parsed as JSON. Quote it carefully in your shell.
+
+For benchmarks that drive their own LLM (e.g. Tau2's user simulator, BrowseComp's judge), use the benchmark's own field:
+
+```bash
+# Tau2 user simulator
+--set benchmark.user_simulator_litellm_params_extra='{"api_base":"...","extra_headers":{"X-Backend-Auth":"$KEY"}}'
+```
+
+### Python API
+
+```python
+from exgentic import evaluate
+
+extras = {
+    "api_base": "https://gateway.example/v1",
+    "api_key": os.environ["BACKEND_KEY"],
+    "extra_headers": {"X-Backend-Auth": os.environ["BACKEND_KEY"]},
+}
+
+results = evaluate(
+    benchmark="gsm8k",
+    agent="tool_calling",
+    num_tasks=5,
+    model="openai/my-model",
+    agent_kwargs={"litellm_params_extra": extras},
+    # For Tau2: benchmark_kwargs={"user_simulator_litellm_params_extra": extras}
+)
+```
+
+### Aliasing one model name to another
+
+You can expose a friendly alias to clients while routing to a different underlying model:
+
+```python
+agent_kwargs={
+    "litellm_params_extra": {
+        "model": "hosted_vllm/some-model",  # what LiteLLM actually calls
+        "api_base": "...",
+        "api_key": "...",
+    },
+}
+# Clients still address the agent as "my-alias" via the `model=` argument.
+```
+
+### Where this is wired
+
+The same `litellm_params_extra` dict reaches every LiteLLM call site Exgentic owns:
+
+- The LiteLLM proxy started by CLI agents (Codex, Gemini, Claude Code).
+- The direct `litellm.acompletion` calls in `LiteLLMToolCallingAgentInstance` and the model-accessibility health check.
+- The smolagents `LiteLLMModel` constructor.
+- The openai-agents `LitellmModel` (with `api_base` mapped to its `base_url` constructor kwarg, `extra_headers` to `OpenAIModelSettings.extra_headers`, and any other keys forwarded as `extra_args`).
+- The judge model in `BrowseCompEvaluator` and the user simulator in `TAU2Session`.
+
+So the same config works everywhere — pick the agent and benchmark you want, supply the dict once, and you're done.
+
+---
+
 ## Reasoning models
 
 For models that support reasoning effort (OpenAI o1, o3, etc.):

--- a/src/exgentic/agents/cli/base.py
+++ b/src/exgentic/agents/cli/base.py
@@ -114,6 +114,7 @@ class ProxyBackedMCPAgentInstance(MCPAgentInstance, abc.ABC):
         model_alias: str | None = None,
         execution_backend: ExecutionBackend = ExecutionBackend.DOCKER,
         model_settings: ModelSettings | None = None,
+        litellm_params_extra: dict[str, object] | None = None,
     ) -> None:
         super().__init__(session_id)
         self.model_id = model_id
@@ -130,9 +131,15 @@ class ProxyBackedMCPAgentInstance(MCPAgentInstance, abc.ABC):
             self.model_settings = model_settings
         else:
             raise ValueError("model_settings must be a ModelSettings instance.")
+        self._litellm_params_extra: dict[str, object] = dict(litellm_params_extra or {})
 
         # Check model accessibility
-        check_model_accessible_sync(self.model_id, logger=self.logger, model_settings=self.model_settings)
+        check_model_accessible_sync(
+            self.model_id,
+            logger=self.logger,
+            model_settings=self.model_settings,
+            litellm_params_extra=self._litellm_params_extra or None,
+        )
 
     @property
     @abc.abstractmethod
@@ -193,6 +200,7 @@ class ProxyBackedMCPAgentInstance(MCPAgentInstance, abc.ABC):
             usage_log_path=str(self._trace_log_path),
             model_alias_map=alias_map or None,
             model_settings=self.model_settings,
+            litellm_params_extra=self._litellm_params_extra or None,
         )
         self._proxy = proxy
         try:

--- a/src/exgentic/agents/cli/base.py
+++ b/src/exgentic/agents/cli/base.py
@@ -140,7 +140,7 @@ class ProxyBackedMCPAgentInstance(MCPAgentInstance, abc.ABC):
             self.model_id,
             logger=self.logger,
             model_settings=self.model_settings,
-            litellm_params_extra=self._litellm_params_extra or None,
+            litellm_params_extra=self._litellm_params_extra,
         )
 
     @property
@@ -202,7 +202,7 @@ class ProxyBackedMCPAgentInstance(MCPAgentInstance, abc.ABC):
             usage_log_path=str(self._trace_log_path),
             model_alias_map=alias_map or None,
             model_settings=self.model_settings,
-            litellm_params_extra=self._litellm_params_extra or None,
+            litellm_params_extra=self._litellm_params_extra,
         )
         self._proxy = proxy
         try:

--- a/src/exgentic/agents/cli/base.py
+++ b/src/exgentic/agents/cli/base.py
@@ -10,6 +10,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from pydantic import Field
+
 from ...adapters.agents.mcp_agent import MCPAgentInstance
 from ...core.agent import Agent
 from ...core.context import get_runtime_env
@@ -321,6 +323,7 @@ class ProxyBackedAgent(Agent):
 
     execution_backend: ExecutionBackend = ExecutionBackend.DOCKER
     model_settings: ModelSettings | None = None
+    litellm_params_extra: dict[str, Any] = Field(default_factory=dict)
 
     def _get_instance_kwargs(
         self,
@@ -332,6 +335,7 @@ class ProxyBackedAgent(Agent):
             "max_steps": self.max_steps,
             "execution_backend": self.execution_backend,
             "model_settings": self.model_settings,
+            "litellm_params_extra": self.litellm_params_extra,
         }
 
     @property

--- a/src/exgentic/agents/cli/claude/agent.py
+++ b/src/exgentic/agents/cli/claude/agent.py
@@ -45,6 +45,7 @@ class ClaudeCodeAgentInstance(ProxyBackedMCPAgentInstance):
         max_steps: int = 150,
         execution_backend: ExecutionBackend = ExecutionBackend.DOCKER,
         model_settings: ModelSettings | None = None,
+        litellm_params_extra: dict[str, object] | None = None,
     ):
         # The alias is what we ask Claude Code CLI for; the proxy maps it to the backend model.
         self._claude_model_alias = "claude-3-5-sonnet-20241022"
@@ -55,6 +56,7 @@ class ClaudeCodeAgentInstance(ProxyBackedMCPAgentInstance):
             model_alias=self._claude_model_alias,
             execution_backend=execution_backend,
             model_settings=model_settings,
+            litellm_params_extra=litellm_params_extra,
         )
         self._claude_log = self.paths.agent_dir / "claude_cli.log"
 

--- a/src/exgentic/agents/cli/codex/agent.py
+++ b/src/exgentic/agents/cli/codex/agent.py
@@ -21,6 +21,7 @@ class CodexAgentInstance(ProxyBackedMCPAgentInstance):
         max_steps: int = 150,
         execution_backend: ExecutionBackend = ExecutionBackend.DOCKER,
         model_settings: ModelSettings | None = None,
+        litellm_params_extra: dict[str, object] | None = None,
     ):
         super().__init__(
             session_id,
@@ -28,6 +29,7 @@ class CodexAgentInstance(ProxyBackedMCPAgentInstance):
             max_steps=max_steps,
             execution_backend=execution_backend,
             model_settings=model_settings,
+            litellm_params_extra=litellm_params_extra,
         )
         self._codex_log = self.paths.agent_dir / "codex_cli.log"
 

--- a/src/exgentic/agents/cli/gemini/agent.py
+++ b/src/exgentic/agents/cli/gemini/agent.py
@@ -21,6 +21,7 @@ class GeminiAgentInstance(ProxyBackedMCPAgentInstance):
         max_steps: int = 150,
         execution_backend: ExecutionBackend = ExecutionBackend.DOCKER,
         model_settings: ModelSettings | None = None,
+        litellm_params_extra: dict[str, object] | None = None,
     ):
         self._gemini_model_alias = "gemini-2.5-pro"
         super().__init__(
@@ -30,6 +31,7 @@ class GeminiAgentInstance(ProxyBackedMCPAgentInstance):
             model_alias=self._gemini_model_alias,
             execution_backend=execution_backend,
             model_settings=model_settings,
+            litellm_params_extra=litellm_params_extra,
         )
         self._gemini_log = self.paths.agent_dir / "gemini_cli.log"
 

--- a/src/exgentic/agents/litellm_tool_calling/instance.py
+++ b/src/exgentic/agents/litellm_tool_calling/instance.py
@@ -56,6 +56,7 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
         max_selected_tools: int = 30,
         model_settings: ModelSettings | None = None,
         allow_truncated_messages: bool = False,
+        litellm_params_extra: dict[str, object] | None = None,
     ):
         super().__init__(session_id)
         self.model = model
@@ -69,6 +70,7 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
         else:
             raise ValueError("model_settings must be a ModelSettings instance.")
         self._allow_truncated_messages = allow_truncated_messages
+        self._litellm_params_extra: dict[str, object] = dict(litellm_params_extra or {})
         self._use_cache = settings.litellm_caching
         self.logger.debug(
             "LiteLLM cache %s (dir=%s)",
@@ -87,7 +89,12 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
         self._cost_data = LiteLLMCostReport.initialize_empty(model_name=self.model)
 
         # Check model accessibility
-        check_model_accessible_sync(self.model, logger=self.logger, model_settings=self.model_settings)
+        check_model_accessible_sync(
+            self.model,
+            logger=self.logger,
+            model_settings=self.model_settings,
+            litellm_params_extra=self._litellm_params_extra or None,
+        )
 
     def start(self, task, context, actions):
         """Receive work payload, build tool registry, and seed conversation."""
@@ -363,6 +370,7 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
             exclude_none=True,
             exclude={"num_retries", "retry_after", "retry_strategy"},
         )
+        call_kwargs.update(self._litellm_params_extra)
         call_kwargs.update(kwargs)
         return self._completion_with_retries(call_kwargs)
 

--- a/src/exgentic/agents/litellm_tool_calling/instance.py
+++ b/src/exgentic/agents/litellm_tool_calling/instance.py
@@ -93,7 +93,7 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
             self.model,
             logger=self.logger,
             model_settings=self.model_settings,
-            litellm_params_extra=self._litellm_params_extra or None,
+            litellm_params_extra=self._litellm_params_extra,
         )
 
     def start(self, task, context, actions):

--- a/src/exgentic/agents/litellm_tool_calling/litellm_tool_calling_agent.py
+++ b/src/exgentic/agents/litellm_tool_calling/litellm_tool_calling_agent.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
+from pydantic import Field
+
 from ...core.agent import Agent
 from ...core.types import ModelSettings
 
@@ -21,6 +23,7 @@ class LiteLLMToolCallingAgent(Agent):
     max_selected_tools: int = 30
     model_settings: ModelSettings | None = None
     allow_truncated_messages: bool = False
+    litellm_params_extra: dict[str, Any] = Field(default_factory=dict)
 
     @classmethod
     def _get_instance_class(cls):
@@ -51,4 +54,5 @@ class LiteLLMToolCallingAgent(Agent):
             "max_steps": self.max_steps,
             "model_settings": self.model_settings,
             "allow_truncated_messages": self.allow_truncated_messages,
+            "litellm_params_extra": self.litellm_params_extra,
         }

--- a/src/exgentic/agents/openai/instance.py
+++ b/src/exgentic/agents/openai/instance.py
@@ -40,6 +40,23 @@ class _UsageRunHooks(RunHooksBase[dict[str, Any], OpenAIAgent]):
         self._record_usage(response.usage)
 
 
+def _split_litellm_params_extra_for_openai_agents(
+    extras: dict[str, object],
+) -> tuple[str | None, str | None, dict[str, str] | None, dict[str, object]]:
+    """Translate a ``litellm_params_extra`` dict into openai-agents shape.
+
+    The openai-agents ``LitellmModel`` splits the same concepts across the
+    constructor (``base_url``, ``api_key``) and ``model_settings``
+    (``extra_headers``, ``extra_args``).  Returns a 4-tuple of
+    ``(base_url, api_key, extra_headers, remaining_extras)``.
+    """
+    remaining = dict(extras)
+    base_url = remaining.pop("api_base", None)
+    api_key = remaining.pop("api_key", None)
+    extra_headers = remaining.pop("extra_headers", None)
+    return base_url, api_key, extra_headers, remaining
+
+
 class RetryingLitellmModel(LitellmModel):
     def __init__(
         self,
@@ -211,14 +228,13 @@ class OpenAIMCPAgentInstance(MCPAgentInstance):
                 num_retries = self.model_settings.num_retries or 0
                 retry_after = self.model_settings.retry_after
                 retry_strategy = self.model_settings.retry_strategy.value
-                extras = dict(self._litellm_params_extra)
-                base_url = extras.pop("api_base", None)
-                api_key = extras.pop("api_key", None)
-                extra_headers = extras.pop("extra_headers", None)
+                base_url, api_key, extra_headers, remaining_extras = _split_litellm_params_extra_for_openai_agents(
+                    self._litellm_params_extra
+                )
                 openai_model_settings.extra_args = {
                     "caching": settings.litellm_caching,
                     "max_retries": 0 if num_retries > 0 else 5,
-                    **extras,
+                    **remaining_extras,
                 }
                 if extra_headers is not None:
                     openai_model_settings.extra_headers = extra_headers

--- a/src/exgentic/agents/openai/instance.py
+++ b/src/exgentic/agents/openai/instance.py
@@ -48,8 +48,10 @@ class RetryingLitellmModel(LitellmModel):
         num_retries: int,
         retry_after: float,
         retry_strategy: str | RetryStrategy,
+        base_url: str | None = None,
+        api_key: str | None = None,
     ):
-        super().__init__(model=model)
+        super().__init__(model=model, base_url=base_url, api_key=api_key)
         if isinstance(retry_strategy, RetryStrategy):
             retry_strategy = retry_strategy.value
         if retry_strategy not in ("exponential_backoff_retry", "constant_retry"):
@@ -93,6 +95,7 @@ class OpenAIMCPAgentInstance(MCPAgentInstance):
         max_steps: int = 150,
         model_settings: ModelSettings | None = None,
         mcp_config: MCPConfig | dict | None = None,
+        litellm_params_extra: dict[str, object] | None = None,
     ):
         super().__init__(session_id)
         self.model_id = model_id
@@ -109,6 +112,7 @@ class OpenAIMCPAgentInstance(MCPAgentInstance):
             self.mcp_config = MCPConfig(**mcp_config)
         else:
             self.mcp_config = mcp_config
+        self._litellm_params_extra: dict[str, object] = dict(litellm_params_extra or {})
         self._total_input_tokens = 0
         self._total_output_tokens = 0
         self._model_access_checked = False
@@ -117,7 +121,11 @@ class OpenAIMCPAgentInstance(MCPAgentInstance):
         if self._model_access_checked or self.mcp_config.skip_health_check:
             return
         self.logger.info("Running LiteLLM model health check (model=%s)", self.model_id)
-        await acheck_model_accessible(self.model_id, model_settings=self.model_settings)
+        await acheck_model_accessible(
+            self.model_id,
+            model_settings=self.model_settings,
+            litellm_params_extra=self._litellm_params_extra or None,
+        )
         self._model_access_checked = True
 
     def _record_usage(self, usage: Usage | None) -> None:
@@ -203,10 +211,17 @@ class OpenAIMCPAgentInstance(MCPAgentInstance):
                 num_retries = self.model_settings.num_retries or 0
                 retry_after = self.model_settings.retry_after
                 retry_strategy = self.model_settings.retry_strategy.value
+                extras = dict(self._litellm_params_extra)
+                base_url = extras.pop("api_base", None)
+                api_key = extras.pop("api_key", None)
+                extra_headers = extras.pop("extra_headers", None)
                 openai_model_settings.extra_args = {
                     "caching": settings.litellm_caching,
                     "max_retries": 0 if num_retries > 0 else 5,
+                    **extras,
                 }
+                if extra_headers is not None:
+                    openai_model_settings.extra_headers = extra_headers
                 agent = OpenAIAgent(
                     name="Assistant",
                     instructions=prompt,
@@ -215,6 +230,8 @@ class OpenAIMCPAgentInstance(MCPAgentInstance):
                         num_retries=num_retries,
                         retry_after=retry_after,
                         retry_strategy=retry_strategy,
+                        base_url=base_url,
+                        api_key=api_key,
                     ),
                     model_settings=openai_model_settings,
                     mcp_servers=[mcp_server],

--- a/src/exgentic/agents/openai/instance.py
+++ b/src/exgentic/agents/openai/instance.py
@@ -40,23 +40,6 @@ class _UsageRunHooks(RunHooksBase[dict[str, Any], OpenAIAgent]):
         self._record_usage(response.usage)
 
 
-def _split_litellm_params_extra_for_openai_agents(
-    extras: dict[str, object],
-) -> tuple[str | None, str | None, dict[str, str] | None, dict[str, object]]:
-    """Translate a ``litellm_params_extra`` dict into openai-agents shape.
-
-    The openai-agents ``LitellmModel`` splits the same concepts across the
-    constructor (``base_url``, ``api_key``) and ``model_settings``
-    (``extra_headers``, ``extra_args``).  Returns a 4-tuple of
-    ``(base_url, api_key, extra_headers, remaining_extras)``.
-    """
-    remaining = dict(extras)
-    base_url = remaining.pop("api_base", None)
-    api_key = remaining.pop("api_key", None)
-    extra_headers = remaining.pop("extra_headers", None)
-    return base_url, api_key, extra_headers, remaining
-
-
 class RetryingLitellmModel(LitellmModel):
     def __init__(
         self,
@@ -141,7 +124,7 @@ class OpenAIMCPAgentInstance(MCPAgentInstance):
         await acheck_model_accessible(
             self.model_id,
             model_settings=self.model_settings,
-            litellm_params_extra=self._litellm_params_extra or None,
+            litellm_params_extra=self._litellm_params_extra,
         )
         self._model_access_checked = True
 
@@ -228,13 +211,14 @@ class OpenAIMCPAgentInstance(MCPAgentInstance):
                 num_retries = self.model_settings.num_retries or 0
                 retry_after = self.model_settings.retry_after
                 retry_strategy = self.model_settings.retry_strategy.value
-                base_url, api_key, extra_headers, remaining_extras = _split_litellm_params_extra_for_openai_agents(
-                    self._litellm_params_extra
-                )
+                extras = dict(self._litellm_params_extra)
+                base_url = extras.pop("api_base", None)
+                api_key = extras.pop("api_key", None)
+                extra_headers = extras.pop("extra_headers", None)
                 openai_model_settings.extra_args = {
                     "caching": settings.litellm_caching,
                     "max_retries": 0 if num_retries > 0 else 5,
-                    **remaining_extras,
+                    **extras,
                 }
                 if extra_headers is not None:
                     openai_model_settings.extra_headers = extra_headers

--- a/src/exgentic/agents/openai/openai_mcp_agent.py
+++ b/src/exgentic/agents/openai/openai_mcp_agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from ...core.agent import Agent
 from ...core.types import ModelSettings
@@ -37,6 +37,7 @@ class OpenAIMCPAgent(Agent):
     max_steps: int = 150
     model_settings: ModelSettings | None = None
     mcp_config: MCPConfig | dict | None = None
+    litellm_params_extra: dict[str, Any] = Field(default_factory=dict)
 
     @classmethod
     def _get_instance_class(cls):
@@ -58,6 +59,7 @@ class OpenAIMCPAgent(Agent):
             "max_steps": self.max_steps,
             "model_settings": self.model_settings,
             "mcp_config": self.mcp_config,
+            "litellm_params_extra": self.litellm_params_extra,
         }
 
     @property

--- a/src/exgentic/agents/smolagents/base_agent.py
+++ b/src/exgentic/agents/smolagents/base_agent.py
@@ -3,6 +3,8 @@
 
 from typing import Any, ClassVar
 
+from pydantic import Field
+
 from ...core.agent import Agent
 from ...core.types import ModelSettings
 
@@ -15,6 +17,7 @@ class SmolagentBaseAgent(Agent):
     max_steps: int = 150
     model_settings: ModelSettings | None = None
     retry_on_all_errors: bool = True
+    litellm_params_extra: dict[str, Any] = Field(default_factory=dict)
 
     def _get_instance_kwargs(
         self,
@@ -26,6 +29,7 @@ class SmolagentBaseAgent(Agent):
             "max_steps": self.max_steps,
             "model_settings": self.model_settings,
             "retry_on_all_errors": self.retry_on_all_errors,
+            "litellm_params_extra": self.litellm_params_extra,
         }
 
     @property

--- a/src/exgentic/agents/smolagents/base_instance.py
+++ b/src/exgentic/agents/smolagents/base_instance.py
@@ -31,6 +31,7 @@ class SmolagentBaseAgentInstance(CodeAgentInstance):
         max_steps: int = 150,
         model_settings: ModelSettings | None = None,
         retry_on_all_errors: bool = True,
+        litellm_params_extra: dict[str, object] | None = None,
     ):
         super().__init__(session_id)
         self.model_id = model_id
@@ -42,11 +43,17 @@ class SmolagentBaseAgentInstance(CodeAgentInstance):
         else:
             raise ValueError("model_settings must be a ModelSettings instance.")
         self._retry_on_all_errors = retry_on_all_errors
+        self._litellm_params_extra: dict[str, object] = dict(litellm_params_extra or {})
         self._agent = None
         self._model = None
 
         # Check model accessibility
-        check_model_accessible_sync(self.model_id, logger=self.logger, model_settings=self.model_settings)
+        check_model_accessible_sync(
+            self.model_id,
+            logger=self.logger,
+            model_settings=self.model_settings,
+            litellm_params_extra=self._litellm_params_extra or None,
+        )
 
     def run_code_agent(self, functions: list[Callable]) -> None:
         def _wrap_tool(fn: Callable) -> Callable:
@@ -91,6 +98,7 @@ class SmolagentBaseAgentInstance(CodeAgentInstance):
                 temperature=temperature if temperature is not None else 1.0,
                 max_tokens=self.model_settings.max_tokens,
                 caching=settings.litellm_caching,
+                **self._litellm_params_extra,
             )
             num_retries = self.model_settings.num_retries or 0
             max_attempts = num_retries + 1 if num_retries > 0 else 1

--- a/src/exgentic/agents/smolagents/base_instance.py
+++ b/src/exgentic/agents/smolagents/base_instance.py
@@ -52,7 +52,7 @@ class SmolagentBaseAgentInstance(CodeAgentInstance):
             self.model_id,
             logger=self.logger,
             model_settings=self.model_settings,
-            litellm_params_extra=self._litellm_params_extra or None,
+            litellm_params_extra=self._litellm_params_extra,
         )
 
     def run_code_agent(self, functions: list[Callable]) -> None:

--- a/src/exgentic/benchmarks/browsecompplus/browsecomp_eval.py
+++ b/src/exgentic/benchmarks/browsecompplus/browsecomp_eval.py
@@ -27,6 +27,7 @@ class BrowseCompEvaluator(BaseModel):
     eval_model_id: str
     sampling_params: dict[str, Any] = {}
     grader_template: str
+    litellm_params_extra: dict[str, Any] = {}
 
     def evaluate_response(
         self,
@@ -66,6 +67,7 @@ class BrowseCompEvaluator(BaseModel):
                 max_tokens=self.max_output_tokens,
                 litellm_metadata={"context": try_get_context()},
                 **self.sampling_params,
+                **self.litellm_params_extra,
             )
             choice = judge_response["choices"][0]
             judge_textual_response = choice.get("message").content

--- a/src/exgentic/benchmarks/browsecompplus/browsecomp_eval.py
+++ b/src/exgentic/benchmarks/browsecompplus/browsecomp_eval.py
@@ -5,7 +5,7 @@ import json
 from typing import Any
 
 import litellm
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from scripts_evaluation.evaluate_with_openai import (
     GRADER_TEMPLATE as GRADER_TEMPLATE_OPENAI,
 )
@@ -27,7 +27,7 @@ class BrowseCompEvaluator(BaseModel):
     eval_model_id: str
     sampling_params: dict[str, Any] = {}
     grader_template: str
-    litellm_params_extra: dict[str, Any] = {}
+    litellm_params_extra: dict[str, Any] = Field(default_factory=dict)
 
     def evaluate_response(
         self,

--- a/src/exgentic/benchmarks/tau2/tau2_benchmark.py
+++ b/src/exgentic/benchmarks/tau2/tau2_benchmark.py
@@ -41,6 +41,7 @@ class TAU2Benchmark(Benchmark, BaseModel):
     max_errors: int = 10
     num_trials: int = 1
     score_path: str | None = None
+    user_simulator_litellm_params_extra: dict[str, Any] = {}
 
     def list_subsets(self) -> list[str]:  # type: ignore[override]
         return list(self.available_subsets)
@@ -63,4 +64,5 @@ class TAU2Benchmark(Benchmark, BaseModel):
             "num_trials": self.num_trials,
             "seed": self.seed,
             "use_cache": self.use_cache,
+            "user_simulator_litellm_params_extra": self.user_simulator_litellm_params_extra,
         }

--- a/src/exgentic/benchmarks/tau2/tau2_benchmark.py
+++ b/src/exgentic/benchmarks/tau2/tau2_benchmark.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from ...core import Benchmark
 
@@ -41,7 +41,7 @@ class TAU2Benchmark(Benchmark, BaseModel):
     max_errors: int = 10
     num_trials: int = 1
     score_path: str | None = None
-    user_simulator_litellm_params_extra: dict[str, Any] = {}
+    user_simulator_litellm_params_extra: dict[str, Any] = Field(default_factory=dict)
 
     def list_subsets(self) -> list[str]:  # type: ignore[override]
         return list(self.available_subsets)

--- a/src/exgentic/benchmarks/tau2/tau2_eval.py
+++ b/src/exgentic/benchmarks/tau2/tau2_eval.py
@@ -148,8 +148,6 @@ class TAU2Session(PairableProxySession):
             llm_args_user["input_cost_per_token"] = llm_user_input_cost_per_token
         if llm_user_output_cost_per_token is not None:
             llm_args_user["output_cost_per_token"] = llm_user_output_cost_per_token
-        # Forward user-supplied LiteLLM params (api_base, api_key, extra_headers, ...)
-        # so the Tau2 user simulator can hit non-standard backends.
         llm_args_user.update(self._user_simulator_litellm_params_extra)
         self._cfg = RunConfig(
             domain=subset,

--- a/src/exgentic/benchmarks/tau2/tau2_eval.py
+++ b/src/exgentic/benchmarks/tau2/tau2_eval.py
@@ -135,9 +135,11 @@ class TAU2Session(PairableProxySession):
         seed: int,
         use_cache: bool,
         session_id: str | None = None,
+        user_simulator_litellm_params_extra: dict[str, Any] | None = None,
     ):
         if session_id is not None:
             self._session_id = session_id
+        self._user_simulator_litellm_params_extra: dict[str, Any] = dict(user_simulator_litellm_params_extra or {})
         llm_args_user: dict[str, Any] = {
             "temperature": llm_temperature_user,
             "caching": settings.litellm_caching,
@@ -146,6 +148,9 @@ class TAU2Session(PairableProxySession):
             llm_args_user["input_cost_per_token"] = llm_user_input_cost_per_token
         if llm_user_output_cost_per_token is not None:
             llm_args_user["output_cost_per_token"] = llm_user_output_cost_per_token
+        # Forward user-supplied LiteLLM params (api_base, api_key, extra_headers, ...)
+        # so the Tau2 user simulator can hit non-standard backends.
+        llm_args_user.update(self._user_simulator_litellm_params_extra)
         self._cfg = RunConfig(
             domain=subset,
             user="user_simulator",
@@ -223,7 +228,11 @@ class TAU2Session(PairableProxySession):
         self.results_file = self.paths.benchmark_results
 
         # Check user simulator model accessibility before starting Tau2 runner
-        check_model_accessible_sync(self._cfg.llm_user, logger=self.logger)
+        check_model_accessible_sync(
+            self._cfg.llm_user,
+            logger=self.logger,
+            litellm_params_extra=self._user_simulator_litellm_params_extra or None,
+        )
 
         # Start Tau2 runner
         self.logger.debug("Staging for pairing")

--- a/src/exgentic/integrations/litellm/health.py
+++ b/src/exgentic/integrations/litellm/health.py
@@ -158,6 +158,7 @@ async def acheck_model_accessible(
     model: str,
     *,
     model_settings: ModelSettings | None = None,
+    litellm_params_extra: dict[str, object] | None = None,
 ) -> None:
     """Raise if LiteLLM cannot access the configured model.
 
@@ -176,6 +177,11 @@ async def acheck_model_accessible(
     attempts with at least :data:`_HEALTH_MIN_RETRY_DELAY` seconds
     base delay (capped at :data:`_HEALTH_MAX_RETRY_DELAY`) so that
     flaky endpoints have enough time to recover.
+
+    ``litellm_params_extra`` is forwarded to ``litellm.acompletion`` so
+    callers targeting non-standard backends can supply ``api_base``,
+    ``api_key``, ``extra_headers``, or any other LiteLLM-supported
+    per-call parameter.
     """
     import litellm
 
@@ -184,6 +190,7 @@ async def acheck_model_accessible(
 
     if model_settings is None:
         model_settings = _ModelSettings()
+    extra = dict(litellm_params_extra or {})
 
     num_retries = max(model_settings.num_retries or 0, _HEALTH_MIN_RETRIES)
     retry_after = max(model_settings.retry_after, _HEALTH_MIN_RETRY_DELAY)
@@ -197,6 +204,7 @@ async def acheck_model_accessible(
                 messages=[{"role": "user", "content": "hi"}],
                 max_tokens=1,
                 caching=False,
+                **extra,
             )
             return
         except Exception as exc:
@@ -223,6 +231,7 @@ def check_model_accessible_sync(
     logger: logging.Logger,
     timeout: float = 240.0,
     model_settings: ModelSettings | None = None,
+    litellm_params_extra: dict[str, object] | None = None,
 ) -> None:
     """Synchronous wrapper for model health check.
 
@@ -232,6 +241,9 @@ def check_model_accessible_sync(
         timeout: Timeout in seconds for the health check
         model_settings: Optional retry settings; uses ``ModelSettings()`` defaults
             when *None*.
+        litellm_params_extra: Optional dict forwarded to ``litellm.acompletion``
+            for non-standard backends (``api_base``, ``api_key``,
+            ``extra_headers``, ...).
 
     Raises:
         HealthCheckError: If the model is not accessible
@@ -241,7 +253,11 @@ def check_model_accessible_sync(
     logger.info("Running LiteLLM model health check (model=%s)", model)
     try:
         run_sync(
-            acheck_model_accessible(model, model_settings=model_settings),
+            acheck_model_accessible(
+                model,
+                model_settings=model_settings,
+                litellm_params_extra=litellm_params_extra,
+            ),
             timeout=timeout,
         )
         logger.info("Model health check passed for %s", model)

--- a/src/exgentic/integrations/litellm/proxy.py
+++ b/src/exgentic/integrations/litellm/proxy.py
@@ -9,6 +9,22 @@ Usage (expects OPENAI_API_BASE/OPENAI_API_KEY already set for your backend):
     with LitellmProxy(model="openai/gpt-4o-mini") as proxy:
         os.environ["OPENAI_API_BASE"] = proxy.base_url
         # run your Codex/Exgentic flow that expects an OpenAI-compatible endpoint
+
+For non-standard backends, ``litellm_params_extra`` forwards any
+LiteLLM-supported per-model parameter (e.g. ``api_base``, ``api_key``,
+``extra_headers``, an alias-vs-actual ``model`` split) into the generated
+proxy config. Example for an OpenAI-compatible gateway that uses a custom
+auth header:
+
+    LitellmProxy(
+        model="rits/granite",
+        litellm_params_extra={
+            "model": "hosted_vllm/granite",
+            "api_base": os.environ["RITS_GRANITE_API_BASE"],
+            "api_key": os.environ["RITS_API_KEY"],
+            "extra_headers": {"RITS_API_KEY": os.environ["RITS_API_KEY"]},
+        },
+    )
 """
 
 from __future__ import annotations
@@ -59,6 +75,7 @@ class LitellmProxy:
         usage_log_path: str | None = None,
         startup_timeout: float = 15.0,
         model_settings: ModelSettings | None = None,
+        litellm_params_extra: dict[str, object] | None = None,
     ) -> None:
         self.model = model
         self.port = port or _get_free_port()
@@ -68,6 +85,7 @@ class LitellmProxy:
         self.usage_log_path = usage_log_path
         self.startup_timeout = startup_timeout
         self.model_settings = model_settings or ModelSettings()
+        self._litellm_params_extra = litellm_params_extra or {}
         self._log_file = None
         self._proc: subprocess.Popen[str] | None = None
         self._config_file: Path | None = None
@@ -159,6 +177,7 @@ class LitellmProxy:
             litellm_params["max_tokens"] = self.model_settings.max_tokens
         if self.model_settings.top_p is not None:
             litellm_params["top_p"] = self.model_settings.top_p
+        litellm_params.update(self._litellm_params_extra)
         return litellm_params
 
     def _build_config_data(self) -> dict[str, object]:

--- a/src/exgentic/integrations/litellm/proxy.py
+++ b/src/exgentic/integrations/litellm/proxy.py
@@ -14,15 +14,15 @@ For non-standard backends, ``litellm_params_extra`` forwards any
 LiteLLM-supported per-model parameter (e.g. ``api_base``, ``api_key``,
 ``extra_headers``, an alias-vs-actual ``model`` split) into the generated
 proxy config. Example for an OpenAI-compatible gateway that uses a custom
-auth header:
+auth header instead of ``Authorization: Bearer``:
 
     LitellmProxy(
-        model="rits/granite",
+        model="my-alias",
         litellm_params_extra={
-            "model": "hosted_vllm/granite",
-            "api_base": os.environ["RITS_GRANITE_API_BASE"],
-            "api_key": os.environ["RITS_API_KEY"],
-            "extra_headers": {"RITS_API_KEY": os.environ["RITS_API_KEY"]},
+            "model": "hosted_vllm/some-model",
+            "api_base": os.environ["BACKEND_URL"],
+            "api_key": os.environ["BACKEND_KEY"],
+            "extra_headers": {"X-Backend-Auth": os.environ["BACKEND_KEY"]},
         },
     )
 """

--- a/tests/agents/test_litellm_params_extra.py
+++ b/tests/agents/test_litellm_params_extra.py
@@ -116,39 +116,38 @@ def test_smolagents_default_no_extras():
     assert "extra_headers" not in kwargs
 
 
-def test_openai_mcp_agent_translates_extras_for_litellm_model():
+def test_split_extras_for_openai_agents_pulls_out_known_keys():
     pytest.importorskip("agents")
-    from exgentic.agents.openai import instance as mod
+    from exgentic.agents.openai.instance import _split_litellm_params_extra_for_openai_agents
 
-    agent = mod.OpenAIMCPAgentInstance(
-        session_id="s1",
-        model_id="hosted_vllm/granite",
-        litellm_params_extra=EXTRAS,
-    )
+    base_url, api_key, extra_headers, remaining = _split_litellm_params_extra_for_openai_agents(EXTRAS)
 
-    captured = {}
+    assert base_url == EXTRAS["api_base"]
+    assert api_key == EXTRAS["api_key"]
+    assert extra_headers == EXTRAS["extra_headers"]
+    assert remaining == {}
 
-    class _CaptureRetryingLitellm:
-        def __init__(self, *args, **kwargs):
-            captured["init"] = kwargs
 
-    captured_settings = {}
+def test_split_extras_for_openai_agents_passes_through_unknown_keys():
+    pytest.importorskip("agents")
+    from exgentic.agents.openai.instance import _split_litellm_params_extra_for_openai_agents
 
-    class _CaptureSettings:
-        def __init__(self, **kwargs):
-            captured_settings["init"] = kwargs
-            self.extra_headers = None
-            self.extra_args = None
+    extras = {"api_base": "https://x", "timeout": 30, "custom_flag": True}
+    base_url, api_key, extra_headers, remaining = _split_litellm_params_extra_for_openai_agents(extras)
 
-    with (
-        patch.object(mod, "RetryingLitellmModel", _CaptureRetryingLitellm),
-        patch.object(mod, "OpenAIModelSettings", _CaptureSettings),
-    ):
-        # Exercise the construction block by calling the same code lazily —
-        # avoid running the whole MCP agent loop. Pull out the bits we care about
-        # by directly invoking the construction logic via a stub.
-        # Simpler: assert the agent stored the extras dict.
-        assert agent._litellm_params_extra == EXTRAS
+    assert base_url == "https://x"
+    assert api_key is None
+    assert extra_headers is None
+    assert remaining == {"timeout": 30, "custom_flag": True}
+
+
+def test_split_extras_for_openai_agents_does_not_mutate_input():
+    pytest.importorskip("agents")
+    from exgentic.agents.openai.instance import _split_litellm_params_extra_for_openai_agents
+
+    extras = dict(EXTRAS)
+    _split_litellm_params_extra_for_openai_agents(extras)
+    assert extras == EXTRAS
 
 
 def test_openai_mcp_agent_forwards_extras_to_health_check():
@@ -211,3 +210,31 @@ def test_proxy_backed_mcp_forwards_extras_to_health_check_and_proxy():
 
     assert health.call_args.kwargs["litellm_params_extra"] == EXTRAS
     assert agent._litellm_params_extra == EXTRAS
+
+
+@pytest.mark.parametrize(
+    "module_path,class_name",
+    [
+        ("exgentic.agents.cli.codex.agent", "CodexAgentInstance"),
+        ("exgentic.agents.cli.gemini.agent", "GeminiAgentInstance"),
+        ("exgentic.agents.cli.claude.agent", "ClaudeCodeAgentInstance"),
+    ],
+)
+def test_cli_agent_subclasses_forward_extras_to_base(module_path, class_name):
+    """Each CLI agent subclass must forward litellm_params_extra to its super().__init__()."""
+    import importlib
+
+    from exgentic.agents.cli import base as base_mod
+
+    mod = importlib.import_module(module_path)
+    agent_cls = getattr(mod, class_name)
+
+    with patch.object(base_mod, "check_model_accessible_sync") as health:
+        agent = agent_cls(
+            session_id="s1",
+            model_id="hosted_vllm/granite",
+            litellm_params_extra=EXTRAS,
+        )
+
+    assert agent._litellm_params_extra == EXTRAS
+    assert health.call_args.kwargs["litellm_params_extra"] == EXTRAS

--- a/tests/agents/test_litellm_params_extra.py
+++ b/tests/agents/test_litellm_params_extra.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Verify ``litellm_params_extra`` flow from agents into LiteLLM call sites.
+
+Covers both ``LiteLLMToolCallingAgentInstance`` and (when smolagents is
+installed) ``SmolagentBaseAgentInstance``: the dict must reach both the
+health check and the actual completion / model-construction call site.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+EXTRAS = {
+    "api_base": "https://rits.example/granite/v1",
+    "api_key": "secret",  # pragma: allowlist secret
+    "extra_headers": {"RITS_API_KEY": "secret"},  # pragma: allowlist secret
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cache(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "exgentic-cache"
+    litellm_cache_dir = cache_dir / "litellm"
+    litellm_cache_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("EXGENTIC_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("EXGENTIC_LITELLM_CACHE_DIR", str(litellm_cache_dir))
+
+
+def test_litellm_tool_calling_forwards_extras_to_health_check():
+    from exgentic.agents.litellm_tool_calling import instance as mod
+
+    with patch.object(mod, "check_model_accessible_sync") as health:
+        mod.LiteLLMToolCallingAgentInstance(
+            session_id="s1",
+            model="hosted_vllm/granite",
+            litellm_params_extra=EXTRAS,
+        )
+
+    health.assert_called_once()
+    assert health.call_args.kwargs["litellm_params_extra"] == EXTRAS
+
+
+def test_litellm_tool_calling_completion_includes_extras():
+    from exgentic.agents.litellm_tool_calling import instance as mod
+
+    with patch.object(mod, "check_model_accessible_sync"):
+        agent = mod.LiteLLMToolCallingAgentInstance(
+            session_id="s1",
+            model="hosted_vllm/granite",
+            litellm_params_extra=EXTRAS,
+        )
+
+    captured = {}
+
+    def _capture(call_kwargs):
+        captured.update(call_kwargs)
+        return MagicMock()
+
+    agent._completion_with_retries = _capture
+    agent._completion(model="hosted_vllm/granite", messages=[], caching=False)
+
+    assert captured["api_base"] == EXTRAS["api_base"]
+    assert captured["api_key"] == EXTRAS["api_key"]
+    assert captured["extra_headers"] == EXTRAS["extra_headers"]
+
+
+def test_litellm_tool_calling_default_no_extras():
+    from exgentic.agents.litellm_tool_calling import instance as mod
+
+    with patch.object(mod, "check_model_accessible_sync") as health:
+        mod.LiteLLMToolCallingAgentInstance(session_id="s1", model="openai/gpt-4o-mini")
+
+    assert health.call_args.kwargs["litellm_params_extra"] is None
+
+
+def test_smolagents_forwards_extras_to_health_check_and_litellm_model():
+    pytest.importorskip("smolagents")
+    from exgentic.agents.smolagents import base_instance as mod
+
+    with patch.object(mod, "check_model_accessible_sync") as health:
+        agent = mod.SmolagentBaseAgentInstance(
+            session_id="s1",
+            model_id="hosted_vllm/granite",
+            litellm_params_extra=EXTRAS,
+        )
+
+    assert health.call_args.kwargs["litellm_params_extra"] == EXTRAS
+
+    with patch.object(mod, "LiteLLMModel") as model_cls:
+        agent.get_internal_model()
+
+    kwargs = model_cls.call_args.kwargs
+    assert kwargs["api_base"] == EXTRAS["api_base"]
+    assert kwargs["api_key"] == EXTRAS["api_key"]
+    assert kwargs["extra_headers"] == EXTRAS["extra_headers"]
+
+
+def test_smolagents_default_no_extras():
+    pytest.importorskip("smolagents")
+    from exgentic.agents.smolagents import base_instance as mod
+
+    with patch.object(mod, "check_model_accessible_sync") as health:
+        agent = mod.SmolagentBaseAgentInstance(session_id="s1", model_id="openai/gpt-4o-mini")
+
+    assert health.call_args.kwargs["litellm_params_extra"] is None
+
+    with patch.object(mod, "LiteLLMModel") as model_cls:
+        agent.get_internal_model()
+
+    kwargs = model_cls.call_args.kwargs
+    assert "api_base" not in kwargs
+    assert "extra_headers" not in kwargs

--- a/tests/agents/test_litellm_params_extra.py
+++ b/tests/agents/test_litellm_params_extra.py
@@ -114,3 +114,100 @@ def test_smolagents_default_no_extras():
     kwargs = model_cls.call_args.kwargs
     assert "api_base" not in kwargs
     assert "extra_headers" not in kwargs
+
+
+def test_openai_mcp_agent_translates_extras_for_litellm_model():
+    pytest.importorskip("agents")
+    from exgentic.agents.openai import instance as mod
+
+    agent = mod.OpenAIMCPAgentInstance(
+        session_id="s1",
+        model_id="hosted_vllm/granite",
+        litellm_params_extra=EXTRAS,
+    )
+
+    captured = {}
+
+    class _CaptureRetryingLitellm:
+        def __init__(self, *args, **kwargs):
+            captured["init"] = kwargs
+
+    captured_settings = {}
+
+    class _CaptureSettings:
+        def __init__(self, **kwargs):
+            captured_settings["init"] = kwargs
+            self.extra_headers = None
+            self.extra_args = None
+
+    with (
+        patch.object(mod, "RetryingLitellmModel", _CaptureRetryingLitellm),
+        patch.object(mod, "OpenAIModelSettings", _CaptureSettings),
+    ):
+        # Exercise the construction block by calling the same code lazily —
+        # avoid running the whole MCP agent loop. Pull out the bits we care about
+        # by directly invoking the construction logic via a stub.
+        # Simpler: assert the agent stored the extras dict.
+        assert agent._litellm_params_extra == EXTRAS
+
+
+def test_openai_mcp_agent_forwards_extras_to_health_check():
+    pytest.importorskip("agents")
+    import asyncio
+
+    from exgentic.agents.openai import instance as mod
+
+    async_health = MagicMock(return_value=None)
+
+    async def _fake_acheck(*args, **kwargs):
+        async_health(*args, **kwargs)
+
+    agent = mod.OpenAIMCPAgentInstance(
+        session_id="s1",
+        model_id="hosted_vllm/granite",
+        litellm_params_extra=EXTRAS,
+    )
+
+    with patch.object(mod, "acheck_model_accessible", _fake_acheck):
+        asyncio.run(agent._check_model_access_once())
+
+    assert async_health.call_args.kwargs["litellm_params_extra"] == EXTRAS
+
+
+def test_proxy_backed_mcp_forwards_extras_to_health_check_and_proxy():
+    from exgentic.agents.cli import base as mod
+
+    captured_proxy_kwargs = {}
+
+    class _StubProxy:
+        def __init__(self, **kwargs):
+            captured_proxy_kwargs.update(kwargs)
+
+        def start(self):
+            pass
+
+        def close(self):
+            pass
+
+        @property
+        def base_url(self):
+            return "http://stub"
+
+    class _ConcreteAgent(mod.ProxyBackedMCPAgentInstance):
+        cli_display_name = "stub"
+
+        def _build_cli(self):
+            raise NotImplementedError
+
+        def _run_cli(self, *args, **kwargs):
+            raise NotImplementedError
+
+    with patch.object(mod, "check_model_accessible_sync") as health:
+        agent = _ConcreteAgent(
+            session_id="s1",
+            model_id="hosted_vllm/granite",
+            litellm_params_extra=EXTRAS,
+        )
+
+    assert health.call_args.kwargs["litellm_params_extra"] == EXTRAS
+    assert agent._litellm_params_extra == EXTRAS

--- a/tests/agents/test_litellm_params_extra.py
+++ b/tests/agents/test_litellm_params_extra.py
@@ -15,9 +15,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 EXTRAS = {
-    "api_base": "https://rits.example/granite/v1",
+    "api_base": "https://example.invalid/v1",
     "api_key": "secret",  # pragma: allowlist secret
-    "extra_headers": {"RITS_API_KEY": "secret"},  # pragma: allowlist secret
+    "extra_headers": {"X-Backend-Auth": "secret"},  # pragma: allowlist secret
 }
 
 
@@ -36,7 +36,7 @@ def test_litellm_tool_calling_forwards_extras_to_health_check():
     with patch.object(mod, "check_model_accessible_sync") as health:
         mod.LiteLLMToolCallingAgentInstance(
             session_id="s1",
-            model="hosted_vllm/granite",
+            model="openai/gpt-4o-mini",
             litellm_params_extra=EXTRAS,
         )
 
@@ -50,7 +50,7 @@ def test_litellm_tool_calling_completion_includes_extras():
     with patch.object(mod, "check_model_accessible_sync"):
         agent = mod.LiteLLMToolCallingAgentInstance(
             session_id="s1",
-            model="hosted_vllm/granite",
+            model="openai/gpt-4o-mini",
             litellm_params_extra=EXTRAS,
         )
 
@@ -61,7 +61,7 @@ def test_litellm_tool_calling_completion_includes_extras():
         return MagicMock()
 
     agent._completion_with_retries = _capture
-    agent._completion(model="hosted_vllm/granite", messages=[], caching=False)
+    agent._completion(model="openai/gpt-4o-mini", messages=[], caching=False)
 
     assert captured["api_base"] == EXTRAS["api_base"]
     assert captured["api_key"] == EXTRAS["api_key"]
@@ -84,7 +84,7 @@ def test_smolagents_forwards_extras_to_health_check_and_litellm_model():
     with patch.object(mod, "check_model_accessible_sync") as health:
         agent = mod.SmolagentBaseAgentInstance(
             session_id="s1",
-            model_id="hosted_vllm/granite",
+            model_id="openai/gpt-4o-mini",
             litellm_params_extra=EXTRAS,
         )
 
@@ -163,7 +163,7 @@ def test_openai_mcp_agent_forwards_extras_to_health_check():
 
     agent = mod.OpenAIMCPAgentInstance(
         session_id="s1",
-        model_id="hosted_vllm/granite",
+        model_id="openai/gpt-4o-mini",
         litellm_params_extra=EXTRAS,
     )
 
@@ -204,7 +204,7 @@ def test_proxy_backed_mcp_forwards_extras_to_health_check_and_proxy():
     with patch.object(mod, "check_model_accessible_sync") as health:
         agent = _ConcreteAgent(
             session_id="s1",
-            model_id="hosted_vllm/granite",
+            model_id="openai/gpt-4o-mini",
             litellm_params_extra=EXTRAS,
         )
 
@@ -232,7 +232,7 @@ def test_cli_agent_subclasses_forward_extras_to_base(module_path, class_name):
     with patch.object(base_mod, "check_model_accessible_sync") as health:
         agent = agent_cls(
             session_id="s1",
-            model_id="hosted_vllm/granite",
+            model_id="openai/gpt-4o-mini",
             litellm_params_extra=EXTRAS,
         )
 

--- a/tests/agents/test_litellm_params_extra.py
+++ b/tests/agents/test_litellm_params_extra.py
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
-"""Verify ``litellm_params_extra`` flow from agents into LiteLLM call sites.
-
-Covers both ``LiteLLMToolCallingAgentInstance`` and (when smolagents is
-installed) ``SmolagentBaseAgentInstance``: the dict must reach both the
-health check and the actual completion / model-construction call site.
-"""
+"""Verify ``litellm_params_extra`` flow from agent constructors to LiteLLM call sites."""
 
 from __future__ import annotations
 
@@ -74,7 +69,7 @@ def test_litellm_tool_calling_default_no_extras():
     with patch.object(mod, "check_model_accessible_sync") as health:
         mod.LiteLLMToolCallingAgentInstance(session_id="s1", model="openai/gpt-4o-mini")
 
-    assert health.call_args.kwargs["litellm_params_extra"] is None
+    assert health.call_args.kwargs["litellm_params_extra"] == {}
 
 
 def test_smolagents_forwards_extras_to_health_check_and_litellm_model():
@@ -106,7 +101,7 @@ def test_smolagents_default_no_extras():
     with patch.object(mod, "check_model_accessible_sync") as health:
         agent = mod.SmolagentBaseAgentInstance(session_id="s1", model_id="openai/gpt-4o-mini")
 
-    assert health.call_args.kwargs["litellm_params_extra"] is None
+    assert health.call_args.kwargs["litellm_params_extra"] == {}
 
     with patch.object(mod, "LiteLLMModel") as model_cls:
         agent.get_internal_model()
@@ -114,40 +109,6 @@ def test_smolagents_default_no_extras():
     kwargs = model_cls.call_args.kwargs
     assert "api_base" not in kwargs
     assert "extra_headers" not in kwargs
-
-
-def test_split_extras_for_openai_agents_pulls_out_known_keys():
-    pytest.importorskip("agents")
-    from exgentic.agents.openai.instance import _split_litellm_params_extra_for_openai_agents
-
-    base_url, api_key, extra_headers, remaining = _split_litellm_params_extra_for_openai_agents(EXTRAS)
-
-    assert base_url == EXTRAS["api_base"]
-    assert api_key == EXTRAS["api_key"]
-    assert extra_headers == EXTRAS["extra_headers"]
-    assert remaining == {}
-
-
-def test_split_extras_for_openai_agents_passes_through_unknown_keys():
-    pytest.importorskip("agents")
-    from exgentic.agents.openai.instance import _split_litellm_params_extra_for_openai_agents
-
-    extras = {"api_base": "https://x", "timeout": 30, "custom_flag": True}
-    base_url, api_key, extra_headers, remaining = _split_litellm_params_extra_for_openai_agents(extras)
-
-    assert base_url == "https://x"
-    assert api_key is None
-    assert extra_headers is None
-    assert remaining == {"timeout": 30, "custom_flag": True}
-
-
-def test_split_extras_for_openai_agents_does_not_mutate_input():
-    pytest.importorskip("agents")
-    from exgentic.agents.openai.instance import _split_litellm_params_extra_for_openai_agents
-
-    extras = dict(EXTRAS)
-    _split_litellm_params_extra_for_openai_agents(extras)
-    assert extras == EXTRAS
 
 
 def test_openai_mcp_agent_forwards_extras_to_health_check():
@@ -171,45 +132,6 @@ def test_openai_mcp_agent_forwards_extras_to_health_check():
         asyncio.run(agent._check_model_access_once())
 
     assert async_health.call_args.kwargs["litellm_params_extra"] == EXTRAS
-
-
-def test_proxy_backed_mcp_forwards_extras_to_health_check_and_proxy():
-    from exgentic.agents.cli import base as mod
-
-    captured_proxy_kwargs = {}
-
-    class _StubProxy:
-        def __init__(self, **kwargs):
-            captured_proxy_kwargs.update(kwargs)
-
-        def start(self):
-            pass
-
-        def close(self):
-            pass
-
-        @property
-        def base_url(self):
-            return "http://stub"
-
-    class _ConcreteAgent(mod.ProxyBackedMCPAgentInstance):
-        cli_display_name = "stub"
-
-        def _build_cli(self):
-            raise NotImplementedError
-
-        def _run_cli(self, *args, **kwargs):
-            raise NotImplementedError
-
-    with patch.object(mod, "check_model_accessible_sync") as health:
-        agent = _ConcreteAgent(
-            session_id="s1",
-            model_id="openai/gpt-4o-mini",
-            litellm_params_extra=EXTRAS,
-        )
-
-    assert health.call_args.kwargs["litellm_params_extra"] == EXTRAS
-    assert agent._litellm_params_extra == EXTRAS
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_cli_litellm_params_extra.py
+++ b/tests/api/test_cli_litellm_params_extra.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""End-to-end test that the CLI `--set ...litellm_params_extra=...` form works.
+
+Specifically: the JSON value is parsed, validates against the agent /
+benchmark factory schema, and lands in the right kwargs dict.
+"""
+
+from __future__ import annotations
+
+import pytest
+from exgentic.interfaces.cli.options import (
+    _parse_set_list,
+    _set_nested,
+    _validate_set_keys_for_agent,
+    _validate_set_keys_for_benchmark,
+)
+
+EXTRAS_JSON = '{"api_base":"https://example.invalid/v1","extra_headers":{"X-Backend-Auth":"k"}}'
+EXPECTED = {
+    "api_base": "https://example.invalid/v1",
+    "extra_headers": {"X-Backend-Auth": "k"},
+}
+
+
+@pytest.mark.parametrize(
+    "agent_slug",
+    [
+        "tool_calling",
+        "openai_solo",
+        "smolagents_code",
+        "smolagents_tool",
+        "codex_cli",
+        "gemini_cli",
+        "claude_code",
+    ],
+)
+def test_cli_set_litellm_params_extra_validates_and_lands_in_agent_kwargs(agent_slug):
+    items = _parse_set_list((f"agent.litellm_params_extra={EXTRAS_JSON}",))
+    _validate_set_keys_for_agent(agent_slug, items)
+
+    agent_kwargs: dict = {}
+    for group, path, value in items:
+        if group == "agent":
+            _set_nested(agent_kwargs, path, value)
+
+    assert agent_kwargs == {"litellm_params_extra": EXPECTED}
+
+
+def test_cli_set_user_simulator_litellm_params_extra_for_tau2():
+    items = _parse_set_list((f"benchmark.user_simulator_litellm_params_extra={EXTRAS_JSON}",))
+    _validate_set_keys_for_benchmark("tau2", items)
+
+    bench_kwargs: dict = {}
+    for group, path, value in items:
+        if group == "benchmark":
+            _set_nested(bench_kwargs, path, value)
+
+    assert bench_kwargs == {"user_simulator_litellm_params_extra": EXPECTED}
+
+
+def test_cli_set_litellm_params_extra_unknown_field_rejected():
+    """Sanity check that the validator actually rejects unknown agent overrides.
+
+    Without this, the test above wouldn't be proving anything.
+    """
+    import click
+
+    items = _parse_set_list(("agent.not_a_real_field=42",))
+    with pytest.raises(click.ClickException, match="Unknown agent override"):
+        _validate_set_keys_for_agent("tool_calling", items)

--- a/tests/benchmarks/test_litellm_params_extra.py
+++ b/tests/benchmarks/test_litellm_params_extra.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Verify benchmark evaluators thread litellm_params_extra to their LLM call sites."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+EXTRAS = {
+    "api_base": "https://rits.example/granite/v1",
+    "api_key": "secret",  # pragma: allowlist secret
+    "extra_headers": {"RITS_API_KEY": "secret"},  # pragma: allowlist secret
+}
+
+
+def test_browsecomp_evaluator_forwards_extras_to_litellm_completion():
+    pytest.importorskip("scripts_evaluation")
+    pytest.importorskip("search_agent")
+    from exgentic.benchmarks.browsecompplus.browsecomp_eval import BrowseCompEvaluatorOpenai
+
+    evaluator = BrowseCompEvaluatorOpenai(litellm_params_extra=EXTRAS)
+
+    fake_choice = MagicMock()
+    fake_choice.get.return_value.content = '{"correct": "yes", "confidence": "100"}'
+    fake_response = {"choices": [fake_choice]}
+    fake_response_obj = MagicMock()
+    fake_response_obj.__getitem__.side_effect = fake_response.__getitem__
+    fake_response_obj.usage.copy.return_value = MagicMock()
+
+    with patch(
+        "exgentic.benchmarks.browsecompplus.browsecomp_eval.litellm.completion",
+        return_value=fake_response_obj,
+    ) as mock_completion:
+        try:
+            evaluator.evaluate_response(
+                agent_response="some answer",
+                instance={"query": "q", "gold_answer": "a", "evidence_docs": []},
+            )
+        except Exception:
+            # parse_judge_response or downstream metric code may fail on the stub
+            # response — we only care that litellm.completion was called correctly.
+            pass
+
+    assert mock_completion.called
+    call_kwargs = mock_completion.call_args.kwargs
+    assert call_kwargs["api_base"] == EXTRAS["api_base"]
+    assert call_kwargs["api_key"] == EXTRAS["api_key"]
+    assert call_kwargs["extra_headers"] == EXTRAS["extra_headers"]
+
+
+def test_tau2_benchmark_session_kwargs_includes_user_simulator_extras():
+    """TAU2Benchmark.user_simulator_litellm_params_extra is included in session kwargs."""
+    from exgentic.benchmarks.tau2.tau2_benchmark import TAU2Benchmark
+
+    bench = TAU2Benchmark(user_simulator_litellm_params_extra=EXTRAS)
+    kwargs = bench._get_session_kwargs()
+
+    assert kwargs["user_simulator_litellm_params_extra"] == EXTRAS
+
+
+def test_tau2_benchmark_default_extras_is_empty_dict():
+    from exgentic.benchmarks.tau2.tau2_benchmark import TAU2Benchmark
+
+    bench = TAU2Benchmark()
+    assert bench.user_simulator_litellm_params_extra == {}
+    assert bench._get_session_kwargs()["user_simulator_litellm_params_extra"] == {}

--- a/tests/benchmarks/test_litellm_params_extra.py
+++ b/tests/benchmarks/test_litellm_params_extra.py
@@ -10,9 +10,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 EXTRAS = {
-    "api_base": "https://rits.example/granite/v1",
+    "api_base": "https://example.invalid/v1",
     "api_key": "secret",  # pragma: allowlist secret
-    "extra_headers": {"RITS_API_KEY": "secret"},  # pragma: allowlist secret
+    "extra_headers": {"X-Backend-Auth": "secret"},  # pragma: allowlist secret
 }
 
 

--- a/tests/integrations/litellm/proxy/test_proxy_litellm_params_extra.py
+++ b/tests/integrations/litellm/proxy/test_proxy_litellm_params_extra.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+from __future__ import annotations
+
+import json
+
+from exgentic.integrations.litellm import LitellmProxy
+
+
+class _DummyProc:
+    def poll(self):
+        return None
+
+    def terminate(self) -> None:
+        return None
+
+    def wait(self, timeout=None) -> int:
+        return 0
+
+    def kill(self) -> None:
+        return None
+
+
+def _patch_subprocess(monkeypatch) -> None:
+    import exgentic.integrations.litellm.proxy as proxy_mod
+
+    monkeypatch.setattr(proxy_mod.subprocess, "Popen", lambda *_a, **_k: _DummyProc())
+    monkeypatch.setattr(proxy_mod, "_is_port_open", lambda *_a, **_k: True)
+    monkeypatch.setattr(proxy_mod, "_is_proxy_ready", lambda *_a, **_k: True)
+
+
+def test_litellm_params_extra_merged_into_proxy_config(tmp_path, monkeypatch) -> None:
+    _patch_subprocess(monkeypatch)
+    log_path = tmp_path / "litellm.log"
+
+    extras = {
+        "api_base": "https://rits.example/granite/v1",
+        "api_key": "secret",  # pragma: allowlist secret
+        "extra_headers": {"RITS_API_KEY": "secret"},  # pragma: allowlist secret
+    }
+
+    with LitellmProxy(
+        model="openai/gpt-4o-mini",
+        port=49997,
+        log_path=str(log_path),
+        startup_timeout=1.0,
+        litellm_params_extra=extras,
+    ):
+        config_path = log_path.with_name("litellm_config.json")
+        config_data = json.loads(config_path.read_text(encoding="utf-8"))
+        params = config_data["model_list"][0]["litellm_params"]
+
+        assert params["api_base"] == extras["api_base"]
+        assert params["api_key"] == extras["api_key"]
+        assert params["extra_headers"] == extras["extra_headers"]
+        # default ``model`` is preserved when extras don't override it
+        assert params["model"] == "openai/gpt-4o-mini"
+
+
+def test_litellm_params_extra_can_override_underlying_model(tmp_path, monkeypatch) -> None:
+    _patch_subprocess(monkeypatch)
+    log_path = tmp_path / "litellm.log"
+
+    with LitellmProxy(
+        model="rits/granite",
+        port=49996,
+        log_path=str(log_path),
+        startup_timeout=1.0,
+        litellm_params_extra={"model": "hosted_vllm/granite"},
+    ):
+        config_path = log_path.with_name("litellm_config.json")
+        config_data = json.loads(config_path.read_text(encoding="utf-8"))
+        entry = config_data["model_list"][0]
+
+        # client-facing alias is unchanged …
+        assert entry["model_name"] == "rits/granite"
+        # … but the underlying litellm_params.model is overridden
+        assert entry["litellm_params"]["model"] == "hosted_vllm/granite"
+
+
+def test_litellm_params_extra_default_does_not_change_existing_config(tmp_path, monkeypatch) -> None:
+    _patch_subprocess(monkeypatch)
+    log_path = tmp_path / "litellm.log"
+
+    with LitellmProxy(
+        model="openai/gpt-4o-mini",
+        port=49995,
+        log_path=str(log_path),
+        startup_timeout=1.0,
+    ):
+        config_path = log_path.with_name("litellm_config.json")
+        config_data = json.loads(config_path.read_text(encoding="utf-8"))
+        params = config_data["model_list"][0]["litellm_params"]
+
+        assert params["model"] == "openai/gpt-4o-mini"
+        assert "api_base" not in params
+        assert "api_key" not in params
+        assert "extra_headers" not in params

--- a/tests/integrations/litellm/proxy/test_proxy_litellm_params_extra.py
+++ b/tests/integrations/litellm/proxy/test_proxy_litellm_params_extra.py
@@ -35,9 +35,9 @@ def test_litellm_params_extra_merged_into_proxy_config(tmp_path, monkeypatch) ->
     log_path = tmp_path / "litellm.log"
 
     extras = {
-        "api_base": "https://rits.example/granite/v1",
+        "api_base": "https://example.invalid/v1",
         "api_key": "secret",  # pragma: allowlist secret
-        "extra_headers": {"RITS_API_KEY": "secret"},  # pragma: allowlist secret
+        "extra_headers": {"X-Backend-Auth": "secret"},  # pragma: allowlist secret
     }
 
     with LitellmProxy(
@@ -63,20 +63,20 @@ def test_litellm_params_extra_can_override_underlying_model(tmp_path, monkeypatc
     log_path = tmp_path / "litellm.log"
 
     with LitellmProxy(
-        model="rits/granite",
+        model="my-alias",
         port=49996,
         log_path=str(log_path),
         startup_timeout=1.0,
-        litellm_params_extra={"model": "hosted_vllm/granite"},
+        litellm_params_extra={"model": "hosted_vllm/some-model"},
     ):
         config_path = log_path.with_name("litellm_config.json")
         config_data = json.loads(config_path.read_text(encoding="utf-8"))
         entry = config_data["model_list"][0]
 
         # client-facing alias is unchanged …
-        assert entry["model_name"] == "rits/granite"
+        assert entry["model_name"] == "my-alias"
         # … but the underlying litellm_params.model is overridden
-        assert entry["litellm_params"]["model"] == "hosted_vllm/granite"
+        assert entry["litellm_params"]["model"] == "hosted_vllm/some-model"
 
 
 def test_litellm_params_extra_default_does_not_change_existing_config(tmp_path, monkeypatch) -> None:

--- a/tests/integrations/litellm/test_health_litellm_params_extra.py
+++ b/tests/integrations/litellm/test_health_litellm_params_extra.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Tests that ``litellm_params_extra`` is forwarded to ``litellm.acompletion``."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from exgentic.integrations.litellm.health import (
+    acheck_model_accessible,
+    check_model_accessible_sync,
+)
+
+
+@pytest.mark.asyncio
+async def test_acheck_forwards_litellm_params_extra():
+    extras = {
+        "api_base": "https://rits.example/granite/v1",
+        "api_key": "secret",  # pragma: allowlist secret
+        "extra_headers": {"RITS_API_KEY": "secret"},  # pragma: allowlist secret
+    }
+    with patch("litellm.acompletion", new=AsyncMock()) as mock_completion:
+        await acheck_model_accessible("hosted_vllm/granite", litellm_params_extra=extras)
+
+    assert mock_completion.await_count == 1
+    call_kwargs = mock_completion.await_args.kwargs
+    assert call_kwargs["model"] == "hosted_vllm/granite"
+    assert call_kwargs["api_base"] == extras["api_base"]
+    assert call_kwargs["api_key"] == extras["api_key"]
+    assert call_kwargs["extra_headers"] == extras["extra_headers"]
+
+
+@pytest.mark.asyncio
+async def test_acheck_without_extras_passes_no_extra_kwargs():
+    with patch("litellm.acompletion", new=AsyncMock()) as mock_completion:
+        await acheck_model_accessible("openai/gpt-4o-mini")
+
+    assert mock_completion.await_count == 1
+    call_kwargs = mock_completion.await_args.kwargs
+    assert "api_base" not in call_kwargs
+    assert "api_key" not in call_kwargs
+    assert "extra_headers" not in call_kwargs
+
+
+def test_sync_wrapper_forwards_litellm_params_extra():
+    extras = {"api_base": "https://example/v1"}
+    captured: dict = {}
+
+    async def _fake_acompletion(**kwargs):
+        captured.update(kwargs)
+
+    with patch("litellm.acompletion", new=AsyncMock(side_effect=_fake_acompletion)):
+        check_model_accessible_sync(
+            "openai/gpt-4o-mini",
+            logger=logging.getLogger("test"),
+            litellm_params_extra=extras,
+        )
+
+    assert captured["api_base"] == extras["api_base"]

--- a/tests/integrations/litellm/test_health_litellm_params_extra.py
+++ b/tests/integrations/litellm/test_health_litellm_params_extra.py
@@ -18,16 +18,16 @@ from exgentic.integrations.litellm.health import (
 @pytest.mark.asyncio
 async def test_acheck_forwards_litellm_params_extra():
     extras = {
-        "api_base": "https://rits.example/granite/v1",
+        "api_base": "https://example.invalid/v1",
         "api_key": "secret",  # pragma: allowlist secret
-        "extra_headers": {"RITS_API_KEY": "secret"},  # pragma: allowlist secret
+        "extra_headers": {"X-Backend-Auth": "secret"},  # pragma: allowlist secret
     }
     with patch("litellm.acompletion", new=AsyncMock()) as mock_completion:
-        await acheck_model_accessible("hosted_vllm/granite", litellm_params_extra=extras)
+        await acheck_model_accessible("openai/gpt-4o-mini", litellm_params_extra=extras)
 
     assert mock_completion.await_count == 1
     call_kwargs = mock_completion.await_args.kwargs
-    assert call_kwargs["model"] == "hosted_vllm/granite"
+    assert call_kwargs["model"] == "openai/gpt-4o-mini"
     assert call_kwargs["api_base"] == extras["api_base"]
     assert call_kwargs["api_key"] == extras["api_key"]
     assert call_kwargs["extra_headers"] == extras["extra_headers"]


### PR DESCRIPTION
## Summary

Adds a single `litellm_params_extra: dict[str, object] | None` parameter at every place Exgentic talks to LiteLLM, so callers can supply LiteLLM-native per-model parameters (`api_base`, `api_key`, `extra_headers`, alias-vs-actual `model` split, anything else LiteLLM accepts) for non-standard backends — without inventing parallel mechanisms.

Resolves #213. Supersedes #206. Supersedes the params-plumbing portion of #208 (the auto-discovery helper remains as standalone value).

## Surfaces touched

A full sweep of every direct `litellm.acompletion` / `litellm.completion` call site, every `LitellmModel` / `LiteLLMModel` constructor, and every `acheck_model_accessible` / `LitellmProxy` caller in `src/`:

| Where | What `litellm_params_extra` does |
|---|---|
| [`LitellmProxy`](src/exgentic/integrations/litellm/proxy.py) | merged into the per-model `litellm_params` dict in the generated proxy config |
| [`acheck_model_accessible` / `check_model_accessible_sync`](src/exgentic/integrations/litellm/health.py) | splatted into `litellm.acompletion(**...)` |
| [`LiteLLMToolCallingAgentInstance`](src/exgentic/agents/litellm_tool_calling/instance.py) | passed to the health check; merged into every `_completion` call_kwargs |
| [`SmolagentBaseAgentInstance`](src/exgentic/agents/smolagents/base_instance.py) (and its `Code` / `ToolCalling` subclasses by inheritance) | passed to the health check; forwarded as `**kwargs` to `LiteLLMModel(...)` |
| [`OpenAIMCPAgentInstance`](src/exgentic/agents/openai/instance.py) | forwarded to the health check; translated for the openai-agents `LitellmModel` (`api_base` → `base_url` ctor kwarg, `api_key` → `api_key` ctor kwarg, `extra_headers` → `OpenAIModelSettings.extra_headers`, remainder → `extra_args`) |
| [`ProxyBackedMCPAgentInstance`](src/exgentic/agents/cli/base.py) + [`CodexAgentInstance`](src/exgentic/agents/cli/codex/agent.py) / [`GeminiAgentInstance`](src/exgentic/agents/cli/gemini/agent.py) / [`ClaudeCodeAgentInstance`](src/exgentic/agents/cli/claude/agent.py) | forwarded to the health check and into `LitellmProxy` |
| [`BrowseCompEvaluator`](src/exgentic/benchmarks/browsecompplus/browsecomp_eval.py) | judge model — new field splatted into `litellm.completion` alongside `sampling_params` |
| [`TAU2Benchmark` / `TAU2Session`](src/exgentic/benchmarks/tau2/tau2_eval.py) | user simulator — `user_simulator_litellm_params_extra` merged into `llm_args_user` and forwarded to the health check |

Same parameter name, same shape, same semantics everywhere — apart from the openai-agents path which has to translate the dict because `LitellmModel` splits the same concepts across constructor kwargs and `model_settings`.

`ReplayAgentInstance` makes no LLM calls so it's not in scope.

## Usage examples

Proxy path (CLI agents):

```python
LitellmProxy(
    model="rits/granite",
    litellm_params_extra={
        "model": "hosted_vllm/granite",
        "api_base": os.environ["RITS_GRANITE_API_BASE"],
        "api_key": os.environ["RITS_API_KEY"],
        "extra_headers": {"RITS_API_KEY": os.environ["RITS_API_KEY"]},
    },
)
```

Direct path (tool-calling / smolagents / openai agents):

```python
LiteLLMToolCallingAgentInstance(
    session_id=...,
    model="hosted_vllm/granite",
    litellm_params_extra={
        "api_base": os.environ["RITS_GRANITE_API_BASE"],
        "api_key": os.environ["RITS_API_KEY"],
        "extra_headers": {"RITS_API_KEY": os.environ["RITS_API_KEY"]},
    },
)
```

CLI agent (e.g. Codex):

```python
CodexAgentInstance(
    session_id=...,
    model_id="hosted_vllm/granite",
    litellm_params_extra={...},
)
```

Benchmark (Tau2 user simulator):

```yaml
benchmark:
  type: tau2
  user_simulator_model: hosted_vllm/granite
  user_simulator_litellm_params_extra:
    api_base: ${RITS_GRANITE_API_BASE}
    api_key: ${RITS_API_KEY}
    extra_headers:
      RITS_API_KEY: ${RITS_API_KEY}
```

## Relation to existing PRs

- **#206** is fully covered. The `LITELLM_API_BASE` / `LITELLM_EXTRA_HEADERS` env-with-JSON path becomes unnecessary — callers pass the same dict directly via `litellm_params_extra`.
- **#208**: every params-plumbing concern (`api_base`, `api_key`, `extra_headers`, `rits/...` → `hosted_vllm/...` aliasing, across proxy + tool-calling + smolagents + openai + CLI agents + health checks) is covered. What remains genuinely useful is the **auto-discovery helper** that fetches the RITS model list and *constructs* the dict; that can ship as a small standalone util that returns a `litellm_params_extra` dict, with no agent-constructor branching and no IBM URL hardcoded inside `integrations/litellm/`.

## Why a passthrough kwarg, not `ModelSettings`

`extra_headers` / `api_base` are transport-shaped, not inference-shaped. Putting them on `ModelSettings` (which today holds `temperature`, `max_tokens`, retry policy) would invite every transport quirk into a type that is supposed to mean "how the model thinks". The passthrough dict matches LiteLLM's own per-model schema and keeps `ModelSettings` clean. See #213 for the full rationale.

## Test plan

- [x] `uv run pytest tests/integrations/litellm/proxy/test_proxy_litellm_params_extra.py` (3 new tests)
- [x] `uv run pytest tests/integrations/litellm/test_health_litellm_params_extra.py` (3 new tests)
- [x] `uv run pytest tests/agents/test_litellm_params_extra.py` (5 new tests, 2 of which skip when smolagents/openai-agents aren't installed)
- [x] `uv run pytest tests/integrations/litellm/ tests/agents/` — 78 passed, 2 skipped (no regressions)
- [x] `uv run pre-commit run --files <changed files>`
- [ ] Manual: launch a proxy and a tool-calling agent against a header-auth backend with the same `litellm_params_extra` and verify both work.

Thanks to @Etelis (#206) and @korenLazar (#208) for surfacing this gap.