### PR TITLE
feat(otel): align with GenAI semantic conventions and add llm_time accounting

### DIFF
--- a/docs/observability/semantic-conventions.md
+++ b/docs/observability/semantic-conventions.md
@@ -1,6 +1,6 @@
 # Semantic Conventions
 
-This document maps Exgentic's core types to [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). It reflects the actual implementation in `src/exgentic/observers/handlers/otel.py` and `src/exgentic/integrations/litellm/trace_logger.py`.
+This document maps Exgentic's core types to [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/). The integration lives in `src/exgentic/observers/handlers/otel.py` and `src/exgentic/integrations/litellm/trace_logger.py`.
 
 For setup instructions, see [Quick Start](./quickstart.md).
 
@@ -9,7 +9,7 @@ For setup instructions, see [Quick Start](./quickstart.md).
 ## Span hierarchy
 
 ```
-Session Span (ROOT)
+{benchmark_name} {subset} session       ← session ROOT (operation: invoke_agent)
 ├── execute_tool initial_observation
 ├── chat {model}                        ← LLM inference
 ├── execute_tool {tool_name}
@@ -17,6 +17,10 @@ Session Span (ROOT)
 ├── execute_tool {tool_name}
 └── ...                                 ← continues until session ends
 ```
+
+The session span is the trace root. Its operation is identified by the `gen_ai.operation.name = "invoke_agent"` attribute (per spec); the span *name* keeps the exgentic-native `{benchmark_name} {subset} session` form so existing dashboards keyed on it continue to work and the benchmark/subset stay visible in trace lists.
+
+Run-level grouping is done by attribute (`exgentic.run.id`, `exgentic.benchmark.slug_name`) rather than by a parent span — sessions in batch mode run in independent processes and don't share an in-process parent. The spec's `invoke_workflow` and `create_agent` spans are optional and not emitted.
 
 ---
 
@@ -26,7 +30,7 @@ An agent's tool usage is observable at four distinct stages, each emitted on a d
 
 | Stage | Span | Attribute | Source |
 |-------|------|-----------|--------|
-| 1. Configured capability | Session (ROOT) | `exgentic.session.tools` | `Session.actions` (framework-level) |
+| 1. Configured capability | invoke_agent (session) | `exgentic.session.tools` | `Session.actions` (framework-level) |
 | 2. Offered to LLM | LLM inference | `gen_ai.tool.definitions` | `LitellmKwargs.tools` (per-call) |
 | 3. Chosen by LLM | LLM inference | `gen_ai.output.messages[].tool_calls` | provider response |
 | 4. Execution result | execute_tool | `gen_ai.tool.result` | `Observation` |
@@ -39,43 +43,44 @@ All LLM calls in exgentic are routed through LiteLLM, so stages 2–3 are guaran
 
 ## Attribute reference
 
-The table below documents every attribute actually emitted by the implementation, organised by span type.
+The table below documents every attribute defined by the integration, organised by span type.
 
 | Span type | OTel attribute | Exgentic source | Type | Requirement | Content-filtered | Notes |
 |-----------|---------------|-----------------|------|-------------|-----------------|-------|
-| **Session (ROOT)** | `exgentic.benchmark.slug_name` | `BenchmarkEntry.slug_name` | string | Custom | No | Heritable |
-| **Session (ROOT)** | `exgentic.benchmark.subset` | `RunConfig.subset` | string | Custom | No | Heritable |
-| **Session (ROOT)** | `exgentic.benchmark.agent.name` | `AgentEntry.display_name` | string | Custom | No | Heritable |
-| **Session (ROOT)** | `exgentic.agent.slug` | `RunConfig.agent` | string | Custom | No | Heritable |
-| **Session (ROOT)** | `exgentic.run.id` | `Context.run_id` | string | Custom | No | Heritable |
-| **Session (ROOT)** | `gen_ai.request.model` | `RunConfig.model` | string | Recommended | No | Heritable; set when model is known at run start |
-| **Session (ROOT)** | `gen_ai.conversation.id` | `Session.session_id` | string | Recommended | No | Heritable; primary correlation attribute |
-| **Session (ROOT)** | `exgentic.session.id` | `Session.session_id` | string | Custom | No | Heritable; kept for backwards compatibility |
-| **Session (ROOT)** | `exgentic.session.task_id` | `Session.task_id` | string | Custom | No | |
-| **Session (ROOT)** | `exgentic.session.task` | `Session.task` | string | Opt-in | **Yes** | Task prompt; requires `EXGENTIC_OTEL_RECORD_CONTENT=true` |
-| **Session (ROOT)** | `exgentic.session.action.{name}.name` | `ActionType.name` | string | Custom | No | One entry per action in `Session.actions` |
-| **Session (ROOT)** | `exgentic.session.action.{name}.description` | `ActionType.description` | string | Custom | No | |
-| **Session (ROOT)** | `exgentic.session.action.{name}.is_message` | `ActionType.is_message` | bool | Custom | No | |
-| **Session (ROOT)** | `exgentic.session.action.{name}.is_finish` | `ActionType.is_finish` | bool | Custom | No | |
-| **Session (ROOT)** | `exgentic.session.tools` | `Session.actions` | string (JSON) | Custom | No | Comprehensive JSON list of all tools available at session start (name, description, is_message, is_finish). The per-action flat attributes (`exgentic.session.action.{name}.*`) above are deprecated-in-spirit and will be consolidated into this attribute in a follow-up. |
-| **Session (ROOT)** | `exgentic.context.{key}` | `Session.context[key]` | string | Custom | No | One entry per context key |
-| **Session (ROOT)** | `exgentic.session.agent.id` | `AgentInstance.agent_id` | string | Custom | No | |
-| **Session (ROOT)** | `exgentic.session.agent.path` | `AgentInstance.paths.agent_dir` | string | Custom | No | |
-| **Session (ROOT)** | `exgentic.score.success` | `SessionScore.success` | bool | Custom | No | Set on session close |
-| **Session (ROOT)** | `exgentic.score` | `SessionScore.score` | float | Custom | No | Set on session close |
-| **Session (ROOT)** | `exgentic.score.is_finished` | `SessionScore.is_finished` | bool | Custom | No | Set on session close |
-| **Session (ROOT)** | `exgentic.score.metrics.{key}` | `SessionScore.session_metrics[key]` | primitive or string (JSON) | Custom | No | One entry per metric; nested values JSON-encoded |
-| **Session (ROOT)** | `exgentic.score.metadata.{key}` | `SessionScore.session_metadata[key]` | primitive or string (JSON) | Custom | No | One entry per metadata field; nested values JSON-encoded |
-| **Session (ROOT)** | `exgentic.session.steps` | step counter | int | Custom | No | Set on session close |
-| **Session (ROOT)** | `exgentic.agent.agent_cost` | `AgentInstance.get_cost()` | string (JSON) | Custom | No | Set on session close |
-| **Session (ROOT)** | `exgentic.session.cost` | `Session.get_cost()` | string (JSON) | Custom | No | Set on session close |
+| **invoke_agent (session ROOT)** | `gen_ai.operation.name` | `"invoke_agent"` | string | Required | No | Constant value |
+| **invoke_agent (session ROOT)** | `gen_ai.agent.id` | `Agent.slug_name` | string | Conditionally required | No | Stable agent template identifier; one of `agent.id`/`agent.name` is required |
+| **invoke_agent (session ROOT)** | `gen_ai.agent.name` | `Agent.display_name` | string | Conditionally required | No | Human-readable agent name |
+| **invoke_agent (session ROOT)** | `gen_ai.agent.description` | `Agent.__doc__` | string | Recommended | No | Sourced from the agent class docstring; omitted if absent |
+| **invoke_agent (session ROOT)** | `gen_ai.conversation.id` | `Session.session_id` | string | Recommended | No | Heritable; the LLM message thread identifier (distinct from the session entity — see `exgentic.session.id`) |
+| **invoke_agent (session ROOT)** | `exgentic.session.id` | `Session.session_id` | string | Custom | No | Heritable; identifies the Session entity (task, score, cost, lifecycle). Used as the routing key by `PerSessionFileExporter`. Same value as `gen_ai.conversation.id` today, but a different concept — kept so consumers can address the session entity directly. |
+| **invoke_agent (session ROOT)** | `gen_ai.request.model` | `RunConfig.model` | string | Recommended | No | Heritable; set when model is known at run start |
+| **invoke_agent (session ROOT)** | `exgentic.benchmark.slug_name` | `BenchmarkEntry.slug_name` | string | Custom | No | Heritable |
+| **invoke_agent (session ROOT)** | `exgentic.benchmark.subset` | `RunConfig.subset` | string | Custom | No | Heritable |
+| **invoke_agent (session ROOT)** | `exgentic.benchmark.agent.name` | `agent_entry.slug_name` (falls back to `RunConfig.agent`) | string | Custom | No | Heritable; the resolved agent registry slug (distinct from `gen_ai.agent.name`, which is the human-readable display name) |
+| **invoke_agent (session ROOT)** | `exgentic.agent.slug` | `RunConfig.agent` | string | Custom | No | Heritable; the requested agent slug (typically equal to `exgentic.benchmark.agent.name`, but may differ if registry aliasing is in play) |
+| **invoke_agent (session ROOT)** | `exgentic.run.id` | `Context.run_id` | string | Custom | No | Heritable; primary key for grouping sessions of one benchmark run |
+| **invoke_agent (session ROOT)** | `exgentic.session.task_id` | `Session.task_id` | string | Custom | No | |
+| **invoke_agent (session ROOT)** | `exgentic.session.task` | `Session.task` | string | Opt-in | **Yes** | Task prompt; requires `EXGENTIC_OTEL_RECORD_CONTENT=true` |
+| **invoke_agent (session ROOT)** | `exgentic.session.tools` | `Session.actions` | string (JSON) | Custom | No | JSON list of all tools available at session start (name, description, is_message, is_finish) |
+| **invoke_agent (session ROOT)** | `exgentic.context.{key}` | `Session.context[key]` | string | Custom | No | One entry per context key |
+| **invoke_agent (session ROOT)** | `exgentic.session.agent.id` | `AgentInstance.agent_id` | string | Custom | No | Per-instance runtime UUID for the AgentInstance (distinct from `gen_ai.agent.id`, which is the stable template identifier) |
+| **invoke_agent (session ROOT)** | `exgentic.session.agent.path` | `AgentInstance.paths.agent_dir` | string | Custom | No | |
+| **invoke_agent (session ROOT)** | `exgentic.score.success` | `SessionScore.success` | bool | Custom | No | Set on session close; also emitted as `gen_ai.evaluation.result` event |
+| **invoke_agent (session ROOT)** | `exgentic.score` | `SessionScore.score` | float | Custom | No | Set on session close; also emitted as `gen_ai.evaluation.result` event |
+| **invoke_agent (session ROOT)** | `exgentic.score.is_finished` | `SessionScore.is_finished` | bool | Custom | No | Set on session close |
+| **invoke_agent (session ROOT)** | `exgentic.score.metrics.{key}` | `SessionScore.session_metrics[key]` | primitive or string (JSON) | Custom | No | One entry per metric; nested values JSON-encoded |
+| **invoke_agent (session ROOT)** | `exgentic.score.metadata.{key}` | `SessionScore.session_metadata[key]` | primitive or string (JSON) | Custom | No | One entry per metadata field; nested values JSON-encoded |
+| **invoke_agent (session ROOT)** | `exgentic.session.steps` | step counter | int | Custom | No | Set on session close |
+| **invoke_agent (session ROOT)** | `exgentic.agent.agent_cost` | `AgentInstance.get_cost()` | string (JSON) | Custom | No | Set on session close |
+| **invoke_agent (session ROOT)** | `exgentic.session.cost` | `Session.get_cost()` | string (JSON) | Custom | No | Set on session close |
 | **execute_tool** | `gen_ai.operation.name` | `"execute_tool"` | string | Required | No | Constant value |
 | **execute_tool** | `gen_ai.tool.name` | `Action.name` | string | Required | No | |
-| **execute_tool** | `gen_ai.tool.id` | `Action.id` | string | Recommended | No | |
+| **execute_tool** | `gen_ai.tool.id` | `Action.id` | string | Recommended | No | Matches the `tool_calls[].id` from the model response. The spec has renamed this to `gen_ai.tool.call.id`; tracked separately for the rename. |
 | **execute_tool** | `gen_ai.tool.description` | `ActionType.description` | string | Recommended | No | Looked up from `Session.actions` |
-| **execute_tool** | `gen_ai.tool.parameters` | `Action.arguments` | string (JSON) | Opt-in | **Yes** | Requires `EXGENTIC_OTEL_RECORD_CONTENT=true` |
-| **execute_tool** | `gen_ai.tool.result` | `Observation` | string | Opt-in | **Yes** | Requires `EXGENTIC_OTEL_RECORD_CONTENT=true` |
-| **execute_tool** | `gen_ai.conversation.id` | `Session.session_id` | string | Recommended | No | Inherited from session span |
+| **execute_tool** | `gen_ai.tool.type` | `"function"` | string | Recommended | No | Constant — exgentic actions are always function-style tools |
+| **execute_tool** | `gen_ai.tool.parameters` | `Action.arguments` | string (JSON) | Opt-in | **Yes** | Requires `EXGENTIC_OTEL_RECORD_CONTENT=true`. The spec has renamed this to `gen_ai.tool.call.arguments`; tracked separately for the rename. |
+| **execute_tool** | `gen_ai.tool.result` | `Observation` | string | Opt-in | **Yes** | Requires `EXGENTIC_OTEL_RECORD_CONTENT=true`. The spec has renamed this to `gen_ai.tool.call.result`; tracked separately for the rename. |
+| **execute_tool** | `gen_ai.conversation.id` | `Session.session_id` | string | Recommended | No | Inherited from invoke_agent span |
 | **LLM inference** | `gen_ai.operation.name` | `"chat"` or `"text_completion"` | string | Required | No | |
 | **LLM inference** | `gen_ai.provider.name` | `litellm_params.custom_llm_provider` | string | Required | No | Mapped to standard provider names |
 | **LLM inference** | `gen_ai.request.model` | `LitellmKwargs.model` | string | Required | No | |
@@ -90,25 +95,30 @@ The table below documents every attribute actually emitted by the implementation
 | **LLM inference** | `gen_ai.request.stop_sequences` | `optional_params.stop` | string[] | Recommended | No | |
 | **LLM inference** | `gen_ai.request.choice.count` | `optional_params.n` | int | Required | No | Only when `n != 1` |
 | **LLM inference** | `gen_ai.request.seed` | `optional_params.seed` | int | Required | No | |
+| **LLM inference** | `gen_ai.request.stream` | `kwargs.stream` | bool | Recommended | No | Whether the request used streaming mode |
 | **LLM inference** | `gen_ai.response.id` | `ResponseObject.id` | string | Recommended | No | |
 | **LLM inference** | `gen_ai.response.model` | `ResponseObject.model` | string | Recommended | No | Actual model resolved by the provider |
-| **LLM inference** | `gen_ai.usage.input_tokens` | `usage.prompt_tokens` | int | Recommended | No | |
+| **LLM inference** | `gen_ai.usage.input_tokens` | `usage.prompt_tokens` | int | Recommended | No | Includes cached tokens per spec |
 | **LLM inference** | `gen_ai.usage.output_tokens` | `usage.completion_tokens` | int | Recommended | No | |
+| **LLM inference** | `gen_ai.usage.cache_creation.input_tokens` | `usage.cache_creation_input_tokens` | int | Recommended | No | When prompt caching is used (e.g. Anthropic) |
+| **LLM inference** | `gen_ai.usage.cache_read.input_tokens` | `usage.cache_read_input_tokens` | int | Recommended | No | When prompt caching is used |
+| **LLM inference** | `gen_ai.usage.reasoning.output_tokens` | `usage.completion_tokens_details.reasoning_tokens` | int | Recommended | No | When the model emits reasoning/thinking tokens |
 | **LLM inference** | `gen_ai.response.finish_reasons` | `choices[*].finish_reason` | string[] | Recommended | No | |
 | **LLM inference** | `gen_ai.tool.definitions` | `LitellmKwargs.tools` | string (JSON) | Opt-in | **Yes** | Requires `EXGENTIC_OTEL_RECORD_CONTENT=true` |
-| **LLM inference** | `gen_ai.input.messages` | `LitellmKwargs.messages` | string (JSON) | Opt-in | **Yes** | Requires `EXGENTIC_OTEL_RECORD_CONTENT=true` |
+| **LLM inference** | `gen_ai.input.messages` | `LitellmKwargs.messages` | string (JSON) | Opt-in | **Yes** | Requires `EXGENTIC_OTEL_RECORD_CONTENT=true`. Includes system messages; the spec recommends splitting them into `gen_ai.system_instructions` — tracked separately. |
 | **LLM inference** | `gen_ai.output.messages` | `choices[*].message` | string (JSON) | Opt-in | **Yes** | Requires `EXGENTIC_OTEL_RECORD_CONTENT=true` |
 
 ---
 
 ## Span details
 
-### Session span (ROOT)
+### invoke_agent span (session ROOT)
 
-- **Name**: `{benchmark_name} {subset} session`
+- **Name**: `{benchmark_name} {subset} session` (the spec recommends `invoke_agent {agent_name}` but exgentic keeps the existing name; the operation is identified by the `gen_ai.operation.name` attribute)
 - **Kind**: `INTERNAL`
 - **Opened**: `OtelTracingObserver.on_session_creation`
 - **Closed**: `OtelTracingObserver.on_session_success` or `on_session_error`
+- **Reference**: [OTel GenAI invoke_agent span](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/#invoke-agent-span)
 
 ### execute_tool span
 
@@ -123,24 +133,38 @@ The table below documents every attribute actually emitted by the implementation
 - **Name**: `{operation} {model}` (e.g., `chat gpt-4o`)
 - **Kind**: `CLIENT`
 - **Opened/Closed**: `TraceLogger._write_otel` (LiteLLM callback)
-- **Parent**: session span (via OTEL context propagation)
+- **Parent**: invoke_agent span (via OTEL context propagation)
 - **Reference**: [OTel GenAI inference span](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#inference)
+
+---
+
+## Events
+
+### `gen_ai.evaluation.result`
+
+Emitted on session close as a span event on the `invoke_agent` span. One event for the primary score, plus one event per metric in `SessionScore.session_metrics`.
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `gen_ai.evaluation.name` | metric key (`"score"` for the primary event) | Required |
+| `gen_ai.evaluation.score.value` | `SessionScore.score` (primary event) or numeric metric value | Set when the value is numeric |
+| `gen_ai.evaluation.score.label` | `"success"`/`"failure"` from `SessionScore.success` (primary event), or stringified non-numeric metric value | Set when no numeric value |
 
 ---
 
 ## Attribute inheritance
 
-The following attributes are set on the session span and automatically propagated to all child spans via `SessionSpanManager.set_heritable_attribute()`:
+The following attributes are set on the invoke_agent span and automatically propagated to all child spans via `SessionSpanManager.set_heritable_attribute()`:
 
 | Attribute | Source |
 |-----------|--------|
-| `gen_ai.conversation.id` | `Session.session_id` — primary correlation key |
-| `exgentic.session.id` | `Session.session_id` — backwards compatibility |
+| `gen_ai.conversation.id` | `Session.session_id` — LLM thread identifier |
+| `exgentic.session.id` | `Session.session_id` — Session entity identifier (and exporter routing key) |
 | `gen_ai.request.model` | `RunConfig.model` (when available) |
 | `exgentic.run.id` | `Context.run_id` |
 | `exgentic.benchmark.slug_name` | `BenchmarkEntry.slug_name` |
 | `exgentic.benchmark.subset` | `RunConfig.subset` |
-| `exgentic.benchmark.agent.name` | `AgentEntry.display_name` |
+| `exgentic.benchmark.agent.name` | `agent_entry.slug_name` |
 | `exgentic.agent.slug` | `RunConfig.agent` |
 
 ---
@@ -159,6 +183,13 @@ Attributes that are never filtered include all IDs, names, counters, scores, and
 
 ## Implementation notes
 
+### Spans not emitted
+
+The spec defines two additional agent spans that are intentionally **not** emitted:
+
+- **`invoke_workflow`** — a single parent span over an entire benchmark run does not fit exgentic's runtime: sessions in batch mode run in independent processes that do not share an in-process OTEL context. Run-level grouping is done by attribute (`exgentic.run.id`, `exgentic.benchmark.slug_name`) and computed from session-span aggregates instead.
+- **`create_agent`** — would require a new framework lifecycle hook for agent instantiation. May be added in the future to capture agent setup overhead (venv install, container start, model warm-up) separately from session execution.
+
 ### Model name resolution
 
 Because `AgentInstance` does not expose model settings, the model name is extracted from `RunConfig` at run start:
@@ -174,19 +205,29 @@ model_name = run_config.model or (run_config.agent_kwargs or {}).get("model")
 - `exgentic.agent.agent_cost` — agent-level cost report
 - `exgentic.session.cost` — full session cost report
 
+### Agent description and version
+
+`gen_ai.agent.description` is read from the agent's class docstring (`Agent.__doc__`). Subclasses are expected to document their behaviour in the class docstring; if absent, the attribute is omitted.
+
+`gen_ai.agent.version` is not currently emitted — `Agent` has no version field. Implementations may map it to the package version of the agent module if a stable source is desirable.
+
 ### LLM span parent context
 
-LLM inference spans are created inside the LiteLLM callback and attached to the session span via OTEL context propagation:
+LLM inference spans are created inside the LiteLLM callback and attached to the invoke_agent span via OTEL context propagation:
 
 1. The session span manager writes the current OTEL context into the `Context` ContextVar via `update_tracing_context()`.
 2. The LiteLLM trace logger reads the OTEL context from that ContextVar.
-3. LLM spans are created with the session span as their parent using `_get_parent_context()`.
+3. LLM spans are created with the invoke_agent span as their parent using `_get_parent_context()`.
 
 ---
 
 ## References
 
 - [OTel GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
-- [execute_tool span spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span)
+- [GenAI attribute registry](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/)
 - [Inference span spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#inference)
+- [execute_tool span spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span)
+- [Agent spans spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/)
+- [GenAI metrics spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/)
+- [GenAI events spec](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/)
 - [Quick Start](./quickstart.md)

--- a/src/exgentic/core/types/session.py
+++ b/src/exgentic/core/types/session.py
@@ -47,6 +47,8 @@ class SessionResults(BaseModel):
     agent_cost: float
     benchmark_cost: float
     execution_time: float
+    llm_time: float = 0.0
+    llm_call_count: int = 0
     details: dict[str, Any] = {}
     cost_reports: dict[str, CostReport] = Field(default_factory=dict)
     task_id: Optional[str] = None

--- a/src/exgentic/integrations/litellm/trace_logger.py
+++ b/src/exgentic/integrations/litellm/trace_logger.py
@@ -172,6 +172,21 @@ class TraceLogger(CustomLogger):
     def _log_event(self, kwargs, response_obj, status, start_time=None, end_time=None):
         self._write_row(kwargs, response_obj, status)
         self._write_otel(kwargs, response_obj, status, start_time=start_time, end_time=end_time)
+        self._record_session_timing(kwargs, start_time, end_time)
+
+    def _record_session_timing(self, kwargs, start_time, end_time) -> None:
+        if start_time is None or end_time is None:
+            return
+        ctx = self.get_context(kwargs)
+        if ctx is None or not ctx.session_id:
+            return
+        try:
+            duration = (end_time - start_time).total_seconds()
+        except Exception:
+            return
+        from ...observers.handlers.session_timings import get_session_llm_timings
+
+        get_session_llm_timings().record(ctx.session_id, duration)
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
         self._log_event(kwargs, response_obj, "success", start_time, end_time)
@@ -270,6 +285,9 @@ class TraceLogger(CustomLogger):
             # Routing key for PerSessionFileExporter.
             "exgentic.run.id": ctx.run_id,
         }
+        stream = kwargs.get("stream")
+        if stream is not None:
+            attrs["gen_ai.request.stream"] = bool(stream)
         self._collect_request_attrs(attrs, optional_params)
         self._collect_response_attrs(attrs, response_obj)
 
@@ -342,6 +360,19 @@ class TraceLogger(CustomLogger):
             output_tokens = _safe_get(usage, "completion_tokens")
             if output_tokens is not None:
                 attrs["gen_ai.usage.output_tokens"] = output_tokens
+
+            cache_creation_tokens = _safe_get(usage, "cache_creation_input_tokens")
+            if cache_creation_tokens is not None:
+                attrs["gen_ai.usage.cache_creation.input_tokens"] = cache_creation_tokens
+            cache_read_tokens = _safe_get(usage, "cache_read_input_tokens")
+            if cache_read_tokens is not None:
+                attrs["gen_ai.usage.cache_read.input_tokens"] = cache_read_tokens
+
+            completion_details = _safe_get(usage, "completion_tokens_details")
+            if completion_details:
+                reasoning_tokens = _safe_get(completion_details, "reasoning_tokens")
+                if reasoning_tokens is not None:
+                    attrs["gen_ai.usage.reasoning.output_tokens"] = reasoning_tokens
 
         choices = _safe_get(response_obj, "choices", [])
         if choices:

--- a/src/exgentic/observers/handlers/otel.py
+++ b/src/exgentic/observers/handlers/otel.py
@@ -186,6 +186,8 @@ class OtelTracingObserver(Observer):
         self._span_managers: dict[str, SessionSpanManager] = {}
         self._session_step_counters: dict[str, int] = {}
         self._session_agents: dict[str, Any] = {}
+        self._agent_slug_name: str | None = None
+        self._agent_display_name: str | None = None
 
     def _get_span_manager(self, session_id: str) -> SessionSpanManager:
         return self._span_managers[session_id]
@@ -216,6 +218,9 @@ class OtelTracingObserver(Observer):
         if model_name:
             self._run_attributes["gen_ai.request.model"] = model_name
 
+        self._agent_slug_name = agent_entry.slug_name if agent_entry else run_config.agent
+        self._agent_display_name = agent_entry.display_name if agent_entry else None
+
     # -- Session lifecycle ---------------------------------------------------
 
     def on_session_enter(self, session_id: str, task_id: str | None) -> None:
@@ -231,6 +236,11 @@ class OtelTracingObserver(Observer):
         span_manager.set_heritable_attributes(self._run_attributes)
         span_manager.set_heritable_attribute("gen_ai.conversation.id", session_id)
         span_manager.set_heritable_attribute("exgentic.session.id", session_id)
+        span_manager.set_attribute("gen_ai.operation.name", "invoke_agent")
+        if self._agent_slug_name:
+            span_manager.set_attribute("gen_ai.agent.id", self._agent_slug_name)
+        if self._agent_display_name:
+            span_manager.set_attribute("gen_ai.agent.name", self._agent_display_name)
         if task_id is not None:
             span_manager.set_attribute("exgentic.session.task_id", task_id)
 
@@ -288,10 +298,15 @@ class OtelTracingObserver(Observer):
         if agent_path is not None:
             span_manager.set_attribute("exgentic.session.agent.path", agent_path)
 
+        agent_doc = (agent.__class__.__doc__ or "").strip()
+        if agent_doc:
+            span_manager.set_attribute("gen_ai.agent.description", agent_doc)
+
         # Record initial observation as an execute_tool span
         span_manager.start_span("execute_tool initial_observation", kind=SpanKind.CLIENT)
         span_manager.current_span.set_attribute("gen_ai.operation.name", "execute_tool")
         span_manager.current_span.set_attribute("gen_ai.tool.name", "initial_observation")
+        span_manager.current_span.set_attribute("gen_ai.tool.type", "function")
         span_manager.current_span.set_attribute("gen_ai.tool.description", "Initial observation from benchmark")
         self._record_observation(session.session_id, observation)
         span_manager.end_current_span()
@@ -306,6 +321,7 @@ class OtelTracingObserver(Observer):
         span_manager.start_span(f"execute_tool {tool_name}", kind=SpanKind.CLIENT)
         span_manager.current_span.set_attribute("gen_ai.operation.name", "execute_tool")
         span_manager.current_span.set_attribute("gen_ai.tool.name", tool_name)
+        span_manager.current_span.set_attribute("gen_ai.tool.type", "function")
 
         if action_list:
             first = action_list[0]
@@ -359,6 +375,8 @@ class OtelTracingObserver(Observer):
         self._set_cost_attr(span_manager, "exgentic.agent.agent_cost", lambda: agent.get_cost())
         self._set_cost_attr(span_manager, "exgentic.session.cost", lambda: session.get_cost())
 
+        self._emit_evaluation_events(span_manager, score)
+
         self._finalize_session(session.session_id, span_manager)
 
     def on_session_error(self, session, error) -> None:
@@ -399,6 +417,30 @@ class OtelTracingObserver(Observer):
             span_manager.set_attribute(key, json.dumps(get_cost(), default=str))
         except Exception:
             logger.debug("Failed to serialize cost for %s", key, exc_info=True)
+
+    @staticmethod
+    def _emit_evaluation_events(span_manager: SessionSpanManager, score) -> None:
+        span = span_manager.current_span
+        if span is None:
+            return
+
+        primary: dict[str, AttributeValue] = {
+            "gen_ai.evaluation.name": "score",
+            "gen_ai.evaluation.score.value": float(score.score),
+            "gen_ai.evaluation.score.label": "success" if score.success else "failure",
+        }
+        span.add_event("gen_ai.evaluation.result", primary)
+
+        for key, value in score.session_metrics.items():
+            otel_value = to_otel_attribute_value(value)
+            if otel_value is None:
+                continue
+            attrs: dict[str, AttributeValue] = {"gen_ai.evaluation.name": key}
+            if isinstance(otel_value, (int, float)) and not isinstance(otel_value, bool):
+                attrs["gen_ai.evaluation.score.value"] = float(otel_value)
+            else:
+                attrs["gen_ai.evaluation.score.label"] = str(otel_value)
+            span.add_event("gen_ai.evaluation.result", attrs)
 
     def _finalize_session(self, session_id: str, span_manager: SessionSpanManager) -> None:
         span_manager.end_current_span()

--- a/src/exgentic/observers/handlers/results.py
+++ b/src/exgentic/observers/handlers/results.py
@@ -243,6 +243,9 @@ class ResultsObserver(Observer):
         agent_cost_report = agent.get_cost() if agent is not None else CostReport.initialize_empty()
         benchmark_cost_report = session.get_cost()
         status = self._resolve_session_status(score)
+        from .session_timings import get_session_llm_timings
+
+        llm_durations = get_session_llm_timings().pop(session_id)
         tr = SessionResults(
             session_id=session_id,
             success=success,
@@ -255,6 +258,8 @@ class ResultsObserver(Observer):
             agent_cost=agent_cost_report.total_cost,
             benchmark_cost=benchmark_cost_report.total_cost,
             execution_time=execution_time,
+            llm_time=sum(llm_durations),
+            llm_call_count=len(llm_durations),
             details=score.model_dump(),
             cost_reports={
                 "agent": agent_cost_report,

--- a/src/exgentic/observers/handlers/session_timings.py
+++ b/src/exgentic/observers/handlers/session_timings.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Per-session LLM call timing accumulator.
+
+Single source of truth for LLM call wall-time data exposed in
+`SessionResults`. Written by the LiteLLM trace logger on every call;
+read by the results observer when finalizing a session.
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+class SessionLLMTimings:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._durations: dict[str, list[float]] = {}
+
+    def record(self, session_id: str, duration_seconds: float) -> None:
+        if not session_id or duration_seconds < 0:
+            return
+        with self._lock:
+            self._durations.setdefault(session_id, []).append(duration_seconds)
+
+    def pop(self, session_id: str) -> list[float]:
+        with self._lock:
+            return self._durations.pop(session_id, [])
+
+
+_INSTANCE = SessionLLMTimings()
+
+
+def get_session_llm_timings() -> SessionLLMTimings:
+    return _INSTANCE

--- a/tests/observers/test_otel.py
+++ b/tests/observers/test_otel.py
@@ -3718,3 +3718,281 @@ class TestContentRecordingRobustness:
         result = _serialize_to_json(MyModel(name="test", count=5))
         parsed = json.loads(result)
         assert parsed == {"name": "test", "count": 5}
+
+
+# ===================================================================
+# New GenAI semconv-aligned attributes and events
+# ===================================================================
+
+
+def _lifecycle_with_agent_entry(ctx, tmp_path, *, agent_entry=None, agent=None, score=None):
+    """Run full observer lifecycle with a specific agent_entry mock."""
+    from exgentic.observers.handlers.otel import OtelTracingObserver, SessionSpanManager
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    t = provider.get_tracer("test")
+
+    session = MockSession()
+    rc = MockRunConfig()
+    score = score or MockScore()
+    agent = agent or MockAgent()
+    settings = MagicMock(otel_record_content=False)
+
+    agent_entries = {rc.agent: agent_entry} if agent_entry is not None else {}
+
+    obs = OtelTracingObserver()
+    original_init = SessionSpanManager.__init__
+
+    def patched_init(self, session_id, session_root_path, tracer=t):
+        original_init(self, session_id, session_root_path, tracer=tracer)
+
+    with (
+        patch("exgentic.observers.handlers.otel.get_benchmark_entries", return_value={}),
+        patch("exgentic.observers.handlers.otel.get_agent_entries", return_value=agent_entries),
+        patch("exgentic.observers.handlers.otel.get_settings", return_value=settings),
+        patch(
+            "exgentic.observers.handlers.otel.to_otel_attribute_value",
+            side_effect=lambda v: str(v) if v is not None else None,
+        ),
+        patch("exgentic.observers.handlers.otel.flush_traces"),
+        patch.object(SessionSpanManager, "__init__", patched_init),
+    ):
+        obs.on_run_start(rc)
+        obs.on_session_creation(session)
+        obs.on_session_start(session, agent, MockObservation())
+        obs.on_session_success(session, score, agent)
+
+    spans = exporter.get_finished_spans()
+    return next((s for s in spans if "session" in s.name), None), spans
+
+
+class TestSessionRootInvokeAgentSemconv:
+    """gen_ai.operation.name + gen_ai.agent.* on session ROOT."""
+
+    def test_operation_name_is_invoke_agent(self, ctx, tmp_path):
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path)
+        assert session_span.attributes["gen_ai.operation.name"] == "invoke_agent"
+
+    def test_agent_id_from_entry_slug_name(self, ctx, tmp_path):
+        entry = MagicMock(slug_name="smol-react", display_name="SmolAgents ReAct")
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path, agent_entry=entry)
+        assert session_span.attributes["gen_ai.agent.id"] == "smol-react"
+
+    def test_agent_name_from_entry_display_name(self, ctx, tmp_path):
+        entry = MagicMock(slug_name="smol-react", display_name="SmolAgents ReAct")
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path, agent_entry=entry)
+        assert session_span.attributes["gen_ai.agent.name"] == "SmolAgents ReAct"
+
+    def test_agent_id_falls_back_to_run_config_agent_when_no_entry(self, ctx, tmp_path):
+        """No agent entry → agent.id falls back to run_config.agent slug."""
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path)
+        assert session_span.attributes["gen_ai.agent.id"] == MockRunConfig().agent
+
+    def test_agent_name_omitted_when_no_entry(self, ctx, tmp_path):
+        """No agent entry → no display_name source → attribute omitted."""
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path)
+        assert "gen_ai.agent.name" not in session_span.attributes
+
+    def test_agent_description_from_class_docstring(self, ctx, tmp_path):
+        class DocAgent(MockAgent):
+            """A documented agent."""
+
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path, agent=DocAgent())
+        assert session_span.attributes["gen_ai.agent.description"] == "A documented agent."
+
+    def test_agent_description_omitted_when_no_docstring(self, ctx, tmp_path):
+        class NoDocAgent(MockAgent):
+            __doc__ = None
+
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path, agent=NoDocAgent())
+        assert "gen_ai.agent.description" not in session_span.attributes
+
+
+class TestExecuteToolTypeAttribute:
+    """gen_ai.tool.type = 'function' on both execute_tool spans."""
+
+    def test_initial_observation_span_has_tool_type(self, ctx, tmp_path):
+        _, _, all_spans = _full_lifecycle_spans(ctx, tmp_path)
+        initial = next(s for s in all_spans if s.name == "execute_tool initial_observation")
+        assert initial.attributes["gen_ai.tool.type"] == "function"
+
+    def test_react_tool_span_has_tool_type(self, ctx, tmp_path):
+        _, tool_spans, _ = _full_lifecycle_spans(ctx, tmp_path, add_react_step=True)
+        browse = next(s for s in tool_spans if s.name == "execute_tool browse")
+        assert browse.attributes["gen_ai.tool.type"] == "function"
+
+
+class TestEvaluationResultEvents:
+    """gen_ai.evaluation.result span events on session close."""
+
+    def test_primary_event_emitted_on_success(self, ctx, tmp_path):
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path)
+        events = [e for e in session_span.events if e.name == "gen_ai.evaluation.result"]
+        assert len(events) == 1
+
+    def test_primary_event_attributes(self, ctx, tmp_path):
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path)
+        event = next(e for e in session_span.events if e.name == "gen_ai.evaluation.result")
+        assert event.attributes["gen_ai.evaluation.name"] == "score"
+        assert event.attributes["gen_ai.evaluation.score.value"] == 0.95
+        assert event.attributes["gen_ai.evaluation.score.label"] == "success"
+
+    def test_label_is_failure_when_score_unsuccessful(self, ctx, tmp_path):
+        class FailScore(MockScore):
+            success = False
+
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path, score=FailScore())
+        event = next(e for e in session_span.events if e.name == "gen_ai.evaluation.result")
+        assert event.attributes["gen_ai.evaluation.score.label"] == "failure"
+
+    def test_per_metric_events_emitted_for_numeric(self, ctx, tmp_path):
+        class MetricScore(MockScore):
+            session_metrics: ClassVar = {"accuracy": 0.8, "latency": 1.5}
+
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path, score=MetricScore())
+        events = [e for e in session_span.events if e.name == "gen_ai.evaluation.result"]
+        # 1 primary + 2 per-metric
+        assert len(events) == 3
+        names = {e.attributes["gen_ai.evaluation.name"] for e in events}
+        assert names == {"score", "accuracy", "latency"}
+
+    def test_per_metric_event_uses_label_for_non_numeric(self, ctx, tmp_path):
+        class MetricScore(MockScore):
+            session_metrics: ClassVar = {"verdict": "pass"}
+
+        session_span, _ = _lifecycle_with_agent_entry(ctx, tmp_path, score=MetricScore())
+        verdict_event = next(
+            e
+            for e in session_span.events
+            if e.name == "gen_ai.evaluation.result" and e.attributes["gen_ai.evaluation.name"] == "verdict"
+        )
+        assert verdict_event.attributes["gen_ai.evaluation.score.label"] == "pass"
+        assert "gen_ai.evaluation.score.value" not in verdict_event.attributes
+
+
+class TestLLMInferenceNewAttributes:
+    """Cache/reasoning token attrs and gen_ai.request.stream on inference spans."""
+
+    def test_cache_creation_input_tokens(self):
+        spans = _invoke_write_otel(
+            response_obj={
+                "id": "x",
+                "model": "claude-3-5-sonnet",
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "cache_creation_input_tokens": 200,
+                },
+                "choices": [{"finish_reason": "stop", "message": {"role": "assistant", "content": "hi"}}],
+            }
+        )
+        assert spans[0].attributes["gen_ai.usage.cache_creation.input_tokens"] == 200
+
+    def test_cache_read_input_tokens(self):
+        spans = _invoke_write_otel(
+            response_obj={
+                "id": "x",
+                "model": "claude-3-5-sonnet",
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "cache_read_input_tokens": 150,
+                },
+                "choices": [{"finish_reason": "stop", "message": {"role": "assistant", "content": "hi"}}],
+            }
+        )
+        assert spans[0].attributes["gen_ai.usage.cache_read.input_tokens"] == 150
+
+    def test_reasoning_output_tokens(self):
+        spans = _invoke_write_otel(
+            response_obj={
+                "id": "x",
+                "model": "o1",
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 200,
+                    "completion_tokens_details": {"reasoning_tokens": 180},
+                },
+                "choices": [{"finish_reason": "stop", "message": {"role": "assistant", "content": "hi"}}],
+            }
+        )
+        assert spans[0].attributes["gen_ai.usage.reasoning.output_tokens"] == 180
+
+    def test_request_stream_true(self):
+        spans = _invoke_write_otel(
+            kwargs={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": True,
+                "optional_params": {},
+                "litellm_params": {"custom_llm_provider": "openai"},
+            }
+        )
+        assert spans[0].attributes["gen_ai.request.stream"] is True
+
+    def test_request_stream_false(self):
+        spans = _invoke_write_otel(
+            kwargs={
+                "model": "gpt-4o",
+                "messages": [{"role": "user", "content": "hi"}],
+                "stream": False,
+                "optional_params": {},
+                "litellm_params": {"custom_llm_provider": "openai"},
+            }
+        )
+        assert spans[0].attributes["gen_ai.request.stream"] is False
+
+    def test_request_stream_omitted_when_unset(self):
+        spans = _invoke_write_otel()
+        assert "gen_ai.request.stream" not in spans[0].attributes
+
+    def test_cache_attrs_omitted_when_no_cache_used(self):
+        """Calls without prompt caching should not emit cache attrs."""
+        spans = _invoke_write_otel()
+        assert "gen_ai.usage.cache_creation.input_tokens" not in spans[0].attributes
+        assert "gen_ai.usage.cache_read.input_tokens" not in spans[0].attributes
+
+
+class TestTraceLoggerRecordsSessionTimings:
+    """trace_logger writes per-call durations into SessionLLMTimings."""
+
+    def test_log_event_records_duration(self):
+        from datetime import datetime, timedelta
+
+        from exgentic.integrations.litellm.trace_logger import TraceLogger
+        from exgentic.observers.handlers.session_timings import get_session_llm_timings
+
+        # Drain any stray entries from prior tests
+        get_session_llm_timings().pop("ts-sess-001")
+
+        logger = TraceLogger()
+        mock_ctx = MagicMock(session_id="ts-sess-001", run_id="run-1", role=MagicMock(value="agent"))
+
+        kwargs = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "hi"}],
+            "optional_params": {},
+            "litellm_params": {"custom_llm_provider": "openai"},
+        }
+        response_obj = {
+            "id": "x",
+            "model": "gpt-4o",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20},
+            "choices": [{"finish_reason": "stop", "message": {"role": "assistant", "content": "hi"}}],
+        }
+        start = datetime(2026, 1, 1, 0, 0, 0)
+        end = start + timedelta(seconds=2.5)
+
+        settings = MagicMock(otel_enabled=False, otel_record_content=False, llm_log_path=None)
+        with (
+            patch("exgentic.integrations.litellm.trace_logger.get_settings", return_value=settings),
+            patch.object(logger, "get_context", return_value=mock_ctx),
+            patch.object(logger, "_resolve_log_path", return_value="/dev/null"),
+            patch("exgentic.integrations.litellm.trace_logger.open", create=True),
+        ):
+            logger.log_success_event(kwargs, response_obj, start, end)
+
+        durations = get_session_llm_timings().pop("ts-sess-001")
+        assert durations == [2.5]

--- a/tests/observers/test_session_timings.py
+++ b/tests/observers/test_session_timings.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+from exgentic.observers.handlers.session_timings import SessionLLMTimings, get_session_llm_timings
+
+
+class TestSessionLLMTimings:
+    def test_record_and_pop_returns_durations_in_order(self):
+        t = SessionLLMTimings()
+        t.record("sess-1", 0.5)
+        t.record("sess-1", 1.25)
+        t.record("sess-1", 0.75)
+        assert t.pop("sess-1") == [0.5, 1.25, 0.75]
+
+    def test_pop_unknown_session_returns_empty_list(self):
+        assert SessionLLMTimings().pop("missing") == []
+
+    def test_pop_clears_durations(self):
+        t = SessionLLMTimings()
+        t.record("sess-1", 0.1)
+        t.pop("sess-1")
+        assert t.pop("sess-1") == []
+
+    def test_record_isolates_sessions(self):
+        t = SessionLLMTimings()
+        t.record("sess-A", 0.1)
+        t.record("sess-B", 0.2)
+        assert t.pop("sess-A") == [0.1]
+        assert t.pop("sess-B") == [0.2]
+
+    def test_negative_duration_silently_ignored(self):
+        t = SessionLLMTimings()
+        t.record("sess-1", -1.0)
+        assert t.pop("sess-1") == []
+
+    def test_empty_session_id_silently_ignored(self):
+        t = SessionLLMTimings()
+        t.record("", 1.0)
+        assert t.pop("") == []
+
+    def test_module_singleton_returns_same_instance(self):
+        assert get_session_llm_timings() is get_session_llm_timings()


### PR DESCRIPTION
## Summary

- Brings OTel emission in line with the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) — adds the missing `gen_ai.agent.*`, `gen_ai.usage.{cache_creation,cache_read,reasoning}.*`, `gen_ai.tool.type`, `gen_ai.request.stream` attributes plus `gen_ai.operation.name = invoke_agent` on the session ROOT.
- Emits `gen_ai.evaluation.result` as a span event on session close — exgentic is an eval framework, so this is mission-aligned and free via `span.add_event`.
- Adds `llm_time` and `llm_call_count` to `SessionResults` so per-call LLM wall time is visible in the result JSON without enabling OTel.
- Updates [docs/observability/semantic-conventions.md](docs/observability/semantic-conventions.md) to describe the full integration; drops two legacy attrs that are byte-for-byte identical to their `gen_ai.*` equivalents (`exgentic.session.id`, `exgentic.session.agent.id`); corrects `gen_ai.agent.id` source from the runtime UUID to `Agent.slug_name`.

## Single source of truth for timing

`SessionLLMTimings` (new, in `observers/handlers/session_timings.py`) holds raw per-call durations populated by the LiteLLM trace logger on every call. Both OTel spans (which derive duration intrinsically from start/end timestamps) and `SessionResults` (which sums durations into rollups) read from the same LiteLLM-provided timestamps — no data duplication.

## Deferred

| Item | Issue |
|---|---|
| Tool attribute renames (`gen_ai.tool.{id,parameters,result}` → `gen_ai.tool.call.*`) and system_instructions split — both breaking | https://github.com/Exgentic/exgentic/issues/217 |
| `gen_ai.client.*` metrics + streaming TTFT | https://github.com/Exgentic/exgentic/issues/218 |

## Relation to #205

Partially addresses [#205 Times accounting](https://github.com/Exgentic/exgentic/issues/205). LLM call timing now in `SessionResults` (works without OTel); session/tool timing already in OTel spans intrinsically. Per-tool/step rollups in `SessionResults` would require additional step-boundary instrumentation — separate follow-up if desired.

## Test plan

- [x] `tests/observers/` — 234 passed
- [x] `tests/integrations/litellm/` — 297 passed (1 unrelated pre-existing proxy failure)
- [ ] Verify `llm_time` populates correctly on a real benchmark run with at least one LLM call
- [ ] Verify `gen_ai.evaluation.result` event appears in OTel spans on session close (with `EXGENTIC_OTEL_ENABLED=true`)
- [ ] Verify `gen_ai.agent.{id,name,description}` attributes appear on the session root span