### PR TITLE
feat(extract): add --scope session and --slim to batch extract

### DIFF
--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -826,6 +826,33 @@ def batch_patch_cmd(
         click.echo(f"Done. {changes} session(s) renamed.")
 
 
+# Bulky/redundant fields to drop when --slim is requested.
+#
+# Run scope: these embed data accessible elsewhere (session_results ==
+# --scope=session output) or are large free-form text/list blobs.
+_SLIM_EXCLUDE_FIELDS_RUN: set[str] = {
+    "session_results",
+    "executed_session_ids",
+    "planned_session_ids",
+    "aggregated_session_ids",
+    "skipped_session_ids",
+    "skipped_session_reasons",
+    "missing_result_files",
+    "accumulated_agent_report",
+    "accumulated_benchmark_report",
+    "benchmark_results",
+}
+
+# Session scope: these are JSON-encoded internal structures (cost breakdowns,
+# benchmark-specific metrics, full error tracebacks). The scalar score/cost/
+# status fields stay. Errors are still surfaced via error_source in the
+# session-level results.json and via the session-level error.log file.
+_SLIM_EXCLUDE_FIELDS_SESSION: set[str] = {
+    "cost_reports",
+    "details",
+}
+
+
 @batch_cmd.command(
     "extract",
     context_settings={"allow_extra_args": True},
@@ -843,25 +870,57 @@ def batch_patch_cmd(
     show_default=True,
     help="CSV output path (use '-' for stdout).",
 )
+@click.option(
+    "--scope",
+    type=click.Choice(["run", "session"]),
+    default="run",
+    show_default=True,
+    help="Granularity: 'run' = one row per config (aggregates), 'session' = one row per task (raw).",
+)
+@click.option(
+    "--slim",
+    is_flag=True,
+    help="Drop bulky/redundant fields. For --scope=run: session_results, *_session_ids, "
+    "accumulated_*_report. For --scope=session: details, cost_reports.",
+)
 @click.pass_context
 def batch_extract_cmd(
     ctx: click.Context,
     config_values: tuple[str, ...],
     output_path: str,
+    scope: str,
+    slim: bool,
 ) -> None:
-    """Extract run results from multiple configs into a single CSV."""
+    """Extract run or per-session results from multiple configs into a single CSV.
+
+    --scope=run    one row per config; emits aggregates from each run's
+                   results.json (default).
+    --scope=session  one row per session; flattens the embedded
+                   session_results list with run-identity columns prepended.
+
+    --slim          drop bulky/redundant fields (only meaningful for --scope=run).
+    """
     config_paths = _expand_config_inputs(config_values, list(ctx.args))
     failures: list[tuple[str, str]] = []
     rows: list[dict[str, Any]] = []
     all_keys: set[str] = set()
-    preferred_keys = [
-        "config_path",
-        "results_path",
-        "run_id",
-    ]
+
+    if scope == "session":
+        preferred_keys = [
+            "config_path",
+            "run_id",
+            "session_id",
+            "task_id",
+        ]
+    else:
+        preferred_keys = [
+            "config_path",
+            "results_path",
+            "run_id",
+        ]
 
     for config_path in config_paths:
-        results_path = "-"
+        results_path: Any = "-"
         run_id = "-"
         try:
             cfg = _load_run_like_config(config_path)
@@ -874,12 +933,35 @@ def batch_extract_cmd(
                 raise click.ClickException(f"Results JSON is not an object: {results_path}")
             if "benchmark_score" not in payload:
                 raise click.ClickException(f"Missing benchmark_score in results: {results_path}")
-            row: dict[str, Any] = {
+            if scope == "session":
+                session_results = payload.get("session_results")
+                if not isinstance(session_results, list):
+                    raise click.ClickException(f"No session_results list in: {results_path}")
+                for s in session_results:
+                    if not isinstance(s, dict):
+                        continue
+                    row: dict[str, Any] = {
+                        "config_path": config_path,
+                        "run_id": run_id,
+                    }
+                    for key, value in s.items():
+                        if slim and key in _SLIM_EXCLUDE_FIELDS_SESSION:
+                            continue
+                        if key in row:
+                            row[f"session_{key}"] = value
+                        else:
+                            row[key] = value
+                    rows.append(row)
+                    all_keys.update(row.keys())
+                continue
+            row = {
                 "config_path": config_path,
                 "results_path": str(results_path),
                 "run_id": run_id,
             }
             for key, value in payload.items():
+                if slim and key in _SLIM_EXCLUDE_FIELDS_RUN:
+                    continue
                 if key in row:
                     row[f"results_{key}"] = value
                 else:
@@ -888,12 +970,13 @@ def batch_extract_cmd(
             failures.append((config_path, str(exc)))
             row = {
                 "config_path": config_path,
-                "results_path": results_path,
+                "results_path": str(results_path),
                 "run_id": run_id,
                 "error": _format_batch_error(exc),
             }
-        rows.append(row)
-        all_keys.update(row.keys())
+        if scope == "run":
+            rows.append(row)
+            all_keys.update(row.keys())
 
     ordered_keys = [k for k in preferred_keys if k in all_keys]
     ordered_keys.extend(sorted(k for k in all_keys if k not in ordered_keys))

--- a/src/exgentic/interfaces/cli/commands/batch.py
+++ b/src/exgentic/interfaces/cli/commands/batch.py
@@ -826,10 +826,8 @@ def batch_patch_cmd(
         click.echo(f"Done. {changes} session(s) renamed.")
 
 
-# Bulky/redundant fields to drop when --slim is requested.
-#
-# Run scope: these embed data accessible elsewhere (session_results ==
-# --scope=session output) or are large free-form text/list blobs.
+# Fields dropped under --slim. Run-scope drops blobs that duplicate
+# --scope=session output; session-scope drops the two JSON-encoded sub-objects.
 _SLIM_EXCLUDE_FIELDS_RUN: set[str] = {
     "session_results",
     "executed_session_ids",
@@ -842,15 +840,7 @@ _SLIM_EXCLUDE_FIELDS_RUN: set[str] = {
     "accumulated_benchmark_report",
     "benchmark_results",
 }
-
-# Session scope: these are JSON-encoded internal structures (cost breakdowns,
-# benchmark-specific metrics, full error tracebacks). The scalar score/cost/
-# status fields stay. Errors are still surfaced via error_source in the
-# session-level results.json and via the session-level error.log file.
-_SLIM_EXCLUDE_FIELDS_SESSION: set[str] = {
-    "cost_reports",
-    "details",
-}
+_SLIM_EXCLUDE_FIELDS_SESSION: set[str] = {"cost_reports", "details"}
 
 
 @batch_cmd.command(
@@ -891,15 +881,7 @@ def batch_extract_cmd(
     scope: str,
     slim: bool,
 ) -> None:
-    """Extract run or per-session results from multiple configs into a single CSV.
-
-    --scope=run    one row per config; emits aggregates from each run's
-                   results.json (default).
-    --scope=session  one row per session; flattens the embedded
-                   session_results list with run-identity columns prepended.
-
-    --slim          drop bulky/redundant fields (only meaningful for --scope=run).
-    """
+    """Extract run-level or per-session results into a single CSV."""
     config_paths = _expand_config_inputs(config_values, list(ctx.args))
     failures: list[tuple[str, str]] = []
     rows: list[dict[str, Any]] = []

--- a/tests/api/test_cli_batch.py
+++ b/tests/api/test_cli_batch.py
@@ -130,6 +130,147 @@ def test_batch_extract_writes_csv(tmp_path):
     assert rows[0]["benchmark_score"] == "1.0"
 
 
+def test_batch_extract_slim_drops_bulky_fields(tmp_path):
+    """--slim should drop session_results, *_session_ids, accumulated_*_report, etc."""
+    runner = CliRunner()
+    config_path = _write_config(tmp_path / "extract-slim.json", run_id="run-slim")
+
+    results_path = tmp_path / "run-slim" / "results.json"
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "benchmark_name": "Test Benchmark",
+        "agent_name": "Test Agent",
+        "benchmark_score": 0.7,
+        "total_sessions": 2,
+        # Bulky fields:
+        "session_results": [{"session_id": "s1", "score": 0.7}, {"session_id": "s2", "score": 0.7}],
+        "executed_session_ids": ["s1", "s2"],
+        "planned_session_ids": ["s1", "s2"],
+        "aggregated_session_ids": ["s1", "s2"],
+        "accumulated_agent_report": "x" * 5000,
+        "accumulated_benchmark_report": "y" * 5000,
+    }
+    results_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    output_csv = tmp_path / "slim.csv"
+    result = runner.invoke(
+        cli,
+        ["batch", "extract", "--config", config_path, "--output", str(output_csv), "--slim"],
+    )
+    assert result.exit_code == 0, result.output
+    with open(output_csv, encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert len(rows) == 1
+    # Aggregates retained:
+    assert rows[0]["benchmark_score"] == "0.7"
+    assert rows[0]["benchmark_name"] == "Test Benchmark"
+    # Bulky fields dropped:
+    for dropped in (
+        "session_results",
+        "executed_session_ids",
+        "planned_session_ids",
+        "aggregated_session_ids",
+        "accumulated_agent_report",
+        "accumulated_benchmark_report",
+    ):
+        assert dropped not in reader.fieldnames, f"{dropped} should be dropped under --slim"
+
+
+def test_batch_extract_scope_session_emits_one_row_per_task(tmp_path):
+    """--scope=session flattens session_results with run-identity columns."""
+    runner = CliRunner()
+    config_path = _write_config(tmp_path / "extract-sess.json", run_id="run-sess")
+
+    results_path = tmp_path / "run-sess" / "results.json"
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    session_results = [
+        {"session_id": "s1", "task_id": "task-1", "score": 1.0, "success": True, "status": "success"},
+        {"session_id": "s2", "task_id": "task-2", "score": 0.0, "success": False, "status": "unsuccessful"},
+        {"session_id": "s3", "task_id": "task-3", "score": 0.0, "success": False, "status": "error"},
+    ]
+    payload = {
+        "benchmark_name": "Test Benchmark",
+        "benchmark_score": 0.33,
+        "total_sessions": 3,
+        "session_results": session_results,
+    }
+    results_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    output_csv = tmp_path / "sessions.csv"
+    result = runner.invoke(
+        cli,
+        ["batch", "extract", "--config", config_path, "--output", str(output_csv), "--scope", "session"],
+    )
+    assert result.exit_code == 0, result.output
+    with open(output_csv, encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    statuses = {r["status"] for r in rows}
+    assert statuses == {"success", "unsuccessful", "error"}
+    # Run-identity columns present on every row:
+    for r in rows:
+        assert r["run_id"] == "run-sess"
+        assert r["config_path"].endswith("extract-sess.json")
+    # Per-session fields present:
+    task_ids = sorted(r["task_id"] for r in rows)
+    assert task_ids == ["task-1", "task-2", "task-3"]
+
+
+def test_batch_extract_scope_session_slim_drops_json_blobs(tmp_path):
+    """--scope=session --slim drops `details` and `cost_reports`."""
+    runner = CliRunner()
+    config_path = _write_config(tmp_path / "extract-sess-slim.json", run_id="run-sess-slim")
+
+    results_path = tmp_path / "run-sess-slim" / "results.json"
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "benchmark_name": "Test Benchmark",
+        "benchmark_score": 1.0,
+        "total_sessions": 1,
+        "session_results": [
+            {
+                "session_id": "s1",
+                "task_id": "task-1",
+                "score": 1.0,
+                "success": True,
+                "status": "success",
+                "agent_cost": 0.05,
+                "details": {"session_metadata": {"large": "x" * 5000}},
+                "cost_reports": {"agent": {"total_cost": 0.05, "by_step": [{"i": 1}] * 100}},
+            }
+        ],
+    }
+    results_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    output_csv = tmp_path / "sessions-slim.csv"
+    result = runner.invoke(
+        cli,
+        [
+            "batch",
+            "extract",
+            "--config",
+            config_path,
+            "--output",
+            str(output_csv),
+            "--scope",
+            "session",
+            "--slim",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    with open(output_csv, encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        fields = reader.fieldnames or []
+        rows = list(reader)
+    assert len(rows) == 1
+    assert rows[0]["score"] == "1.0"
+    assert "details" not in fields
+    assert "cost_reports" not in fields
+
+
 def _write_session_results(run_root, session_id: str, payload: dict) -> None:
     sdir = run_root / "sessions" / session_id
     sdir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Why

\`batch extract\` today emits run-level rows with all fields including JSON-encoded blobs (\`session_results\`, \`accumulated_*_report\`, \`*_session_ids\`) — the CSV is ~70 MB on a moderate run tree and not useful for downstream statistical analysis. There's also no built-in way to get per-session results in tabular form; users have been walking session dirs with ad-hoc scripts.

## What

Two new options on \`batch extract\`:

| Flag | Default | Meaning |
|---|---|---|
| \`--scope run\|session\` | \`run\` | \`run\` = existing one-row-per-config behavior; \`session\` = one row per task, flattens each run's embedded \`session_results\` |
| \`--slim\` | off | Drop bulky/redundant fields. For run scope: \`session_results\`, \`*_session_ids\`, \`accumulated_*_report\`, etc. For session scope: \`details\`, \`cost_reports\`. |

## Impact

Same ~150-config / 12k-session tree:

| | CSV size |
|---|---:|
| \`--scope run\` | 70 MB |
| \`--scope run --slim\` | **82 KB** |
| \`--scope session\` | 70 MB |
| \`--scope session --slim\` | **2.4 MB** |

For a repo-tracked snapshot or a HuggingFace dataset:

\`\`\`bash
exgentic batch extract --config "experiments/*/*/*/config.json" \\
  --scope run --slim --output runs.csv

exgentic batch extract --config "experiments/*/*/*/config.json" \\
  --scope session --slim --output sessions.csv
\`\`\`

## Tests

- \`test_batch_extract_slim_drops_bulky_fields\`
- \`test_batch_extract_scope_session_emits_one_row_per_task\`
- \`test_batch_extract_scope_session_slim_drops_json_blobs\`

All 6 existing tests in \`test_cli_batch.py\` pass unchanged.

## Compatibility

Default behavior (no flags) is byte-identical to before. \`--scope\` defaults to \`run\` and \`--slim\` defaults to off.