### PR TITLE
feat(tool_calling): make tool_choice configurable via model_settings

### DIFF
--- a/src/exgentic/agents/cli/base.py
+++ b/src/exgentic/agents/cli/base.py
@@ -133,6 +133,8 @@ class ProxyBackedMCPAgentInstance(MCPAgentInstance, abc.ABC):
             self.model_settings = model_settings
         else:
             raise ValueError("model_settings must be a ModelSettings instance.")
+        if self.model_settings.tool_choice is not None:
+            self.logger.warning("tool_choice is not supported by this agent (it owns its tool-call loop); ignoring it.")
         self._litellm_params_extra: dict[str, object] = dict(litellm_params_extra or {})
 
         # Check model accessibility

--- a/src/exgentic/agents/litellm_tool_calling/instance.py
+++ b/src/exgentic/agents/litellm_tool_calling/instance.py
@@ -325,6 +325,7 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
             model=self.model,
             messages=self.messages,
             tools=self._assistant_tools(),
+            **({"tool_choice": self.model_settings.tool_choice} if self.model_settings.tool_choice else {}),
             caching=self._use_cache,
         )
 
@@ -368,7 +369,9 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
     def _completion(self, **kwargs):
         call_kwargs = self.model_settings.model_dump(
             exclude_none=True,
-            exclude={"num_retries", "retry_after", "retry_strategy"},
+            # tool_choice is applied explicitly on the action completion only, never on
+            # the (tool-less) shortlisting completion, so keep it out of the generic dump.
+            exclude={"num_retries", "retry_after", "retry_strategy", "tool_choice"},
         )
         call_kwargs.update(self._litellm_params_extra)
         call_kwargs.update(kwargs)

--- a/src/exgentic/agents/openai/instance.py
+++ b/src/exgentic/agents/openai/instance.py
@@ -207,6 +207,7 @@ class OpenAIMCPAgentInstance(MCPAgentInstance):
                     max_tokens=self.model_settings.max_tokens,
                     top_p=self.model_settings.top_p,
                     reasoning=(Reasoning(effort=reasoning_effort) if reasoning_effort is not None else None),
+                    tool_choice=self.model_settings.tool_choice,
                 )
                 num_retries = self.model_settings.num_retries or 0
                 retry_after = self.model_settings.retry_after

--- a/src/exgentic/agents/smolagents/base_instance.py
+++ b/src/exgentic/agents/smolagents/base_instance.py
@@ -42,6 +42,8 @@ class SmolagentBaseAgentInstance(CodeAgentInstance):
             self.model_settings = model_settings
         else:
             raise ValueError("model_settings must be a ModelSettings instance.")
+        if self.model_settings.tool_choice is not None:
+            self.logger.warning("tool_choice is not supported by this agent (it owns its tool-call loop); ignoring it.")
         self._retry_on_all_errors = retry_on_all_errors
         self._litellm_params_extra: dict[str, object] = dict(litellm_params_extra or {})
         self._agent = None

--- a/src/exgentic/core/types/model_settings.py
+++ b/src/exgentic/core/types/model_settings.py
@@ -18,6 +18,7 @@ class ModelSettings(BaseModel):
     top_p: float | None = None
     max_tokens: int | None = None
     reasoning_effort: str | None = None
+    tool_choice: str | None = None
     num_retries: int | None = 5
     retry_after: float = 0.5
     retry_strategy: RetryStrategy = RetryStrategy.EXPONENTIAL_BACKOFF

--- a/tests/agents/test_litellm_params_extra.py
+++ b/tests/agents/test_litellm_params_extra.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -160,3 +161,79 @@ def test_cli_agent_subclasses_forward_extras_to_base(module_path, class_name):
 
     assert agent._litellm_params_extra == EXTRAS
     assert health.call_args.kwargs["litellm_params_extra"] == EXTRAS
+
+
+class _FakeActionResponse(dict):
+    """Minimal litellm response shaped for the action completion in ``react``."""
+
+    def __init__(self):
+        super().__init__(
+            choices=[{"message": SimpleNamespace(content="done", tool_calls=None), "finish_reason": "stop"}]
+        )
+        self.usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1)
+
+
+class _FakeShortlistResponse:
+    """Minimal litellm response shaped for the tool-shortlisting completion."""
+
+    def __init__(self):
+        self.choices = [SimpleNamespace(message={"content": ""})]
+        self.usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1)
+
+
+def _make_tool_calling_agent(tool_choice):
+    from exgentic.agents.litellm_tool_calling import instance as mod
+    from exgentic.core.types import ModelSettings
+
+    with patch.object(mod, "check_model_accessible_sync"):
+        return mod.LiteLLMToolCallingAgentInstance(
+            session_id="s1",
+            model="openai/gpt-4o-mini",
+            model_settings=ModelSettings(tool_choice=tool_choice),
+        )
+
+
+def test_tool_choice_forwarded_on_action_completion():
+    agent = _make_tool_calling_agent("required")
+    agent.enable_tool_shortlisting = False
+    agent._registry = MagicMock()
+    agent._registry.openai_tools.return_value = []
+
+    captured = []
+    agent._completion_with_retries = lambda call_kwargs: (captured.append(call_kwargs), _FakeActionResponse())[1]
+
+    agent.react(None)
+
+    assert captured[0]["tool_choice"] == "required"
+
+
+def test_tool_choice_absent_on_shortlist_completion():
+    agent = _make_tool_calling_agent("required")
+    agent.enable_tool_shortlisting = True
+    agent.max_selected_tools = 1
+    agent._registry = MagicMock()
+    agent._registry.openai_tools.return_value = [
+        {"function": {"name": "a", "description": "tool a"}},
+        {"function": {"name": "b", "description": "tool b"}},
+    ]
+
+    captured = []
+    agent._completion_with_retries = lambda call_kwargs: (captured.append(call_kwargs), _FakeShortlistResponse())[1]
+
+    agent._assistant_tools()
+
+    assert "tool_choice" not in captured[0]
+
+
+def test_tool_choice_absent_on_action_completion_when_unset():
+    agent = _make_tool_calling_agent(None)
+    agent.enable_tool_shortlisting = False
+    agent._registry = MagicMock()
+    agent._registry.openai_tools.return_value = []
+
+    captured = []
+    agent._completion_with_retries = lambda call_kwargs: (captured.append(call_kwargs), _FakeActionResponse())[1]
+
+    agent.react(None)
+
+    assert "tool_choice" not in captured[0]


### PR DESCRIPTION
## Problem
The litellm tool_calling agent sends no `tool_choice`, so litellm defaults it to `"auto"`. Models whose output distribution cannot reliably produce the native tool-call wire format then return 0 tool_calls and emit free-text instead. Driving such a model requires `tool_choice="required"` so the serving engine applies guided decoding and constrains generation to a valid tool-call grammar — but there is currently no way to set `tool_choice` without editing the agent.

## Change
Make `tool_choice` a `model_settings` field, plumbed through to the action completion only.

- Add `tool_choice: str | None = None` to `ModelSettings`.
- Exclude it from the generic `model_dump()` in `_completion` so it never leaks into the (tool-less) tool-shortlisting completion.
- Pass it on the action completion only when set.

## Usage
```
--agent-json '{"model_settings": {"tool_choice": "required"}}'
```

## Compatibility
`tool_choice` defaults to `None`, which is omitted from the request, so litellm keeps applying `"auto"`. No behavior change for existing runs.
