### PR TITLE
fix(session): write results.json when scorer crashes

### DIFF
--- a/src/exgentic/core/orchestrator/session.py
+++ b/src/exgentic/core/orchestrator/session.py
@@ -98,20 +98,23 @@ def run_session(
     except (AgentTerminationError, BenchmarkTerminationError):
         tracker.on_session_scoring(session)
         # If the benchmark scorer itself crashes (e.g. tau2 rejecting a
-        # malformed AssistantMessage), treat that as a benchmark error so
-        # observers still write results.json. Otherwise the session leaves
-        # only trajectory/otel/agent logs on disk and is reclassified as
-        # INCOMPLETE on the next pass — re-running the same crash forever.
+        # malformed AssistantMessage), treat it as a benchmark error so
+        # observers still write results.json. Otherwise the session
+        # leaves only trajectory/otel/agent logs on disk, is reclassified
+        # INCOMPLETE on the next pass, and re-runs the same crash forever.
+        # Cleanup mirrors the BenchmarkError handler below — only the
+        # agent is closed; the benchmark already raised, so we avoid
+        # touching session.close().
         try:
             score = session.score()
         except Exception as exc:
             tracker.on_session_error(session, BenchmarkError(exc))
+            agent_instance.close()
+        else:
+            if score.is_finished is None:
+                score.is_finished = True
+            tracker.on_session_success(session, score, agent_instance)
             _close_session_agent(session, agent_instance)
-            return
-        if score.is_finished is None:
-            score.is_finished = True
-        tracker.on_session_success(session, score, agent_instance)
-        _close_session_agent(session, agent_instance)
     except BenchmarkError as exc:
         tracker.on_session_error(session, exc)
         agent_instance.close()

--- a/src/exgentic/core/orchestrator/session.py
+++ b/src/exgentic/core/orchestrator/session.py
@@ -97,7 +97,17 @@ def run_session(
         _close_session_agent(session, agent_instance)
     except (AgentTerminationError, BenchmarkTerminationError):
         tracker.on_session_scoring(session)
-        score = session.score()
+        # If the benchmark scorer itself crashes (e.g. tau2 rejecting a
+        # malformed AssistantMessage), treat that as a benchmark error so
+        # observers still write results.json. Otherwise the session leaves
+        # only trajectory/otel/agent logs on disk and is reclassified as
+        # INCOMPLETE on the next pass — re-running the same crash forever.
+        try:
+            score = session.score()
+        except Exception as exc:
+            tracker.on_session_error(session, BenchmarkError(exc))
+            _close_session_agent(session, agent_instance)
+            return
         if score.is_finished is None:
             score.is_finished = True
         tracker.on_session_success(session, score, agent_instance)

--- a/tests/core/test_session_observer_lifecycle.py
+++ b/tests/core/test_session_observer_lifecycle.py
@@ -215,3 +215,32 @@ def test_on_session_creation_called_before_start(ctx, tmp_path):
     creation_idx = observer.calls.index("on_session_creation")
     start_idx = observer.calls.index("on_session_start")
     assert creation_idx < start_idx, "on_session_creation must precede on_session_start"
+
+
+def test_session_error_when_score_raises(ctx, tmp_path):
+    """Regression: a benchmark scorer crash must surface as on_session_error.
+
+    Without this guard the score() exception leaves the session in a
+    half-state on disk (no results.json), which is then re-classified as
+    INCOMPLETE on the next pass and re-run forever in a deterministic
+    crash loop. We instead expect the failure to land in on_session_error
+    so observers (including the results writer) record the outcome.
+    """
+
+    class CrashingScoreSession(MockSession):
+        def score(self):
+            raise RuntimeError("scorer rejected malformed conversation")
+
+    observer = RecordingObserver()
+    run_session(
+        session_config=MagicMock(),
+        session=CrashingScoreSession(),
+        agent=MockAgent(),
+        tracker=Tracker(observers=[observer], use_defaults=False),
+    )
+
+    assert "on_session_scoring" in observer.calls
+    assert "on_session_error" in observer.calls
+    assert "on_session_success" not in observer.calls
+    # Error must land *after* scoring started.
+    assert observer.calls.index("on_session_scoring") < observer.calls.index("on_session_error")


### PR DESCRIPTION
## Why

When a benchmark's \`session.score()\` raises (we hit this with tau2 rejecting a malformed AssistantMessage), the exception propagates out of \`run_session\`, the worker dies, and the session dir is left half-written:

\`\`\`
session_dir/
├── agent/
├── benchmark/
├── config.json
├── otel.log
├── otel_spans.jsonl
├── session.json
├── trajectory.jsonl
└── (no results.json)
\`\`\`

On the next pass, \`SessionStatus.from_config\` sees a session_dir with no \`results.json\` and classifies it \`INCOMPLETE\` → goes to \`to_run\` → re-run → same deterministic crash. The session loops forever, burning compute and writing nothing useful.

## Fix

Wrap \`session.score()\` in the \`AgentTermination/BenchmarkTermination\` handler with try/except. On exception, route to \`tracker.on_session_error\` (wrapping the underlying exception as a \`BenchmarkError\`). Observers — including the results writer — record the outcome, the session ends in \`ERROR\` state on disk, and the orchestrator can move on.

\`\`\`python
try:
    score = session.score()
except Exception as exc:
    tracker.on_session_error(session, BenchmarkError(exc))
    _close_session_agent(session, agent_instance)
    return
\`\`\`

## Tests

- \`test_session_error_when_score_raises\`: a session whose \`score()\` raises must produce \`on_session_scoring\` → \`on_session_error\` (not \`on_session_success\`). All 3 existing tests in the file still pass.

## Caveat

This catches generic \`Exception\` from the scorer. That's deliberate: a benchmark's scoring code is third-party and can fail in many ways; we don't want to enumerate them. The trade-off is masking a buggy \`tracker.on_session_error\` if it itself raises — but that's a problem regardless.