### PR TITLE
litellm/trace_logger: normalize tool definitions + input messages to OTel spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ Exgentic is a universal evaluation framework that enables standardized testing o
 3. **Researchers & Component Developers** - Test agentic components (memory, context compression, planning) across different agents and domains.
 4. **Benchmark Builders** - Evaluate your benchmark across multiple agents to ensure meaningful differentiation.
 
+## Resources
+
+| | |
+|---|---|
+| **Leaderboard** | [exgentic.ai](https://www.exgentic.ai) |
+| **Results Dataset** | [open-agent-leaderboard/results](https://huggingface.co/datasets/open-agent-leaderboard/results) |
+| **Leaderboard Space** | [open-agent-leaderboard/leaderboard](https://huggingface.co/spaces/open-agent-leaderboard/leaderboard) |
+| **Paper** | [arXiv:2602.22953](https://arxiv.org/abs/2602.22953) |
+| **Submit Results** | Open a PR on the [results dataset](https://huggingface.co/datasets/open-agent-leaderboard/results) |
+
 ---
 
 ## Quick Start

--- a/src/exgentic/integrations/litellm/trace_logger.py
+++ b/src/exgentic/integrations/litellm/trace_logger.py
@@ -67,157 +67,91 @@ def _set_json_attr(span, key: str, value: Any) -> None:
             span.set_attribute(key, serialized)
 
 
-# ---------------------------------------------------------------------------
-# Spec-shape normalization for content attributes
-# ---------------------------------------------------------------------------
-# `gen_ai.tool.definitions`, `gen_ai.input.messages`, and
-# `gen_ai.output.messages` each have a canonical OTel GenAI shape. LiteLLM
-# hands us whatever the underlying provider used (OpenAI native, Anthropic
-# native, …), so we have to normalize before serializing.
+# OTel GenAI content attributes have canonical shapes. LiteLLM hands us
+# the raw provider format (OpenAI envelope / Anthropic native), so we
+# normalize before serializing.
 
 
 def _normalize_tool_definitions(tools: Any) -> list[dict] | Any:
-    """Normalize each entry to the OTel Tool Definitions JSON Schema shape.
+    """Tool entries → flat `{type:"function", name, description, parameters}`.
 
-    Target shape: `{type, name, description, parameters}`.
-
-    OpenAI native      `{type:"function", function:{name, description, parameters}}`
-    Anthropic native   `{name, description, input_schema}`                     (no type)
-    Spec target        `{type:"function", name, description, parameters}`
+    Handles OpenAI envelope `{type, function:{...}}` and Anthropic native
+    `{name, description, input_schema}` (which has no type).
     """
     if not isinstance(tools, list):
         return tools
-    out: list[dict] = []
+    out = []
     for t in tools:
         if not isinstance(t, dict):
-            out.append(t)
-            continue
-        d: dict[str, Any] = {}
-        ttype = t.get("type")
-        d["type"] = ttype if isinstance(ttype, str) and ttype else "function"
-        # OpenAI envelope: pull body out of `function: {...}`.
-        if "function" in t and isinstance(t["function"], dict):
-            inner = t["function"]
-            for k in ("name", "description", "parameters"):
-                if k in inner:
-                    d[k] = inner[k]
-            for k, v in inner.items():
-                d.setdefault(k, v)
-        # Flat shape (Anthropic / spec): copy direct keys.
-        for k in ("name", "description", "parameters"):
-            if k in t and k not in d:
-                d[k] = t[k]
-        # Anthropic uses `input_schema`; spec uses `parameters`.
-        if "input_schema" in t and "parameters" not in d:
-            d["parameters"] = t["input_schema"]
+            out.append(t); continue
+        # OpenAI envelope → unwrap `function: {...}`.
+        if isinstance(t.get("function"), dict):
+            d = {"type": t.get("type") or "function", **t["function"]}
+        else:
+            d = {**t}
+            d.setdefault("type", "function")
+        # Anthropic `input_schema` → spec `parameters`.
+        if "input_schema" in d and "parameters" not in d:
+            d["parameters"] = d.pop("input_schema")
         out.append(d)
     return out
 
 
+def _block_to_part(blk: dict) -> dict:
+    """One Anthropic content block → one OTel part."""
+    t = blk.get("type")
+    if t == "tool_use":
+        return {"type": "tool_call", "id": blk.get("id", ""),
+                "name": blk.get("name", ""), "arguments": blk.get("input", {})}
+    if t == "tool_result":
+        # Per v2.10 contract: `result` is always a JSON-stringified blocks list.
+        inner = blk.get("content", "")
+        blocks = inner if isinstance(inner, list) else [{"type": "text", "text": str(inner) if inner else ""}]
+        return {"type": "tool_call_response", "id": blk.get("tool_use_id", ""),
+                "result": json.dumps(blocks, ensure_ascii=False, default=str)}
+    if t == "thinking":
+        p = {"type": "thinking", "thinking": blk.get("thinking", "")}
+        if blk.get("signature") is not None:
+            p["signature"] = blk["signature"]
+        return p
+    if t == "image":
+        return {"type": "text", "content": "[image content]"}
+    return {"type": "text", "content": blk.get("text", "") or str(blk)}
+
+
 def _convert_input_messages_to_parts(messages: Any) -> list[dict] | Any:
-    """Convert OpenAI / Anthropic native messages to the OTel parts shape.
+    """Messages → OTel `[{role, parts: [{type, ...}]}]` shape.
 
-    Target shape: `[{role, parts: [{type, ...}]}]`.
-
-    Handles:
-      - role=user/assistant with string content → single text part
-      - role=user with list content (Anthropic blocks):
-            type=text       → text part
-            type=tool_use   → tool_call part
-            type=tool_result → tool_call_response part (multi-block content
-                              preserved as JSON-stringified blocks list per
-                              the v2.10 contract — `json.loads(result)` is
-                              always a list of {type, ...} blocks)
-            type=image      → text placeholder (no image part type in OTel yet)
-      - role=assistant with tool_calls → tool_call parts
-      - role=tool (OpenAI) → tool_call_response part
+    Handles OpenAI native (string content, `tool_calls`, `role=tool`) and
+    Anthropic native (typed content blocks: text/tool_use/tool_result/thinking).
     """
     if not isinstance(messages, list):
         return messages
-    out: list[dict] = []
+    out = []
     for m in messages:
-        if not isinstance(m, dict):
-            continue
+        if not isinstance(m, dict): continue
         role = m.get("role", "")
         content = m.get("content", "")
-        parts: list[dict] = []
-        # OpenAI `tool` role messages: the `content` IS the tool result, not
-        # natural-language text. Skip the text-part path; the tool_call_response
-        # handler below will produce the right part shape.
+        parts = []
         if role == "tool":
-            pass
+            # OpenAI tool message: content is the result itself.
+            c = content if isinstance(content, str) else json.dumps(content, default=str)
+            parts.append({"type": "tool_call_response", "id": m.get("tool_call_id", ""),
+                          "result": json.dumps([{"type": "text", "text": c}], ensure_ascii=False)})
         elif isinstance(content, str):
             if content:
                 parts.append({"type": "text", "content": content})
         elif isinstance(content, list):
-            for blk in content:
-                if not isinstance(blk, dict):
-                    continue
-                btype = blk.get("type")
-                if btype == "text":
-                    parts.append({"type": "text", "content": blk.get("text", "")})
-                elif btype == "tool_use":
-                    parts.append(
-                        {
-                            "type": "tool_call",
-                            "id": blk.get("id", ""),
-                            "name": blk.get("name", ""),
-                            "arguments": blk.get("input", {}),
-                        }
-                    )
-                elif btype == "tool_result":
-                    inner = blk.get("content", "")
-                    # Per v2.10 contract: `result` is always a
-                    # JSON-stringified blocks list, regardless of content.
-                    if isinstance(inner, list):
-                        blocks = inner
-                    elif isinstance(inner, str):
-                        blocks = [{"type": "text", "text": inner}]
-                    else:
-                        blocks = [{"type": "text", "text": str(inner)}]
-                    parts.append(
-                        {
-                            "type": "tool_call_response",
-                            "id": blk.get("tool_use_id", ""),
-                            "result": json.dumps(blocks, ensure_ascii=False, default=str),
-                        }
-                    )
-                elif btype == "thinking":
-                    p = {"type": "thinking", "thinking": blk.get("thinking", "")}
-                    if blk.get("signature") is not None:
-                        p["signature"] = blk["signature"]
-                    parts.append(p)
-                elif btype == "image":
-                    parts.append({"type": "text", "content": "[image content]"})
-                else:
-                    parts.append({"type": "text", "content": blk.get("text", "") or str(blk)})
-        # Assistant tool_calls (OpenAI native)
-        if role == "assistant" and m.get("tool_calls"):
-            for tc in m["tool_calls"]:
-                fn = tc.get("function", {}) if isinstance(tc, dict) else {}
-                args = fn.get("arguments", "") if isinstance(fn, dict) else ""
-                try:
-                    args = json.loads(args) if isinstance(args, str) else args
-                except (json.JSONDecodeError, TypeError):
-                    pass
-                parts.append(
-                    {
-                        "type": "tool_call",
-                        "id": tc.get("id", "") if isinstance(tc, dict) else "",
-                        "name": fn.get("name", "") if isinstance(fn, dict) else "",
-                        "arguments": args,
-                    }
-                )
-        # OpenAI tool message → tool_call_response
-        if role == "tool":
-            c = content if isinstance(content, str) else json.dumps(content, default=str)
-            parts.append(
-                {
-                    "type": "tool_call_response",
-                    "id": m.get("tool_call_id", ""),
-                    "result": json.dumps([{"type": "text", "text": c}], ensure_ascii=False),
-                }
-            )
+            parts.extend(_block_to_part(b) for b in content if isinstance(b, dict))
+        # Assistant tool_calls (OpenAI envelope).
+        for tc in (m.get("tool_calls") or []) if role == "assistant" else ():
+            if not isinstance(tc, dict): continue
+            fn = tc.get("function") or {}
+            args = fn.get("arguments", "")
+            try: args = json.loads(args) if isinstance(args, str) else args
+            except (json.JSONDecodeError, TypeError): pass
+            parts.append({"type": "tool_call", "id": tc.get("id", ""),
+                          "name": fn.get("name", ""), "arguments": args})
         out.append({"role": role, "parts": parts})
     return out
 

--- a/src/exgentic/integrations/litellm/trace_logger.py
+++ b/src/exgentic/integrations/litellm/trace_logger.py
@@ -83,7 +83,8 @@ def _normalize_tool_definitions(tools: Any) -> list[dict] | Any:
     out = []
     for t in tools:
         if not isinstance(t, dict):
-            out.append(t); continue
+            out.append(t)
+            continue
         # OpenAI envelope → unwrap `function: {...}`.
         if isinstance(t.get("function"), dict):
             d = {"type": t.get("type") or "function", **t["function"]}
@@ -101,14 +102,21 @@ def _block_to_part(blk: dict) -> dict:
     """One Anthropic content block → one OTel part."""
     t = blk.get("type")
     if t == "tool_use":
-        return {"type": "tool_call", "id": blk.get("id", ""),
-                "name": blk.get("name", ""), "arguments": blk.get("input", {})}
+        return {
+            "type": "tool_call",
+            "id": blk.get("id", ""),
+            "name": blk.get("name", ""),
+            "arguments": blk.get("input", {}),
+        }
     if t == "tool_result":
         # Per v2.10 contract: `result` is always a JSON-stringified blocks list.
         inner = blk.get("content", "")
         blocks = inner if isinstance(inner, list) else [{"type": "text", "text": str(inner) if inner else ""}]
-        return {"type": "tool_call_response", "id": blk.get("tool_use_id", ""),
-                "result": json.dumps(blocks, ensure_ascii=False, default=str)}
+        return {
+            "type": "tool_call_response",
+            "id": blk.get("tool_use_id", ""),
+            "result": json.dumps(blocks, ensure_ascii=False, default=str),
+        }
     if t == "thinking":
         p = {"type": "thinking", "thinking": blk.get("thinking", "")}
         if blk.get("signature") is not None:
@@ -129,15 +137,21 @@ def _convert_input_messages_to_parts(messages: Any) -> list[dict] | Any:
         return messages
     out = []
     for m in messages:
-        if not isinstance(m, dict): continue
+        if not isinstance(m, dict):
+            continue
         role = m.get("role", "")
         content = m.get("content", "")
         parts = []
         if role == "tool":
             # OpenAI tool message: content is the result itself.
             c = content if isinstance(content, str) else json.dumps(content, default=str)
-            parts.append({"type": "tool_call_response", "id": m.get("tool_call_id", ""),
-                          "result": json.dumps([{"type": "text", "text": c}], ensure_ascii=False)})
+            parts.append(
+                {
+                    "type": "tool_call_response",
+                    "id": m.get("tool_call_id", ""),
+                    "result": json.dumps([{"type": "text", "text": c}], ensure_ascii=False),
+                }
+            )
         elif isinstance(content, str):
             if content:
                 parts.append({"type": "text", "content": content})
@@ -145,13 +159,15 @@ def _convert_input_messages_to_parts(messages: Any) -> list[dict] | Any:
             parts.extend(_block_to_part(b) for b in content if isinstance(b, dict))
         # Assistant tool_calls (OpenAI envelope).
         for tc in (m.get("tool_calls") or []) if role == "assistant" else ():
-            if not isinstance(tc, dict): continue
+            if not isinstance(tc, dict):
+                continue
             fn = tc.get("function") or {}
             args = fn.get("arguments", "")
-            try: args = json.loads(args) if isinstance(args, str) else args
-            except (json.JSONDecodeError, TypeError): pass
-            parts.append({"type": "tool_call", "id": tc.get("id", ""),
-                          "name": fn.get("name", ""), "arguments": args})
+            try:
+                args = json.loads(args) if isinstance(args, str) else args
+            except (json.JSONDecodeError, TypeError):
+                pass
+            parts.append({"type": "tool_call", "id": tc.get("id", ""), "name": fn.get("name", ""), "arguments": args})
         out.append({"role": role, "parts": parts})
     return out
 

--- a/src/exgentic/integrations/litellm/trace_logger.py
+++ b/src/exgentic/integrations/litellm/trace_logger.py
@@ -67,6 +67,161 @@ def _set_json_attr(span, key: str, value: Any) -> None:
             span.set_attribute(key, serialized)
 
 
+# ---------------------------------------------------------------------------
+# Spec-shape normalization for content attributes
+# ---------------------------------------------------------------------------
+# `gen_ai.tool.definitions`, `gen_ai.input.messages`, and
+# `gen_ai.output.messages` each have a canonical OTel GenAI shape. LiteLLM
+# hands us whatever the underlying provider used (OpenAI native, Anthropic
+# native, …), so we have to normalize before serializing.
+
+
+def _normalize_tool_definitions(tools: Any) -> list[dict] | Any:
+    """Normalize each entry to the OTel Tool Definitions JSON Schema shape.
+
+    Target shape: `{type, name, description, parameters}`.
+
+    OpenAI native      `{type:"function", function:{name, description, parameters}}`
+    Anthropic native   `{name, description, input_schema}`                     (no type)
+    Spec target        `{type:"function", name, description, parameters}`
+    """
+    if not isinstance(tools, list):
+        return tools
+    out: list[dict] = []
+    for t in tools:
+        if not isinstance(t, dict):
+            out.append(t)
+            continue
+        d: dict[str, Any] = {}
+        ttype = t.get("type")
+        d["type"] = ttype if isinstance(ttype, str) and ttype else "function"
+        # OpenAI envelope: pull body out of `function: {...}`.
+        if "function" in t and isinstance(t["function"], dict):
+            inner = t["function"]
+            for k in ("name", "description", "parameters"):
+                if k in inner:
+                    d[k] = inner[k]
+            for k, v in inner.items():
+                d.setdefault(k, v)
+        # Flat shape (Anthropic / spec): copy direct keys.
+        for k in ("name", "description", "parameters"):
+            if k in t and k not in d:
+                d[k] = t[k]
+        # Anthropic uses `input_schema`; spec uses `parameters`.
+        if "input_schema" in t and "parameters" not in d:
+            d["parameters"] = t["input_schema"]
+        out.append(d)
+    return out
+
+
+def _convert_input_messages_to_parts(messages: Any) -> list[dict] | Any:
+    """Convert OpenAI / Anthropic native messages to the OTel parts shape.
+
+    Target shape: `[{role, parts: [{type, ...}]}]`.
+
+    Handles:
+      - role=user/assistant with string content → single text part
+      - role=user with list content (Anthropic blocks):
+            type=text       → text part
+            type=tool_use   → tool_call part
+            type=tool_result → tool_call_response part (multi-block content
+                              preserved as JSON-stringified blocks list per
+                              the v2.10 contract — `json.loads(result)` is
+                              always a list of {type, ...} blocks)
+            type=image      → text placeholder (no image part type in OTel yet)
+      - role=assistant with tool_calls → tool_call parts
+      - role=tool (OpenAI) → tool_call_response part
+    """
+    if not isinstance(messages, list):
+        return messages
+    out: list[dict] = []
+    for m in messages:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role", "")
+        content = m.get("content", "")
+        parts: list[dict] = []
+        # OpenAI `tool` role messages: the `content` IS the tool result, not
+        # natural-language text. Skip the text-part path; the tool_call_response
+        # handler below will produce the right part shape.
+        if role == "tool":
+            pass
+        elif isinstance(content, str):
+            if content:
+                parts.append({"type": "text", "content": content})
+        elif isinstance(content, list):
+            for blk in content:
+                if not isinstance(blk, dict):
+                    continue
+                btype = blk.get("type")
+                if btype == "text":
+                    parts.append({"type": "text", "content": blk.get("text", "")})
+                elif btype == "tool_use":
+                    parts.append(
+                        {
+                            "type": "tool_call",
+                            "id": blk.get("id", ""),
+                            "name": blk.get("name", ""),
+                            "arguments": blk.get("input", {}),
+                        }
+                    )
+                elif btype == "tool_result":
+                    inner = blk.get("content", "")
+                    # Per v2.10 contract: `result` is always a
+                    # JSON-stringified blocks list, regardless of content.
+                    if isinstance(inner, list):
+                        blocks = inner
+                    elif isinstance(inner, str):
+                        blocks = [{"type": "text", "text": inner}]
+                    else:
+                        blocks = [{"type": "text", "text": str(inner)}]
+                    parts.append(
+                        {
+                            "type": "tool_call_response",
+                            "id": blk.get("tool_use_id", ""),
+                            "result": json.dumps(blocks, ensure_ascii=False, default=str),
+                        }
+                    )
+                elif btype == "thinking":
+                    p = {"type": "thinking", "thinking": blk.get("thinking", "")}
+                    if blk.get("signature") is not None:
+                        p["signature"] = blk["signature"]
+                    parts.append(p)
+                elif btype == "image":
+                    parts.append({"type": "text", "content": "[image content]"})
+                else:
+                    parts.append({"type": "text", "content": blk.get("text", "") or str(blk)})
+        # Assistant tool_calls (OpenAI native)
+        if role == "assistant" and m.get("tool_calls"):
+            for tc in m["tool_calls"]:
+                fn = tc.get("function", {}) if isinstance(tc, dict) else {}
+                args = fn.get("arguments", "") if isinstance(fn, dict) else ""
+                try:
+                    args = json.loads(args) if isinstance(args, str) else args
+                except (json.JSONDecodeError, TypeError):
+                    pass
+                parts.append(
+                    {
+                        "type": "tool_call",
+                        "id": tc.get("id", "") if isinstance(tc, dict) else "",
+                        "name": fn.get("name", "") if isinstance(fn, dict) else "",
+                        "arguments": args,
+                    }
+                )
+        # OpenAI tool message → tool_call_response
+        if role == "tool":
+            c = content if isinstance(content, str) else json.dumps(content, default=str)
+            parts.append(
+                {
+                    "type": "tool_call_response",
+                    "id": m.get("tool_call_id", ""),
+                    "result": json.dumps([{"type": "text", "text": c}], ensure_ascii=False),
+                }
+            )
+        out.append({"role": role, "parts": parts})
+    return out
+
+
 class TraceLogger(CustomLogger):
     def __init__(self, file_path: str | None = None) -> None:
         super().__init__()
@@ -382,8 +537,23 @@ class TraceLogger(CustomLogger):
 
     @staticmethod
     def _set_content_attributes(span, kwargs: dict[str, Any], response_obj: dict[str, Any]) -> None:
-        _set_json_attr(span, "gen_ai.tool.definitions", kwargs.get("tools"))
-        _set_json_attr(span, "gen_ai.input.messages", kwargs.get("messages"))
+        # Tool definitions must follow the OTel JSON Schema shape (flat keys,
+        # required `type` and `name`). LiteLLM may hand us OpenAI native shape
+        # (`{type, function: {...}}`) or Anthropic native shape (no `type`).
+        _set_json_attr(
+            span,
+            "gen_ai.tool.definitions",
+            _normalize_tool_definitions(kwargs.get("tools")),
+        )
+        # Input messages must be in OTel `[{role, parts: [...]}]` shape. The
+        # raw provider format (OpenAI or Anthropic native) needs converting so
+        # downstream consumers don't see vendor-specific block structures
+        # leaking through as text.
+        _set_json_attr(
+            span,
+            "gen_ai.input.messages",
+            _convert_input_messages_to_parts(kwargs.get("messages")),
+        )
 
         if not response_obj:
             return
@@ -404,12 +574,21 @@ class TraceLogger(CustomLogger):
 
             for tc in _safe_get(message, "tool_calls") or []:
                 func = _safe_get(tc, "function", {})
+                # OpenAI hands us `arguments` as a JSON-encoded string;
+                # downstream OTel consumers want the deserialized dict so a
+                # follow-on `args["command"]` works. Decode best-effort.
+                args = _safe_get(func, "arguments")
+                if isinstance(args, str):
+                    try:
+                        args = json.loads(args)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
                 output_msg["parts"].append(
                     {
                         "type": "tool_call",
                         "id": _safe_get(tc, "id"),
                         "name": _safe_get(func, "name"),
-                        "arguments": _safe_get(func, "arguments"),
+                        "arguments": args,
                     }
                 )
 

--- a/tests/integrations/litellm/test_trace_logger_spec_shape.py
+++ b/tests/integrations/litellm/test_trace_logger_spec_shape.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Unit tests for the spec-shape normalizers in trace_logger.
+
+The OTel GenAI semantic conventions define canonical shapes for
+gen_ai.tool.definitions and gen_ai.input.messages. LiteLLM hands the
+logger whatever the underlying provider used (OpenAI native, Anthropic
+native, ...) so the logger must normalize before serializing — otherwise
+the spans are non-conformant and downstream consumers (e.g. the
+Exgentic agent-llm-traces-v2 dataset) inherit shape bugs.
+
+These tests exist to catch regressions: if the normalizer drifts, the
+dataset rebuilders we patched (v2.10, v2.11) would have to keep fixing
+the same bugs forever.
+"""
+
+from __future__ import annotations
+
+import json
+
+from exgentic.integrations.litellm.trace_logger import (
+    _convert_input_messages_to_parts,
+    _normalize_tool_definitions,
+)
+
+# ---------------------------------------------------------------------------
+# _normalize_tool_definitions
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_openai_native_unwraps_function_envelope():
+    """OpenAI's envelope must unwrap to the flat spec shape.
+
+    OpenAI ships `{type:function, function:{name, description, parameters}}`.
+    OTel spec wants flat `{type:function, name, description, parameters}`.
+    """
+    out = _normalize_tool_definitions(
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "search the web",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+    )
+    assert out == [
+        {
+            "type": "function",
+            "name": "search",
+            "description": "search the web",
+            "parameters": {"type": "object"},
+        }
+    ]
+
+
+def test_normalize_anthropic_native_adds_type_and_renames_input_schema():
+    """Anthropic ships `{name, description, input_schema}` with no `type`."""
+    out = _normalize_tool_definitions(
+        [
+            {
+                "name": "search",
+                "description": "search the web",
+                "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}},
+            }
+        ]
+    )
+    assert out == [
+        {
+            "type": "function",
+            "name": "search",
+            "description": "search the web",
+            "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+        }
+    ]
+
+
+def test_normalize_already_spec_shape_is_idempotent():
+    spec = [{"type": "function", "name": "search", "parameters": {}}]
+    assert _normalize_tool_definitions(spec) == spec
+
+
+def test_normalize_preserves_provider_extension_type():
+    """Provider-extension types pass through unchanged.
+
+    e.g. Anthropic's `computer_20241022` — only spec-required fields are
+    normalized, extension types pass through.
+    """
+    out = _normalize_tool_definitions([{"type": "computer_20241022", "name": "computer"}])
+    assert out == [{"type": "computer_20241022", "name": "computer"}]
+
+
+def test_normalize_non_list_passes_through():
+    assert _normalize_tool_definitions(None) is None
+    assert _normalize_tool_definitions("not a list") == "not a list"
+
+
+# ---------------------------------------------------------------------------
+# _convert_input_messages_to_parts
+# ---------------------------------------------------------------------------
+
+
+def test_convert_openai_plain_string_content():
+    out = _convert_input_messages_to_parts(
+        [
+            {"role": "system", "content": "be helpful"},
+            {"role": "user", "content": "hi"},
+        ]
+    )
+    assert out == [
+        {"role": "system", "parts": [{"type": "text", "content": "be helpful"}]},
+        {"role": "user", "parts": [{"type": "text", "content": "hi"}]},
+    ]
+
+
+def test_convert_anthropic_tool_use_block_becomes_tool_call_part():
+    """Anthropic `tool_use` blocks must become OTel `tool_call` parts.
+
+    Not text parts (the Issue #14 anti-pattern).
+    """
+    out = _convert_input_messages_to_parts(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "let me search"},
+                    {"type": "tool_use", "id": "tu_1", "name": "search", "input": {"q": "x"}},
+                ],
+            }
+        ]
+    )
+    assert out == [
+        {
+            "role": "assistant",
+            "parts": [
+                {"type": "text", "content": "let me search"},
+                {"type": "tool_call", "id": "tu_1", "name": "search", "arguments": {"q": "x"}},
+            ],
+        }
+    ]
+
+
+def test_convert_anthropic_tool_result_block_becomes_tool_call_response():
+    """Anthropic `tool_result` block becomes a `tool_call_response` part.
+
+    The `result` field is always a JSON-stringified blocks list — the v2.10
+    contract — so `json.loads(result)` always returns `[{type, ...}]`.
+    """
+    out = _convert_input_messages_to_parts(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "tool_use_id": "tu_1",
+                        "type": "tool_result",
+                        "content": [{"type": "text", "text": "result text"}],
+                    }
+                ],
+            }
+        ]
+    )
+    [m] = out
+    assert m["role"] == "user"
+    [p] = m["parts"]
+    assert p["type"] == "tool_call_response"
+    assert p["id"] == "tu_1"
+    assert json.loads(p["result"]) == [{"type": "text", "text": "result text"}]
+
+
+def test_convert_anthropic_multiblock_tool_result_preserves_structure():
+    """Multi-block content must be preserved one block per element.
+
+    So the wire structure the model saw is recoverable.
+    """
+    out = _convert_input_messages_to_parts(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "tool_use_id": "tu_1",
+                        "type": "tool_result",
+                        "content": [
+                            {"type": "text", "text": "part A"},
+                            {"type": "text", "text": "part B"},
+                        ],
+                    }
+                ],
+            }
+        ]
+    )
+    [p] = out[0]["parts"]
+    blocks = json.loads(p["result"])
+    assert blocks == [
+        {"type": "text", "text": "part A"},
+        {"type": "text", "text": "part B"},
+    ]
+
+
+def test_convert_anthropic_string_tool_result_wraps_as_single_text_block():
+    """Plain-string `tool_result.content` wraps as a single text block.
+
+    Rare but allowed by Anthropic. Wrap so `result` shape stays uniform.
+    """
+    out = _convert_input_messages_to_parts(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "tool_use_id": "tu_1",
+                        "type": "tool_result",
+                        "content": "plain text result",
+                    }
+                ],
+            }
+        ]
+    )
+    [p] = out[0]["parts"]
+    assert json.loads(p["result"]) == [{"type": "text", "text": "plain text result"}]
+
+
+def test_convert_openai_tool_message_becomes_tool_call_response():
+    out = _convert_input_messages_to_parts(
+        [
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "tool output",
+            }
+        ]
+    )
+    [m] = out
+    [p] = m["parts"]
+    assert p["type"] == "tool_call_response"
+    assert p["id"] == "call_1"
+    assert json.loads(p["result"]) == [{"type": "text", "text": "tool output"}]
+
+
+def test_convert_openai_assistant_tool_calls_become_tool_call_parts():
+    out = _convert_input_messages_to_parts(
+        [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "search", "arguments": '{"q": "x"}'}},
+                ],
+            }
+        ]
+    )
+    [m] = out
+    [p] = m["parts"]
+    assert p == {"type": "tool_call", "id": "call_1", "name": "search", "arguments": {"q": "x"}}
+
+
+def test_convert_anthropic_thinking_block_preserves_signature():
+    out = _convert_input_messages_to_parts(
+        [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "let me think", "signature": "sig123"},
+                ],
+            }
+        ]
+    )
+    [p] = out[0]["parts"]
+    assert p == {"type": "thinking", "thinking": "let me think", "signature": "sig123"}
+
+
+def test_convert_non_list_passes_through():
+    assert _convert_input_messages_to_parts(None) is None
+    assert _convert_input_messages_to_parts("not a list") == "not a list"


### PR DESCRIPTION
## Summary

LiteLLM hands the trace logger whatever the underlying provider emitted — OpenAI native \`{type:function, function:{...}}\` for tool definitions, Anthropic native \`[{tool_use_id, type:tool_result, content:[...]}]\` for tool-result-bearing messages, and so on. The current logger passes those through verbatim, producing OTel spans that violate the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) in two ways:

| Violation | Where it surfaced |
|---|---|
| \`gen_ai.tool.definitions\` from Anthropic providers ships with no top-level \`type\` field (spec requires \`["type", "name"]\`) | Exgentic [\`agent-llm-traces-v2\` v2.11](https://huggingface.co/datasets/Exgentic/agent-llm-traces-v2) retroactively fixed 9.27M entries across 98k chat spans |
| \`gen_ai.input.messages\` ships in raw OpenAI/Anthropic shapes (not OTel \`[{role, parts: [...]}]\`), causing vendor-specific blocks (\`tool_use\`, \`tool_result\`, \`thinking\`) to leak through as text | The Issue #14 family — also fixed retroactively in the dataset |

## What's new

Two pure normalizer helpers wired into \`_set_content_attributes\`:

### \`_normalize_tool_definitions\`
- OpenAI envelope \`{type, function:{name, description, parameters}}\` → flat spec shape
- Anthropic native \`{name, description, input_schema}\` (no \`type\`) → \`{type:"function", name, description, parameters}\` (renaming \`input_schema\` → \`parameters\` per spec)
- Provider-extension \`type\` values (e.g. Anthropic's \`computer_20241022\`, OpenAI's \`code_interpreter\`/\`file_search\`) preserved as-is

### \`_convert_input_messages_to_parts\`
- role=user/assistant with string content → single text part
- Anthropic blocks → matching OTel parts:
  - \`text\` → text part
  - \`tool_use\` → \`tool_call\` part
  - \`tool_result\` → \`tool_call_response\` part; \`result\` is always a JSON-stringified blocks list (the [v2.10 contract](https://huggingface.co/datasets/Exgentic/agent-llm-traces-v2/commit/), so \`json.loads(result)\` always yields \`[{type, ...}]\`)
  - \`thinking\` → \`thinking\` part (signature preserved)
- OpenAI \`role=tool\` → \`tool_call_response\` part
- OpenAI assistant \`tool_calls\` → \`tool_call\` parts (arguments JSON-decoded so downstream can read \`part["arguments"]["command"]\` directly)

### Also: JSON-decode \`tool_calls[].function.arguments\` in output messages

Matches the dataset v2.9 fix that retroactively unwrapped \`{"_value": "<JSON-string>"}\` shapes on 74k entries — same root cause when LiteLLM serialized arguments as a JSON string and the consumer expected a dict.

## Tests

14 new tests covering every conversion path:
- OpenAI envelope unwrap, Anthropic native type default + \`input_schema\` rename, idempotency on already-spec shape, provider-extension type preservation, non-list passthrough
- Plain-string content, multi-block content preservation, single-string \`tool_result\` content wrap, OpenAI tool message, assistant tool_calls, Anthropic thinking with signatures

## Why this matters

The Exgentic team has spent the past several days retroactively patching \`agent-llm-traces-v2\` to fix spans this logger produced (commits v2.7 through v2.11 on the HF dataset). Without this PR, every new run would re-introduce the same bugs. The fixes here are paired with [tracelab PR #17](https://github.com/Exgentic/tracelab/pull/17) which adds the corresponding \`validate_genai\` checks to catch any future drift.

## Test plan

- [ ] CI green on the existing suite
- [ ] \`pytest tests/integrations/litellm/\` passes
- [ ] Run one bench end-to-end and \`tracelab validate <spans.jsonl> --allow-prefix exgentic.\` returns 0