### PR TITLE
docs: document custom-model pricing registration for non-standard backends

### DIFF
--- a/docs/custom-models.md
+++ b/docs/custom-models.md
@@ -266,6 +266,49 @@ The same `litellm_params_extra` dict reaches every LiteLLM call site Exgentic ow
 
 So the same config works everywhere — pick the agent and benchmark you want, supply the dict once, and you're done.
 
+### Custom-model pricing (cost tracking for non-standard backends)
+
+Exgentic's cost tracking calls `litellm.cost_per_token(model=...)`, which looks the model up in LiteLLM's built-in pricing database. For non-standard backends (your own gateway, an internal deployment, RITS, etc.) the model isn't in that database, so the lookup raises `ValueError("No pricing info found for model '...'")` and your run fails when it tries to record cost.
+
+LiteLLM's native fix is `litellm.register_model()` — register your model once, before constructing the agent, and the lookup succeeds from then on:
+
+```python
+import litellm
+
+litellm.register_model({
+    "hosted_vllm/granite": {
+        "input_cost_per_token": 0.0001,    # USD per token
+        "output_cost_per_token": 0.0002,
+        "litellm_provider": "hosted_vllm",
+    },
+})
+
+# Now any agent using "hosted_vllm/granite" will report accurate cost.
+agent = LiteLLMToolCallingAgentInstance(
+    session_id=...,
+    model="hosted_vllm/granite",
+    litellm_params_extra={"api_base": "https://gateway.example/v1"},
+)
+```
+
+If you don't know the rates, set both to `0`:
+
+```python
+litellm.register_model({
+    "hosted_vllm/granite": {
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
+        "litellm_provider": "hosted_vllm",
+    },
+})
+```
+
+Cost will report as `$0` — your explicit choice, not a silent fallback. The framework deliberately doesn't auto-suppress the pricing-lookup failure: a silent `$0` for an unregistered model would hide a real bill from you.
+
+Reference: [LiteLLM custom pricing docs](https://docs.litellm.ai/docs/proxy/custom_pricing).
+
+> **CLI users**: cost registration currently only works through the Python API (the CLI subprocess has no place to slip in a `register_model` call). If you're driving from the CLI against a non-standard backend, either run via `exgentic.evaluate(...)` from a script that does the registration first, or accept the cost-tracking failure for now. A follow-up will add CLI support if there's demand.
+
 ---
 
 ## Reasoning models


### PR DESCRIPTION
## Summary

Adds a **Custom-model pricing** subsection to [docs/custom-models.md](docs/custom-models.md) explaining how to register pricing for non-standard backends (RITS, custom OpenAI-compatible gateways, internal deployments).

## Why

Cost tracking calls `litellm.cost_per_token(model=...)` which looks the model up in LiteLLM's built-in pricing database. For non-standard backends the model isn't there, so the lookup raises `ValueError("No pricing info found for model '...'")` and the run fails when it tries to record cost. This was the symptom @korenLazar worked around in #208 with a `try/except ValueError` in the agent.

LiteLLM's native fix is `litellm.register_model({...})`. It's a one-line setup — just wasn't documented anywhere in exgentic.

## What's documented

- Why the lookup fails for unknown models.
- How to register pricing via `litellm.register_model()` before constructing the agent.
- The "set both to `0`" pattern when rates are unknown — framed as an explicit user choice, not a silent framework fallback (deliberately not silencing the lookup error: a silent `\$0` for an unregistered model would hide a real bill).
- A direct link to [LiteLLM's custom pricing docs](https://docs.litellm.ai/docs/proxy/custom_pricing).
- A clear note on the current CLI limitation (registration only works through the Python API for now; CLI subprocess support is a possible follow-up if there's demand).

## Why docs-only

Same principle as #214: stop building parallel mechanisms; expose LiteLLM's native ones. `register_model()` already exists, is the documented LiteLLM extension API, and works today. Pure docs is the smallest correct fix.

If CLI users start hitting this, the natural follow-up is a ~15-line auto-register helper that pulls `input_cost_per_token`/`output_cost_per_token` out of `litellm_params_extra` at agent init. Not bundling that here — keep it scoped, ship the docs first.

## Refs

- #213 — original "expose LiteLLM-native config" issue
- #214 — `litellm_params_extra` PR that closed #213 (this is the cost-tracking gap that PR explicitly punted)
- #208 — Koren's RITS PR that surfaced the cost-tracking failure mode

Co-authored-by Koren Lazar (raised the concern) and Itay Etelis.