### PR TITLE
Allow custom model pricing without modifying source code

### DIFF
--- a/docs/custom-models.md
+++ b/docs/custom-models.md
@@ -270,7 +270,44 @@ So the same config works everywhere — pick the agent and benchmark you want, s
 
 Exgentic's cost tracking calls `litellm.cost_per_token(model=...)`, which looks the model up in LiteLLM's built-in pricing database. For non-standard backends (your own gateway, an internal deployment, RITS, etc.) the model isn't in that database, so the lookup raises `ValueError("No pricing info found for model '...'")` and your run fails when it tries to record cost.
 
-LiteLLM's native fix is `litellm.register_model()` — register your model once, before constructing the agent, and the lookup succeeds from then on:
+#### Option 1: Config file (recommended for CLI users)
+
+Create a `~/.exgentic/pricing.json` file with your custom model pricing:
+
+```json
+{
+  "my-custom-model": {
+    "input_cost_per_token": 0.0001,
+    "output_cost_per_token": 0.0002,
+    "litellm_provider": "openai"
+  },
+  "another-model": {
+    "input_cost_per_token": 0.00005,
+    "output_cost_per_token": 0.00015,
+    "litellm_provider": "openai"
+  }
+}
+```
+
+Exgentic automatically loads this file on startup and registers all models with LiteLLM. This works for both CLI and Python API usage.
+
+If you don't know the rates, set both to `0`:
+
+```json
+{
+  "my-custom-model": {
+    "input_cost_per_token": 0,
+    "output_cost_per_token": 0,
+    "litellm_provider": "openai"
+  }
+}
+```
+
+Cost will report as `$0` — your explicit choice, not a silent fallback.
+
+#### Option 2: Python API with `litellm.register_model()`
+
+For Python API users, you can also register models programmatically using LiteLLM's native API — register your model once, before constructing the agent, and the lookup succeeds from then on:
 
 ```python
 import litellm
@@ -306,8 +343,6 @@ litellm.register_model({
 Cost will report as `$0` — your explicit choice, not a silent fallback. The framework deliberately doesn't auto-suppress the pricing-lookup failure: a silent `$0` for an unregistered model would hide a real bill from you.
 
 Reference: [LiteLLM custom pricing docs](https://docs.litellm.ai/docs/proxy/custom_pricing).
-
-> **CLI users**: cost registration currently only works through the Python API (the CLI subprocess has no place to slip in a `register_model` call). If you're driving from the CLI against a non-standard backend, either run via `exgentic.evaluate(...)` from a script that does the registration first, or accept the cost-tracking failure for now. A follow-up will add CLI support if there's demand.
 
 ---
 

--- a/src/exgentic/utils/cost.py
+++ b/src/exgentic/utils/cost.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
+import json
+import logging
+from pathlib import Path
 from typing import Any, Optional, Self, Sequence, TypeVar
 
 from pydantic import BaseModel, computed_field
+
+_log = logging.getLogger(__name__)
 
 name_map = {
     "claude-3-5-haiku": "claude-3-5-haiku-20241022",
@@ -11,6 +16,59 @@ name_map = {
     "DeepSeek-V3": "deepseek/deepseek-v3",
     "Kimi-K2.5": "moonshot/kimi-k2.5",
 }
+
+_pricing_loaded = False
+
+
+def _load_custom_pricing() -> None:
+    """Load custom model pricing from ~/.exgentic/pricing.json if it exists.
+
+    The pricing file should be a JSON object mapping model names to pricing info:
+    {
+        "my-custom-model": {
+            "input_cost_per_token": 0.0001,
+            "output_cost_per_token": 0.0002,
+            "litellm_provider": "openai"
+        }
+    }
+
+    This allows users to register pricing for custom models without modifying source code.
+    """
+    global _pricing_loaded
+    if _pricing_loaded:
+        return
+
+    _pricing_loaded = True
+
+    pricing_file = Path.home() / ".exgentic" / "pricing.json"
+    if not pricing_file.exists():
+        return
+
+    try:
+        import litellm
+
+        with open(pricing_file) as f:
+            custom_pricing = json.load(f)
+
+        if not isinstance(custom_pricing, dict):
+            _log.warning("Custom pricing file %s is not a JSON object, ignoring", pricing_file)
+            return
+
+        for model_name, pricing_info in custom_pricing.items():
+            if not isinstance(pricing_info, dict):
+                _log.warning("Pricing info for model %s is not a dict, skipping", model_name)
+                continue
+
+            try:
+                litellm.register_model({model_name: pricing_info})
+                _log.debug("Registered custom pricing for model: %s", model_name)
+            except Exception as e:
+                _log.warning("Failed to register pricing for model %s: %s", model_name, e)
+
+    except json.JSONDecodeError as e:
+        _log.warning("Failed to parse custom pricing file %s: %s", pricing_file, e)
+    except Exception as e:
+        _log.warning("Failed to load custom pricing from %s: %s", pricing_file, e)
 
 
 class TokensCost(BaseModel):
@@ -30,6 +88,8 @@ def litellm_cost_per_token(model_name: str):
 
 
 def litellm_tokens_cost(input_tokens: int, output_tokens: int, model_name: str) -> TokensCost:
+    _load_custom_pricing()
+
     for src, dst in name_map.items():
         model_name = model_name.replace(src, dst)
 
@@ -49,7 +109,8 @@ def litellm_tokens_cost(input_tokens: int, output_tokens: int, model_name: str) 
             continue
     raise ValueError(
         f"No pricing info found for model '{model_name}'. "
-        f"Add it to the name_map in exgentic/utils/cost.py or check litellm model support."
+        f"Add it to ~/.exgentic/pricing.json, the name_map in exgentic/utils/cost.py, "
+        f"or check litellm model support."
     )
 
 

--- a/tests/utils/test_cost_custom_pricing.py
+++ b/tests/utils/test_cost_custom_pricing.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make package importable
+sys.path.insert(0, os.path.abspath("src"))
+from exgentic.utils.cost import _load_custom_pricing, litellm_tokens_cost  # noqa: E402
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    """Create a temporary home directory for testing."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def reset_pricing_loaded():
+    """Reset the _pricing_loaded flag before each test."""
+    import exgentic.utils.cost as cost_module
+
+    cost_module._pricing_loaded = False
+    yield
+    cost_module._pricing_loaded = False
+
+
+def test_load_custom_pricing_file_not_exists(temp_home):
+    """Test that loading works when pricing file doesn't exist."""
+    _load_custom_pricing()
+    # Should not raise any errors
+
+
+def test_load_custom_pricing_valid_file(temp_home):
+    """Test loading a valid custom pricing file."""
+    pricing_dir = temp_home / ".exgentic"
+    pricing_dir.mkdir()
+    pricing_file = pricing_dir / "pricing.json"
+
+    custom_pricing = {
+        "my-custom-model": {
+            "input_cost_per_token": 0.0001,
+            "output_cost_per_token": 0.0002,
+            "litellm_provider": "openai",
+        }
+    }
+
+    pricing_file.write_text(json.dumps(custom_pricing))
+
+    # Mock litellm.register_model to verify it's called
+    with patch("litellm.register_model") as mock_register:
+        _load_custom_pricing()
+        mock_register.assert_called_once_with(custom_pricing)
+
+
+def test_load_custom_pricing_invalid_json(temp_home, caplog):
+    """Test handling of invalid JSON in pricing file."""
+    pricing_dir = temp_home / ".exgentic"
+    pricing_dir.mkdir()
+    pricing_file = pricing_dir / "pricing.json"
+
+    pricing_file.write_text("{ invalid json }")
+
+    _load_custom_pricing()
+    assert "Failed to parse custom pricing file" in caplog.text
+
+
+def test_load_custom_pricing_not_dict(temp_home, caplog):
+    """Test handling when pricing file is not a JSON object."""
+    pricing_dir = temp_home / ".exgentic"
+    pricing_dir.mkdir()
+    pricing_file = pricing_dir / "pricing.json"
+
+    pricing_file.write_text(json.dumps(["not", "a", "dict"]))
+
+    _load_custom_pricing()
+    assert "is not a JSON object" in caplog.text
+
+
+def test_load_custom_pricing_invalid_model_entry(temp_home, caplog):
+    """Test handling when a model entry is not a dict."""
+    pricing_dir = temp_home / ".exgentic"
+    pricing_dir.mkdir()
+    pricing_file = pricing_dir / "pricing.json"
+
+    custom_pricing = {
+        "valid-model": {
+            "input_cost_per_token": 0.0001,
+            "output_cost_per_token": 0.0002,
+        },
+        "invalid-model": "not a dict",
+    }
+
+    pricing_file.write_text(json.dumps(custom_pricing))
+
+    with patch("litellm.register_model") as mock_register:
+        _load_custom_pricing()
+        # Should only register the valid model
+        mock_register.assert_called_once()
+        assert "invalid-model" in caplog.text
+        assert "is not a dict" in caplog.text
+
+
+def test_load_custom_pricing_called_once():
+    """Test that custom pricing is only loaded once."""
+    with patch("exgentic.utils.cost.Path.home") as mock_home:
+        mock_home.return_value = Path(tempfile.mkdtemp())
+        pricing_dir = mock_home.return_value / ".exgentic"
+        pricing_dir.mkdir()
+        pricing_file = pricing_dir / "pricing.json"
+        pricing_file.write_text(json.dumps({}))
+
+        with patch("litellm.register_model") as mock_register:
+            _load_custom_pricing()
+            _load_custom_pricing()
+            _load_custom_pricing()
+            # Should only be called once despite multiple invocations
+            assert mock_register.call_count <= 1
+
+
+def test_litellm_tokens_cost_loads_custom_pricing(temp_home):
+    """Test that litellm_tokens_cost calls _load_custom_pricing."""
+    pricing_dir = temp_home / ".exgentic"
+    pricing_dir.mkdir()
+    pricing_file = pricing_dir / "pricing.json"
+
+    # Create a custom model with known pricing
+    custom_pricing = {
+        "test-custom-model": {
+            "input_cost_per_token": 0.0001,
+            "output_cost_per_token": 0.0002,
+            "litellm_provider": "openai",
+        }
+    }
+
+    pricing_file.write_text(json.dumps(custom_pricing))
+
+    # This should load custom pricing and then try to get cost
+    # It will fail because litellm won't actually have the model registered in test,
+    # but we can verify the loading was attempted
+    with patch("exgentic.utils.cost._load_custom_pricing") as mock_load:
+        try:
+            litellm_tokens_cost(100, 100, "test-custom-model")
+        except ValueError:
+            pass  # Expected to fail in test environment
+        mock_load.assert_called_once()
+
+
+def test_error_message_mentions_pricing_json():
+    """Test that the error message mentions the pricing.json file."""
+    with pytest.raises(ValueError) as exc_info:
+        litellm_tokens_cost(100, 100, "totally-nonexistent-model-xyz")
+
+    error_message = str(exc_info.value)
+    assert "~/.exgentic/pricing.json" in error_message
+    assert "name_map" in error_message


### PR DESCRIPTION
Closes #106

## Summary
Users can now configure custom model pricing without modifying source code by creating a `~/.exgentic/pricing.json` file. This solves the problem where every new model required a code change to the `name_map` in `exgentic/utils/cost.py`.

The implementation automatically loads the pricing file on first cost lookup and registers all models with LiteLLM's `register_model()` API. This works seamlessly for both CLI and Python API usage.

## Changes
- **Added `_load_custom_pricing()` function** in `src/exgentic/utils/cost.py` that:
  - Reads `~/.exgentic/pricing.json` if it exists
  - Validates the JSON structure
  - Registers each model with `litellm.register_model()`
  - Handles errors gracefully with appropriate logging
  - Uses a global flag to ensure loading happens only once
- **Updated error message** to mention the new `~/.exgentic/pricing.json` config file as the first option
- **Added comprehensive tests** in `tests/utils/test_cost_custom_pricing.py` covering:
  - Valid pricing file loading
  - Invalid JSON handling
  - Invalid structure handling
  - Single-load guarantee
  - Integration with `litellm_tokens_cost()`
  - Error message verification
- **Updated documentation** in `docs/custom-models.md`:
  - Added "Option 1: Config file" section with examples
  - Kept existing "Option 2: Python API" section
  - Removed outdated note about CLI limitations

## Testing
All tests pass:
- 8 new tests for custom pricing functionality
- All existing cost tests continue to pass
- Pre-commit hooks pass (ruff, codespell, SPDX headers, etc.)

## Example Usage

Create `~/.exgentic/pricing.json`:
```json
{
  "my-custom-model": {
    "input_cost_per_token": 0.0001,
    "output_cost_per_token": 0.0002,
    "litellm_provider": "openai"
  }
}
```

Then use the model normally:
```bash
exgentic evaluate --benchmark gsm8k --agent tool_calling --model my-custom-model
```

Cost tracking will work automatically without any code changes.