### PR TITLE
fix(gsm8k): update dataset name to openai/gsm8k

### DIFF
--- a/src/exgentic/benchmarks/gsm8k/gsm8k_benchmark.py
+++ b/src/exgentic/benchmarks/gsm8k/gsm8k_benchmark.py
@@ -156,7 +156,7 @@ class GSM8kSession(Session):
         if session_id is not None:
             self._session_id = session_id
         idx = int(task_id)
-        row = load_dataset("gsm8k", "main", split=f"test[{idx}:{idx + 1}]")[0]
+        row = load_dataset("openai/gsm8k", "main", split=f"test[{idx}:{idx + 1}]")[0]
         self._question = row["question"]
         self._answer = row["answer"]
         self._task_id = idx


### PR DESCRIPTION
HuggingFace datasets library now requires namespace/name format. The gsm8k dataset moved to `openai/gsm8k`.

One-line fix.

Signed-off-by: alan blount <alan@zeroasterisk.com>