### PR TITLE
fix(health): treat proxy-wrapped permanent errors as PERMANENT (auth + model-availability)

### DIFF
--- a/src/exgentic/integrations/litellm/health.py
+++ b/src/exgentic/integrations/litellm/health.py
@@ -64,6 +64,32 @@ _TRANSIENT_STATUS_CODES = frozenset({429, 500, 502, 503})
 _REACHABLE_STATUS_CODES = frozenset({400, 422})
 _PERMANENT_STATUS_CODES = frozenset({401, 403, 404})
 
+# Lowercase substrings identifying errors that are permanent for THIS caller
+# regardless of HTTP status. We've seen the LiteLLM proxy wrap auth failures
+# AND model-availability failures inside HTTP 400 responses, which the status
+# code alone classifies as REACHABLE — letting the health check pass on a
+# misconfigured key. Match by substring on the message body to override.
+_PERMANENT_MARKERS = (
+    # Auth
+    "authentication error",
+    "expired_key",
+    "expired key",
+    "invalid_api_key",
+    "invalid api key",
+    "incorrect api key",
+    # Model availability for this key/team
+    "invalid model name",
+    "team not allowed",
+    "model not allowed",
+    "model_not_found",
+    "model_not_available",
+)
+
+
+def _looks_permanent(exc: BaseException) -> bool:
+    msg = (getattr(exc, "message", None) or str(exc) or "").lower()
+    return any(marker in msg for marker in _PERMANENT_MARKERS)
+
 
 class ErrorCategory(Enum):
     """Classification of a litellm error for retry/health-check decisions."""
@@ -86,7 +112,11 @@ def classify_error(exc: BaseException) -> ErrorCategory:
 
     Classification priority:
     1. Python built-in types (TimeoutError, ConnectionError)
-    2. HTTP status code (extracted from exc or exc.original_exception)
+    2. HTTP status code (extracted from exc or exc.original_exception).
+       For REACHABLE statuses (400/422), permanent-marker substrings in the
+       message body override to PERMANENT — LiteLLM proxy wraps auth and
+       model-availability failures in 400 responses that would otherwise
+       silently pass the health check.
     3. litellm exception type name
     """
     # 1. Python built-ins
@@ -109,6 +139,10 @@ def classify_error(exc: BaseException) -> ErrorCategory:
         if status in _PERMANENT_STATUS_CODES:
             return ErrorCategory.PERMANENT
         if status in _REACHABLE_STATUS_CODES:
+            # Refine: a "reachable" status with a permanent-marker in the body
+            # is still permanent (auth, model-not-available, team-blocked).
+            if _looks_permanent(exc) or (original is not None and _looks_permanent(original)):
+                return ErrorCategory.PERMANENT
             return ErrorCategory.REACHABLE
         if status in _TRANSIENT_STATUS_CODES:
             return ErrorCategory.TRANSIENT

--- a/tests/integrations/litellm/test_health.py
+++ b/tests/integrations/litellm/test_health.py
@@ -417,6 +417,66 @@ def test_is_permanent_error_not_permanent():
     assert classify_error(_FakeRateLimitError()) == ErrorCategory.TRANSIENT
 
 
+# Some proxies (LiteLLM proxy) wrap auth and model-availability failures
+# inside HTTP 400 responses. Without the permanent-marker override, these
+# would be classified REACHABLE and the health check would silently pass.
+
+
+class _FakeProxyExpiredKey400Error(Exception):
+    def __init__(self):
+        self.status_code = 400
+        super().__init__(
+            "Error code: 400 - {'error': {'message': 'Authentication Error - "
+            "Expired Key. Key Expiry time 2026-04-28', 'type': 'expired_key'}}"
+        )
+
+
+class _FakeProxyInvalidModel400Error(Exception):
+    def __init__(self):
+        self.status_code = 400
+        super().__init__(
+            "/chat/completions: Invalid model name passed in model=azure/X. "
+            "Call `/v1/models` to view available models for your key."
+        )
+
+
+class _FakeProxyTeamBlocked400Error(Exception):
+    def __init__(self):
+        self.status_code = 400
+        super().__init__("team not allowed to access model.")
+
+
+def test_proxy_expired_key_400_is_permanent():
+    assert classify_error(_FakeProxyExpiredKey400Error()) == ErrorCategory.PERMANENT
+
+
+def test_proxy_invalid_model_400_is_permanent():
+    """Regression: model-not-available wrapped in 400 should not silently pass."""
+    assert classify_error(_FakeProxyInvalidModel400Error()) == ErrorCategory.PERMANENT
+
+
+def test_proxy_team_blocked_400_is_permanent():
+    assert classify_error(_FakeProxyTeamBlocked400Error()) == ErrorCategory.PERMANENT
+
+
+def test_400_without_permanent_marker_still_reachable():
+    """Regression guard: ordinary 400s (e.g. content policy) stay REACHABLE."""
+    assert classify_error(_FakeContentPolicyError()) == ErrorCategory.REACHABLE
+
+
+@pytest.mark.asyncio
+async def test_acheck_fails_fast_on_proxy_invalid_model():
+    """Health check must NOT pass when the proxy returns invalid-model in a 400."""
+    mock = AsyncMock(side_effect=_FakeProxyInvalidModel400Error())
+
+    with patch("litellm.acompletion", mock):
+        with pytest.raises(_FakeProxyInvalidModel400Error):
+            await acheck_model_accessible("m")
+
+    # No retries — fail on first attempt.
+    assert mock.call_count == 1
+
+
 @pytest.mark.asyncio
 async def test_acheck_does_not_retry_auth_error():
     """401 auth errors should fail immediately without retry."""


### PR DESCRIPTION
Supersedes #215, which only handled the auth-marker case.

## Why

Some proxies (notably LiteLLM proxy) wrap permanent-for-this-caller errors inside HTTP 400 responses. \`classify_error\` then maps 400 to \`REACHABLE\` and the health check silently passes. We hit this in production twice in the same workflow:

1. **Expired key**: \`Authentication Error - Expired Key. Key Expiry time 2026-04-28\` → HTTP 400.
2. **Model unavailable for the key's team**: \`/chat/completions: Invalid model name passed in model=azure/X. Call \`/v1/models\` to view available models for your key.\` → HTTP 400. The proxy's team allowlist referenced \`azure/DeepSeek-V3.2\`, but no actual deployment with that exact name was registered on the chat-completions route.

Both cases launched hundreds of doomed sessions. Each ran for 30-60s, hit the same proxy error, and recorded \`status: "error"\` to disk. Process-level monitoring (PID alive, children alive, no log tracebacks) showed everything \"fine\" — the failures were only visible by querying disk after the fact.

## Fix

Add a permanent-marker substring check inside the REACHABLE branch (400/422 statuses only). Markers cover both:

- **Auth**: \`authentication error\`, \`expired_key\`, \`expired key\`, \`invalid_api_key\`, \`invalid api key\`, \`incorrect api key\`
- **Model availability**: \`invalid model name\`, \`team not allowed\`, \`model not allowed\`, \`model_not_found\`, \`model_not_available\`

Ordinary 400s (content policy, schema validation) are unaffected. PERMANENT/TRANSIENT statuses (401/403/404/429/500/502/503) are unaffected. Only 400/422 inspect the body.

## Tests

- Three new \`classify_error\` cases for proxy-wrapped 400s: expired_key, invalid_model_name, team_not_allowed → all PERMANENT.
- Regression guard: ordinary 400 (content policy) stays REACHABLE.
- New \`acheck_model_accessible\` test: health check fails fast on invalid-model 400 without retries.
- All 36 existing tests in \`test_health.py\` pass unchanged.