### PR TITLE
fix: RITS/hosted_vllm pricing tolerance, AppWorld init lock, env-conf

### DIFF
--- a/src/exgentic/adapters/runners/_utils.py
+++ b/src/exgentic/adapters/runners/_utils.py
@@ -77,6 +77,7 @@ _FORWARD_SUFFIXES = (
 # Prefix patterns catch multi-variable providers that use keys without
 # the above suffixes (region names, credential file paths, model IDs).
 _FORWARD_PREFIXES = (
+    "CE_MANAGER_",
     "AWS_",
     "AZURE_",
     "GOOGLE_",
@@ -93,18 +94,34 @@ _FORWARD_PREFIXES = (
 )
 
 
+_FORWARD_EXACT = frozenset({"PYTHONPATH", "HOME", "USER", "LANG", "LC_ALL"})
+
+
 def prepare_subprocess_env() -> dict[str, str]:
     """Build a filtered env dict for subprocess runners (venv, docker).
 
-    Forwards only model-provider credentials, base URLs, and OTEL
-    configuration (see :data:`_FORWARD_SUFFIXES` and
-    :data:`_FORWARD_PREFIXES`).  Exgentic context and settings travel
-    via ``runtime.json`` (see :func:`inject_exgentic_env`), so no
-    ``EXGENTIC_*`` vars need to be forwarded here.
+    Forwards only model-provider credentials, base URLs, OTEL
+    configuration, and a small set of exact-match vars needed for
+    package resolution and locale (see :data:`_FORWARD_SUFFIXES`,
+    :data:`_FORWARD_PREFIXES`, and :data:`_FORWARD_EXACT`).
+
+    ``PYTHONPATH`` is forwarded so that optional packages installed
+    outside the venv (e.g. ``ce_manager``, ``llm_ce_proxy``) remain
+    importable in the child process for CE-Manager bootstrap.
+
+    Exgentic context and settings travel via ``runtime.json``
+    (see :func:`inject_exgentic_env`), so no ``EXGENTIC_*`` vars need
+    to be forwarded here.
     """
     import os
 
-    return {k: v for k, v in os.environ.items() if k.endswith(_FORWARD_SUFFIXES) or k.startswith(_FORWARD_PREFIXES)}
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if k in _FORWARD_EXACT
+        or k.endswith(_FORWARD_SUFFIXES)
+        or k.startswith(_FORWARD_PREFIXES)
+    }
 
 
 def inject_exgentic_env(env: dict[str, str], role: Role | None = None) -> None:

--- a/src/exgentic/adapters/runners/venv.py
+++ b/src/exgentic/adapters/runners/venv.py
@@ -36,8 +36,19 @@ from ._utils import (
 from .service import HTTPTransport, _wait_for_health
 from .transport import ObjectProxy
 
-_HEALTH_TIMEOUT = 360.0
-_TRANSPORT_TIMEOUT = 600.0
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+_HEALTH_TIMEOUT = _float_env("EXGENTIC_VENV_HEALTH_TIMEOUT", 360.0)
+_TRANSPORT_TIMEOUT = _float_env("EXGENTIC_VENV_TRANSPORT_TIMEOUT", 600.0)
 
 
 def _uv(*args: str, check: bool = True, **kwargs: Any) -> subprocess.CompletedProcess:

--- a/src/exgentic/agents/smolagents/base_instance.py
+++ b/src/exgentic/agents/smolagents/base_instance.py
@@ -3,6 +3,7 @@
 
 import functools
 import logging
+import os
 from abc import abstractmethod
 from collections.abc import Callable
 
@@ -48,11 +49,19 @@ class SmolagentBaseAgentInstance(CodeAgentInstance):
         self._model = None
 
         # Check model accessibility
+        _health_timeout_env = os.environ.get("EXGENTIC_MODEL_HEALTH_TIMEOUT")
+        _health_kwargs: dict = {}
+        if _health_timeout_env:
+            try:
+                _health_kwargs["timeout"] = float(_health_timeout_env)
+            except ValueError:
+                pass
         check_model_accessible_sync(
             self.model_id,
             logger=self.logger,
             model_settings=self.model_settings,
             litellm_params_extra=self._litellm_params_extra,
+            **_health_kwargs,
         )
 
     def run_code_agent(self, functions: list[Callable]) -> None:

--- a/src/exgentic/benchmarks/appworld/appworld_eval.py
+++ b/src/exgentic/benchmarks/appworld/appworld_eval.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+import threading
 from pathlib import Path
 from shutil import copytree
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
@@ -68,6 +69,7 @@ class AppWorldSession(Session):
     CACHE_DIR: ClassVar[str] = "./appworld_disk_cache"
     TASK_OUTPUT_SUBDIR: ClassVar[str] = "task_output"
     SCORES_FILE_NAME: ClassVar[str] = "scores.json"
+    _APPWORLD_INIT_LOCK: ClassVar[threading.Lock] = threading.Lock()
 
     def __init__(
         self,
@@ -116,7 +118,7 @@ class AppWorldSession(Session):
         # check_same_thread=True, causing ProgrammingError.
         self._patch_appworld_sqlite()
 
-        self._world: AppWorld = AppWorld(task_id=self._task_id, **self._env_kwargs)
+        self._world: AppWorld = self._create_world(task_id=self._task_id, env_kwargs=self._env_kwargs)
         self._experiment_name: str = self._world.experiment_name or DEFAULT_EXPERIMENT_NAME
         self._task_output_dir: Path = (
             Path(path_store.experiment_outputs) / self._experiment_name / "tasks" / self._task_id
@@ -124,6 +126,19 @@ class AppWorldSession(Session):
 
         self.logger.info(f"Task ID: {task_id}")
         super().__init__()
+
+    @staticmethod
+    def _create_world(task_id: str, env_kwargs: dict[str, Any]):
+        """Construct AppWorld under a global lock.
+
+        AppWorld initialization calls global cache cleanup routines that are not
+        thread-safe in some versions. Serializing construction avoids races like
+        "dictionary changed size during iteration" when sessions start in parallel.
+        """
+        from appworld.environment import AppWorld  # type: ignore
+
+        with AppWorldSession._APPWORLD_INIT_LOCK:
+            return AppWorld(task_id=task_id, **env_kwargs)
 
     @staticmethod
     def _patch_appworld_sqlite() -> None:

--- a/src/exgentic/integrations/litellm/trace_logger.py
+++ b/src/exgentic/integrations/litellm/trace_logger.py
@@ -152,6 +152,10 @@ class TraceLogger(CustomLogger):
         from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 
         ctx = self.get_context(kwargs)
+        # Handle missing context: return current OTEL context without parent span
+        if ctx is None or ctx.otel_context is None:
+            return context.get_current()
+
         trace_id_hex = ctx.otel_context.trace_id
         span_id_hex = ctx.otel_context.span_id
 

--- a/src/exgentic/observers/handlers/results.py
+++ b/src/exgentic/observers/handlers/results.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2026, The Exgentic organization and its contributors.
 
 import json
+import logging
 import os
 import threading
 import time
@@ -32,6 +33,9 @@ from ...core.types import (
 from ...interfaces.registry import get_agent_entries, get_benchmark_entries
 from ...utils.cost import CostReport, accumulate_reports
 from .session_ledger import SessionLedger
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -240,7 +244,20 @@ class ResultsObserver(Observer):
         success = bool(score.success)
         value = score.score
         is_finished = score.is_finished
-        agent_cost_report = agent.get_cost() if agent is not None else CostReport.initialize_empty()
+        if agent is not None:
+            try:
+                agent_cost_report = agent.get_cost()
+            except Exception as exc:
+                if "No pricing info found for model" in str(exc):
+                    logger.warning(
+                        "Failed to resolve agent pricing; defaulting agent cost to 0.0. error=%s",
+                        exc,
+                    )
+                    agent_cost_report = CostReport.initialize_empty()
+                else:
+                    raise
+        else:
+            agent_cost_report = CostReport.initialize_empty()
         benchmark_cost_report = session.get_cost()
         status = self._resolve_session_status(score)
         from .session_timings import get_session_llm_timings

--- a/src/exgentic/utils/cost.py
+++ b/src/exgentic/utils/cost.py
@@ -19,6 +19,11 @@ class TokensCost(BaseModel):
     total_cost: float
 
 
+def _is_unpriced_rits_model(model_name: str) -> bool:
+    lower = model_name.lower()
+    return lower.startswith("hosted_vllm/") or lower.startswith("rits/")
+
+
 def _cost_per_token(*, model: str, prompt_tokens: int, completion_tokens: int):
     from litellm.cost_calculator import cost_per_token
 
@@ -30,6 +35,9 @@ def litellm_cost_per_token(model_name: str):
 
 
 def litellm_tokens_cost(input_tokens: int, output_tokens: int, model_name: str) -> TokensCost:
+    if _is_unpriced_rits_model(model_name):
+        return TokensCost(input_cost=0.0, output_cost=0.0, total_cost=0.0)
+
     for src, dst in name_map.items():
         model_name = model_name.replace(src, dst)
 

--- a/tests/adapters/runners/test_utils.py
+++ b/tests/adapters/runners/test_utils.py
@@ -5,10 +5,11 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import patch
 
-from exgentic.adapters.runners._utils import find_project_root
+from exgentic.adapters.runners._utils import find_project_root, prepare_subprocess_env
 
 
 def test_find_project_root_returns_repo_root():
@@ -78,3 +79,61 @@ def test_find_project_root_fallback_is_idempotent(tmp_path: Path):
 
     assert result1 == result2
     assert result1 == fake_home / ".exgentic"
+
+
+class TestPrepareSubprocessEnv:
+    """Tests for prepare_subprocess_env env-var forwarding."""
+
+    def test_forwards_pythonpath(self):
+        """PYTHONPATH must be forwarded for CE-Manager bootstrap."""
+        with patch.dict(
+            os.environ,
+            {"PYTHONPATH": "/some/path:/another/path"},
+            clear=False,
+        ):
+            env = prepare_subprocess_env()
+            assert "PYTHONPATH" in env
+            assert env["PYTHONPATH"] == "/some/path:/another/path"
+
+    def test_forwards_ce_manager_vars(self):
+        """CE_MANAGER_* prefix vars must be forwarded."""
+        with patch.dict(
+            os.environ,
+            {
+                "CE_MANAGER_BOOTSTRAP_ENABLED": "1",
+                "CE_MANAGER_BOOTSTRAP_CONFIG_PATH": "/path/to/config.json",
+            },
+            clear=False,
+        ):
+            env = prepare_subprocess_env()
+            assert env.get("CE_MANAGER_BOOTSTRAP_ENABLED") == "1"
+            assert env.get("CE_MANAGER_BOOTSTRAP_CONFIG_PATH") == "/path/to/config.json"
+
+    def test_forwards_provider_api_keys(self):
+        """Provider credential vars matching suffix patterns are forwarded."""
+        with patch.dict(
+            os.environ,
+            {"OPENAI_API_KEY": "sk-test", "SOME_PROVIDER_API_BASE": "http://x"},
+            clear=False,
+        ):
+            env = prepare_subprocess_env()
+            assert env.get("OPENAI_API_KEY") == "sk-test"
+            assert env.get("SOME_PROVIDER_API_BASE") == "http://x"
+
+    def test_does_not_forward_unrelated_vars(self):
+        """Unrelated env vars must not leak into the subprocess."""
+        with patch.dict(
+            os.environ,
+            {"EDITOR": "vim", "TERM": "xterm-256color", "SHELL": "/bin/zsh"},
+            clear=False,
+        ):
+            env = prepare_subprocess_env()
+            assert "EDITOR" not in env
+            assert "TERM" not in env
+            assert "SHELL" not in env
+
+    def test_forwards_home(self):
+        """HOME is needed for package resolution and tool discovery."""
+        with patch.dict(os.environ, {"HOME": "/Users/testuser"}, clear=False):
+            env = prepare_subprocess_env()
+            assert env.get("HOME") == "/Users/testuser"

--- a/tests/benchmarks/test_appworld_session_init_lock.py
+++ b/tests/benchmarks/test_appworld_session_init_lock.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import threading
+import time
+import types
+from concurrent.futures import ThreadPoolExecutor
+
+from exgentic.benchmarks.appworld.appworld_eval import AppWorldSession
+
+
+def test_create_world_serializes_parallel_initialization(monkeypatch):
+    """Concurrent session startup should not initialize AppWorld concurrently."""
+    state_lock = threading.Lock()
+    active = 0
+    overlap_detected = False
+
+    class FakeAppWorld:
+        def __init__(self, task_id: str, **_kwargs):
+            nonlocal active, overlap_detected
+            with state_lock:
+                if active > 0:
+                    overlap_detected = True
+                active += 1
+            time.sleep(0.05)
+            with state_lock:
+                active -= 1
+            self.experiment_name = f"exp-{task_id}"
+
+    fake_appworld_pkg = types.ModuleType("appworld")
+    fake_environment_mod = types.ModuleType("appworld.environment")
+    fake_environment_mod.AppWorld = FakeAppWorld
+
+    monkeypatch.setitem(sys.modules, "appworld", fake_appworld_pkg)
+    monkeypatch.setitem(sys.modules, "appworld.environment", fake_environment_mod)
+
+    task_ids = [str(i) for i in range(8)]
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda task_id: AppWorldSession._create_world(task_id=task_id, env_kwargs={}), task_ids))
+
+    assert overlap_detected is False

--- a/tests/observers/test_otel.py
+++ b/tests/observers/test_otel.py
@@ -801,6 +801,43 @@ class TestTraceLoggerParentContext:
         # tracer methods should not have been called
         logger._tracer.start_span.assert_not_called()
 
+    def test_get_parent_context_handles_none_context(self):
+        """_get_parent_context returns current OTEL context when get_context returns None."""
+        from exgentic.integrations.litellm.trace_logger import TraceLogger
+        from opentelemetry import context as otel_context
+
+        logger = TraceLogger()
+        
+        with patch.object(logger, "get_context", return_value=None):
+            parent_ctx = logger._get_parent_context({})
+        
+        # Should return current OTEL context without raising AttributeError
+        assert parent_ctx is not None
+        # Verify it's the current context (same object)
+        assert parent_ctx == otel_context.get_current()
+
+    def test_get_parent_context_handles_missing_otel_context(self):
+        """_get_parent_context returns current OTEL context when otel_context is None."""
+        from exgentic.integrations.litellm.trace_logger import TraceLogger
+        from opentelemetry import context as otel_context
+
+        ctx = Context(
+            run_id="run-1",
+            output_dir="/tmp",
+            cache_dir="/tmp",
+            session_id="sess-1",
+            otel_context=None,  # Missing otel_context
+        )
+
+        logger = TraceLogger()
+
+        with patch.object(logger, "get_context", return_value=ctx):
+            parent_ctx = logger._get_parent_context({})
+
+        # Should return current OTEL context without raising AttributeError
+        assert parent_ctx is not None
+        assert parent_ctx == otel_context.get_current()
+
 
 # ===================================================================
 # H. on_session_success final attributes

--- a/tests/utils/test_cost.py
+++ b/tests/utils/test_cost.py
@@ -106,3 +106,12 @@ def test_cost_per_token(name, expected):
 def test_unknown_model_raises():
     with pytest.raises(ValueError, match="No pricing info found"):
         litellm_tokens_cost(model_name="openai/azure/totally-fake-model", input_tokens=100, output_tokens=100)
+
+
+def test_hosted_vllm_model_returns_zero_cost():
+    cost = litellm_tokens_cost(
+        model_name="hosted_vllm/Qwen/Qwen3.5-397B-A17B-FP8",
+        input_tokens=100,
+        output_tokens=100,
+    )
+    assert cost == TokensCost(input_cost=0.0, output_cost=0.0, total_cost=0.0)


### PR DESCRIPTION
…igurable timeouts, child-process env forwarding

Small set of focused fixes uncovered while running CE-Manager + Mnemex sweeps on AppWorld with RITS-hosted models. Each fix is independently useful for any user running:
- benchmarks with parallel sessions on AppWorld,
- models that LiteLLM has no pricing for (e.g. hosted_vllm/*, rits/*),
- subprocess (venv) runners with slow model-health endpoints,
- subprocess runners that need PYTHONPATH or locale forwarded.

Bugfixes:
- benchmarks/appworld/appworld_eval.py: serialise AppWorld(__init__) under a class-level threading.Lock. AppWorld's init clears a global cache dict that races under parallel workers, producing 'dictionary changed size during iteration'. New tests/benchmarks/test_appworld_session_init_lock.py.
- integrations/litellm/trace_logger.py: guard against ctx is None or ctx.otel_context is None in start_span_context_from_kwargs. Avoids AttributeError when LiteLLM emits trace events outside an Exgentic context. Coverage in tests/observers/test_otel.py.
- observers/handlers/results.py + utils/cost.py: tolerate models that litellm.cost_calculator has no pricing for (currently hosted_vllm/* and rits/*). Previously crashed the entire results pipeline with 'No pricing info found for model'; now returns zero-cost and logs a warning. Coverage in tests/utils/test_cost.py.

Configurability:
- adapters/runners/venv.py: EXGENTIC_VENV_HEALTH_TIMEOUT and EXGENTIC_VENV_TRANSPORT_TIMEOUT override the previously-hardcoded defaults (360s / 600s), needed for slow inference endpoints.
- agents/smolagents/base_instance.py: EXGENTIC_MODEL_HEALTH_TIMEOUT flows into check_model_accessible_sync.
- adapters/runners/_utils.py: forward PYTHONPATH, HOME, USER, LANG, LC_ALL, and CE_MANAGER_* env vars to subprocess runners so optional packages and locale survive the venv hop. Coverage in tests/adapters/runners/test_utils.py.