### PR TITLE
fix(tau2): Python 3.12 compat + tau2 v2.3 API + Vertex AI location

### DIFF
--- a/src/exgentic/benchmarks/tau2/tau2_eval.py
+++ b/src/exgentic/benchmarks/tau2/tau2_eval.py
@@ -239,9 +239,15 @@ class TAU2Session(PairableProxySession):
 
         def _runner():
             self.logger.debug(f"Runner started PID:{os.getpid()}")
+            # Ensure litellm uses the correct Vertex AI location for Gemini 3.x models
+            import litellm as _litellm
+            if os.environ.get("VERTEXAI_LOCATION"):
+                _litellm.vertex_location = os.environ["VERTEXAI_LOCATION"]
+            if os.environ.get("VERTEXAI_PROJECT"):
+                _litellm.vertex_project = os.environ["VERTEXAI_PROJECT"]
             agent_name = self._cfg.agent
             if agent_name not in registry.get_agents():
-                registry.register_agent(TAU2ProxyAgent, agent_name)
+                registry.register_agent_factory(factory=TAU2ProxyAgent, name=agent_name)
             # Prepare session log path and redirect Tau2 console + prints
             log_fh = open(self.paths.benchmark_dir / "tau2_session.log", "a", encoding="utf-8")
             prev_console = ConsoleDisplay.console

--- a/src/exgentic/benchmarks/tau2/tau2_shim.py
+++ b/src/exgentic/benchmarks/tau2/tau2_shim.py
@@ -48,7 +48,7 @@ from tau2.data_model.message import (  # noqa: E402
     ToolMessage,
     UserMessage,
 )
-from tau2.data_model.simulation import Results, RunConfig, TerminationReason  # noqa: E402
+from tau2.data_model.simulation import Results, TextRunConfig as RunConfig, TerminationReason  # noqa: E402
 from tau2.environment.tool import Tool  # noqa: E402
 from tau2.metrics.agent_metrics import compute_metrics, is_successful  # noqa: E402
 from tau2.registry import registry  # noqa: E402


### PR DESCRIPTION
## Problem

The tau2 benchmark shim fails on Python 3.12+ with tau2 v2.3 and Gemini 3.x models on Vertex AI.

## Fixes (3 issues, 8 lines changed)

1. **RunConfig typing (Python 3.12+)**: `RunConfig = Union[TextRunConfig, VoiceRunConfig]` cannot be instantiated in Python 3.12+ (`TypeError: Cannot instantiate typing.Union`). Fixed by importing `TextRunConfig as RunConfig`.

2. **Agent registration API (tau2 v2.3)**: `registry.register_agent()` was renamed to `registry.register_agent_factory(factory, name)` in tau2 v2.3.

3. **Vertex AI location propagation**: Gemini 3.x models require `VERTEXAI_LOCATION=global` but the runner thread didn't propagate env vars to litellm module globals. The user simulator LLM call would hit `us-central1` (default) and get 404. Fixed by reading env vars and setting litellm globals in the runner thread.

## Testing

Verified with tau2 v2.3.2 on Python 3.12, `vertex_ai/gemini-3.1-flash-lite`:
- `evaluator.list_tasks()` returns 50 airline tasks, 10 mock tasks
- `session.start()` succeeds, returns actions
- First agent turn completes through the A2A adapter