### PR TITLE
feat(browsecompplus): expose eval_model_id on the benchmark config

### DIFF
--- a/src/exgentic/benchmarks/browsecompplus/browsecomp_benchmark.py
+++ b/src/exgentic/benchmarks/browsecompplus/browsecomp_benchmark.py
@@ -594,7 +594,7 @@ class BrowseCompPlusBenchmark(Benchmark, BaseModel):
     inference_model: str = "N/A"
 
     # Judge model used by the evaluator to grade agent responses.
-    eval_model: str = "openai/Azure/gpt-4.1"
+    judge_model: str = "openai/Azure/gpt-4.1"
 
     # searcher params
     searcher_type: str = "faiss"  # "bm25" or "faiss"
@@ -709,7 +709,7 @@ class BrowseCompPlusBenchmark(Benchmark, BaseModel):
         kwargs: dict[str, Any] = {
             "searcher_params": self._searcher_params(),
             "assets_dir": self._assets_dir,
-            "eval_model_id": self.eval_model,
+            "eval_model_id": self.judge_model,
             "max_interactions": self.max_interactions,
         }
         if self.retriever_runner:

--- a/src/exgentic/benchmarks/browsecompplus/browsecomp_benchmark.py
+++ b/src/exgentic/benchmarks/browsecompplus/browsecomp_benchmark.py
@@ -593,6 +593,9 @@ class BrowseCompPlusBenchmark(Benchmark, BaseModel):
     # Agent inference params (for logging)
     inference_model: str = "N/A"
 
+    # Judge model used by the evaluator to grade agent responses.
+    eval_model_id: str = "openai/Azure/gpt-4.1"
+
     # searcher params
     searcher_type: str = "faiss"  # "bm25" or "faiss"
     searcher_model_name: str = "Qwen/Qwen3-Embedding-8B"  # Used for faiss only
@@ -706,6 +709,7 @@ class BrowseCompPlusBenchmark(Benchmark, BaseModel):
         kwargs: dict[str, Any] = {
             "searcher_params": self._searcher_params(),
             "assets_dir": self._assets_dir,
+            "eval_model_id": self.eval_model_id,
             "max_interactions": self.max_interactions,
         }
         if self.retriever_runner:

--- a/src/exgentic/benchmarks/browsecompplus/browsecomp_benchmark.py
+++ b/src/exgentic/benchmarks/browsecompplus/browsecomp_benchmark.py
@@ -594,7 +594,7 @@ class BrowseCompPlusBenchmark(Benchmark, BaseModel):
     inference_model: str = "N/A"
 
     # Judge model used by the evaluator to grade agent responses.
-    eval_model_id: str = "openai/Azure/gpt-4.1"
+    eval_model: str = "openai/Azure/gpt-4.1"
 
     # searcher params
     searcher_type: str = "faiss"  # "bm25" or "faiss"
@@ -709,7 +709,7 @@ class BrowseCompPlusBenchmark(Benchmark, BaseModel):
         kwargs: dict[str, Any] = {
             "searcher_params": self._searcher_params(),
             "assets_dir": self._assets_dir,
-            "eval_model_id": self.eval_model_id,
+            "eval_model_id": self.eval_model,
             "max_interactions": self.max_interactions,
         }
         if self.retriever_runner:


### PR DESCRIPTION
## Summary
- The BrowseComp-Plus judge model was hard-coded to `openai/Azure/gpt-4.1`: `BrowseCompPlusSession.__init__` had it as a default, but `BrowseCompPlusBenchmark._get_session_kwargs()` never forwarded a value, so the default always won.
- Surface `eval_model_id` as a top-level field on `BrowseCompPlusBenchmark` (default unchanged) and forward it through `_get_session_kwargs()`, mirroring how `TAU2Benchmark.user_simulator_model` is exposed.

Closes #225

## Test plan
- [ ] `exgentic batch evaluate` on BrowseComp-Plus with the default config still grades against `openai/Azure/gpt-4.1`.
- [ ] Setting `eval_model_id` in the benchmark config routes the judge call through the chosen model (e.g. `BrowseCompEvaluatorOpenai` is constructed with it).