### PR TITLE
fix(health): treat auth errors as PERMANENT regardless of HTTP status

### DIFF
--- a/src/exgentic/integrations/litellm/health.py
+++ b/src/exgentic/integrations/litellm/health.py
@@ -104,10 +104,11 @@ def classify_error(exc: BaseException) -> ErrorCategory:
 
     Classification priority:
     1. Python built-in types (TimeoutError, ConnectionError)
-    2. Auth-error message markers (override status: some proxies wrap
-       expired/invalid-key errors in HTTP 400)
-    3. HTTP status code (extracted from exc or exc.original_exception)
-    4. litellm exception type name
+    2. HTTP status code (extracted from exc or exc.original_exception).
+       For REACHABLE statuses (400/422), an auth marker in the message
+       overrides to PERMANENT — some proxies wrap expired/invalid-key
+       errors in a 400 response that would otherwise pass the health check.
+    3. litellm exception type name
     """
     # 1. Python built-ins
     if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
@@ -120,12 +121,7 @@ def classify_error(exc: BaseException) -> ErrorCategory:
     if original is not None and isinstance(original, (TimeoutError, asyncio.TimeoutError)):
         return ErrorCategory.TRANSIENT
 
-    # 2. Auth markers in message body — checked before status so that an
-    # expired_key wrapped as 400 isn't treated as REACHABLE.
-    if _looks_like_auth_error(exc) or (original is not None and _looks_like_auth_error(original)):
-        return ErrorCategory.PERMANENT
-
-    # 3. HTTP status code (from exc or exc.original_exception)
+    # 2. HTTP status code (from exc or exc.original_exception)
     status = getattr(exc, "status_code", None)
     if status is None and original is not None:
         status = getattr(original, "status_code", None)
@@ -134,11 +130,15 @@ def classify_error(exc: BaseException) -> ErrorCategory:
         if status in _PERMANENT_STATUS_CODES:
             return ErrorCategory.PERMANENT
         if status in _REACHABLE_STATUS_CODES:
+            # Refine: a "reachable" status with an auth marker in the body
+            # is still permanent (LiteLLM proxy returns expired_key as 400).
+            if _looks_like_auth_error(exc) or (original is not None and _looks_like_auth_error(original)):
+                return ErrorCategory.PERMANENT
             return ErrorCategory.REACHABLE
         if status in _TRANSIENT_STATUS_CODES:
             return ErrorCategory.TRANSIENT
 
-    # 4. litellm exception type name
+    # 3. litellm exception type name
     name = type(exc).__name__
     if name in _PERMANENT_TYPES:
         return ErrorCategory.PERMANENT

--- a/src/exgentic/integrations/litellm/health.py
+++ b/src/exgentic/integrations/litellm/health.py
@@ -64,6 +64,24 @@ _TRANSIENT_STATUS_CODES = frozenset({429, 500, 502, 503})
 _REACHABLE_STATUS_CODES = frozenset({400, 422})
 _PERMANENT_STATUS_CODES = frozenset({401, 403, 404})
 
+# Lowercase substrings identifying authentication failures regardless of HTTP
+# status. The LiteLLM proxy wraps expired/invalid-key errors inside a 400
+# response, which would otherwise be classified as REACHABLE and silently pass
+# the health check.
+_AUTH_ERROR_MARKERS = (
+    "authentication error",
+    "expired_key",
+    "expired key",
+    "invalid_api_key",
+    "invalid api key",
+    "incorrect api key",
+)
+
+
+def _looks_like_auth_error(exc: BaseException) -> bool:
+    msg = (getattr(exc, "message", None) or str(exc) or "").lower()
+    return any(marker in msg for marker in _AUTH_ERROR_MARKERS)
+
 
 class ErrorCategory(Enum):
     """Classification of a litellm error for retry/health-check decisions."""
@@ -86,8 +104,10 @@ def classify_error(exc: BaseException) -> ErrorCategory:
 
     Classification priority:
     1. Python built-in types (TimeoutError, ConnectionError)
-    2. HTTP status code (extracted from exc or exc.original_exception)
-    3. litellm exception type name
+    2. Auth-error message markers (override status: some proxies wrap
+       expired/invalid-key errors in HTTP 400)
+    3. HTTP status code (extracted from exc or exc.original_exception)
+    4. litellm exception type name
     """
     # 1. Python built-ins
     if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
@@ -100,7 +120,12 @@ def classify_error(exc: BaseException) -> ErrorCategory:
     if original is not None and isinstance(original, (TimeoutError, asyncio.TimeoutError)):
         return ErrorCategory.TRANSIENT
 
-    # 2. HTTP status code (from exc or exc.original_exception)
+    # 2. Auth markers in message body — checked before status so that an
+    # expired_key wrapped as 400 isn't treated as REACHABLE.
+    if _looks_like_auth_error(exc) or (original is not None and _looks_like_auth_error(original)):
+        return ErrorCategory.PERMANENT
+
+    # 3. HTTP status code (from exc or exc.original_exception)
     status = getattr(exc, "status_code", None)
     if status is None and original is not None:
         status = getattr(original, "status_code", None)
@@ -113,7 +138,7 @@ def classify_error(exc: BaseException) -> ErrorCategory:
         if status in _TRANSIENT_STATUS_CODES:
             return ErrorCategory.TRANSIENT
 
-    # 3. litellm exception type name
+    # 4. litellm exception type name
     name = type(exc).__name__
     if name in _PERMANENT_TYPES:
         return ErrorCategory.PERMANENT

--- a/tests/integrations/litellm/test_health.py
+++ b/tests/integrations/litellm/test_health.py
@@ -411,6 +411,56 @@ def test_is_permanent_error_404():
     assert classify_error(_FakeNotFoundError()) == ErrorCategory.PERMANENT
 
 
+# Some proxies (LiteLLM proxy in particular) wrap auth failures inside an
+# HTTP 400 response. Without the auth-marker override, classify_error would
+# call these REACHABLE and the health check would silently pass on a dead key.
+
+
+class _FakeProxyExpiredKey400Error(Exception):
+    """LiteLLM proxy returns expired-key as 400 with type=expired_key."""
+
+    def __init__(self):
+        self.status_code = 400
+        super().__init__(
+            "Error code: 400 - {'error': {'message': 'Authentication Error - "
+            "Expired Key. Key Expiry time 2026-04-28', 'type': 'expired_key', "
+            "'code': '400'}}"
+        )
+
+
+class _FakeProxyInvalidKey400Error(Exception):
+    def __init__(self):
+        self.status_code = 400
+        super().__init__("invalid api key")
+
+
+def test_proxy_expired_key_400_is_permanent_not_reachable():
+    """Regression: LiteLLM proxy wraps expired_key in 400 — must not pass health."""
+    assert classify_error(_FakeProxyExpiredKey400Error()) == ErrorCategory.PERMANENT
+
+
+def test_proxy_invalid_key_400_is_permanent():
+    assert classify_error(_FakeProxyInvalidKey400Error()) == ErrorCategory.PERMANENT
+
+
+def test_400_without_auth_marker_still_reachable():
+    """Regression guard: ordinary 400s (e.g. content policy) stay REACHABLE."""
+    assert classify_error(_FakeContentPolicyError()) == ErrorCategory.REACHABLE
+
+
+@pytest.mark.asyncio
+async def test_acheck_fails_fast_on_proxy_expired_key():
+    """Health check must NOT pass on proxy-wrapped expired_key responses."""
+    mock = AsyncMock(side_effect=_FakeProxyExpiredKey400Error())
+
+    with patch("litellm.acompletion", mock):
+        with pytest.raises(_FakeProxyExpiredKey400Error):
+            await acheck_model_accessible("m")
+
+    # No retries — fail on first attempt.
+    assert mock.call_count == 1
+
+
 def test_is_permanent_error_not_permanent():
     """Transient errors should NOT be permanent."""
     assert classify_error(TimeoutError()) == ErrorCategory.TRANSIENT


### PR DESCRIPTION
## Why

Some proxies (notably the LiteLLM proxy) wrap expired/invalid-key errors inside an HTTP 400 response:

\`\`\`
Error code: 400 - {'error': {'message': 'Authentication Error - Expired Key.
 Key Expiry time 2026-04-28', 'type': 'expired_key', 'code': '400'}}
\`\`\`

\`classify_error\` saw \`status=400\` and returned \`REACHABLE\`, so the health check passed and the orchestrator went on to launch hundreds of sessions. Each one failed with the same auth error in its first \`react()\` call, but the failure was buried in per-session \`error.log\` files; the batch-level signal showed \"running fine\".

## Fix

Check the error message body for auth-failure markers **before** the status-code lookup. Markers (lowercase substring match): \`authentication error\`, \`expired_key\`, \`expired key\`, \`invalid_api_key\`, \`invalid api key\`, \`incorrect api key\`. If found, return \`PERMANENT\`.

This catches the proxy-wrapped form regardless of HTTP status. Direct-SDK paths (already classified as \`PERMANENT\` via 401) are unchanged. Ordinary 400s (e.g. content policy) stay \`REACHABLE\`.

## Tests

- \`test_proxy_expired_key_400_is_permanent_not_reachable\` — the actual case I hit
- \`test_proxy_invalid_key_400_is_permanent\`
- \`test_400_without_auth_marker_still_reachable\` — regression guard
- \`test_acheck_fails_fast_on_proxy_expired_key\` — health check no longer silently passes

All 35 existing tests in \`test_health.py\` still pass.