### PR TITLE
feat: cloud-native runner + pod-native SWE-bench sandbox (run evals in Kubernetes)

### DIFF
--- a/src/exgentic/adapters/runners/__init__.py
+++ b/src/exgentic/adapters/runners/__init__.py
@@ -133,8 +133,6 @@ def with_runner(
             "use_job",
             "health_timeout",
             "port_forward",
-            "docker_socket",
-            "sandbox",
         ):
             if key in kwargs:
                 k8s_kw[key] = kwargs.pop(key)

--- a/src/exgentic/adapters/runners/__init__.py
+++ b/src/exgentic/adapters/runners/__init__.py
@@ -122,6 +122,7 @@ def with_runner(
             "image",
             "namespace",
             "service_account",
+            "image_pull_secrets",
             "resources",
             "env_secrets",
             "env",

--- a/src/exgentic/adapters/runners/__init__.py
+++ b/src/exgentic/adapters/runners/__init__.py
@@ -11,6 +11,7 @@ Runners wrap any object and control where it executes:
 - ``service`` — HTTP service in a background thread
 - ``docker``  — HTTP service inside a Docker container
 - ``venv``    — HTTP service in an isolated uv virtual environment
+- ``kubernetes`` — HTTP service in a Kubernetes Pod (in-cluster, off the laptop)
 
 Usage::
 
@@ -27,7 +28,7 @@ from .transport import ObjectHost, ObjectProxy, Transport
 if TYPE_CHECKING:
     from ...core.context import Role
 
-RunnerName = Literal["direct", "thread", "process", "service", "docker", "venv"]
+RunnerName = Literal["direct", "thread", "process", "service", "docker", "venv", "kubernetes"]
 
 
 def _resolve_cls(cls: type | str) -> type:
@@ -110,6 +111,33 @@ def with_runner(
             if key in kwargs:
                 docker_kw[key] = kwargs.pop(key)
         return DockerRunner(cls, *args, role=role, **docker_kw, **kwargs).start()
+
+    if runner == "kubernetes":
+        from .kubernetes import KubernetesRunner
+
+        k8s_kw = {}
+        for key in (
+            "env_name",
+            "module_path",
+            "image",
+            "namespace",
+            "service_account",
+            "resources",
+            "env_secrets",
+            "env",
+            "volumes",
+            "security_context",
+            "node_selector",
+            "labels",
+            "use_job",
+            "health_timeout",
+            "port_forward",
+            "docker_socket",
+            "sandbox",
+        ):
+            if key in kwargs:
+                k8s_kw[key] = kwargs.pop(key)
+        return KubernetesRunner(cls, *args, role=role, **k8s_kw, **kwargs).start()
 
     if runner == "venv":
         from .venv import VenvRunner

--- a/src/exgentic/adapters/runners/kubernetes.py
+++ b/src/exgentic/adapters/runners/kubernetes.py
@@ -20,19 +20,25 @@ runtime *inside* the pod (there is no host Docker socket to bind-mount).
 When ``docker_socket=True`` the runner provisions one so the existing
 sibling-container + ``run_evaluation`` grading code runs unchanged:
 
-* ``sandbox="podman"`` (default) — rootless podman baked into the image,
-  exposed as ``DOCKER_HOST``; runs under the given (anyuid) service account.
-* ``sandbox="dind"`` — a privileged ``docker:dind`` sidecar sharing a socket
-  ``emptyDir``; the runner's ``DOCKER_HOST`` points at it.
+* ``sandbox="dind"`` — a privileged ``docker:dind`` sidecar runs ``dockerd``
+  and shares ``/var/run`` with the runner; ``DOCKER_HOST`` points at its
+  socket. Self-contained: works with any image.
+* ``sandbox="podman"`` (default) — rootless, no privileged. The runner image
+  must provide ``podman``; the runner starts ``podman system service`` on
+  ``unix:///tmp/podman.sock`` (backgrounded before ``exgentic serve``) and
+  points ``DOCKER_HOST`` at it. If the image has no podman, use ``dind``.
 
-A per-task k8s-Pod sandbox backend (no privileged) is intentionally out of
-scope for this runner.
+For SWE-bench specifically there is also a docker-free, non-privileged
+alternative that does not need this runner at all: a per-task Pod backend
+(``SWEBENCH_SANDBOX=kubernetes``) where each task's environment is its own Pod
+built from the instance image - see ``benchmarks/swebench/kube_sandbox.py``.
 """
 
 from __future__ import annotations
 
 import atexit
 import json
+import shlex
 import shutil
 import subprocess
 import time
@@ -242,10 +248,18 @@ class KubernetesRunner:
                     "env": [{"name": "DOCKER_TLS_CERTDIR", "value": ""}],
                     "volumeMounts": [{"name": "dind-sock", "mountPath": "/var/run"}],
                 })
-            else:  # rootless podman baked into the image
+            else:  # rootless podman served from inside the runner image
+                sock = "unix:///tmp/podman.sock"
                 runner_container.setdefault("env", []).append(
-                    {"name": "DOCKER_HOST", "value": "unix:///tmp/podman.sock"}
+                    {"name": "DOCKER_HOST", "value": sock}
                 )
+                # The image must provide podman; start its API service in the
+                # background, then exec the serve command so DOCKER_HOST is live.
+                inner = " ".join(shlex.quote(c) for c in serve_cmd)
+                runner_container["command"] = [
+                    "sh", "-c",
+                    f"podman system service --time=0 {sock} >/tmp/podman.log 2>&1 & exec {inner}",
+                ]
 
         spec: dict[str, Any] = {
             "restartPolicy": "Never",

--- a/src/exgentic/adapters/runners/kubernetes.py
+++ b/src/exgentic/adapters/runners/kubernetes.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""KubernetesRunner — runs the HTTP service inside a Kubernetes Pod.
+
+The cloud-native sibling of :class:`DockerRunner`: instead of ``docker run``
+on the laptop it creates a ConfigMap + Pod + ClusterIP Service running
+``exgentic serve``, waits for ``/health``, and returns the same
+``ObjectProxy`` over the same ``HTTPTransport``.  vLLM (or any model
+endpoint) is reached as an ordinary in-cluster Service — the eval lifecycle
+no longer lives on the laptop.
+
+Manifests are applied with ``kubectl apply`` as JSON (no PyYAML / k8s-client
+dependency).  Reach the service either over in-cluster DNS
+(``<svc>.<ns>.svc.cluster.local``) or, when driving from a laptop, over a
+``kubectl port-forward`` (``port_forward=True``).
+
+SWE-bench and other ``docker_socket=True`` benchmarks need a container
+runtime *inside* the pod (there is no host Docker socket to bind-mount).
+When ``docker_socket=True`` the runner provisions one so the existing
+sibling-container + ``run_evaluation`` grading code runs unchanged:
+
+* ``sandbox="podman"`` (default) — rootless podman baked into the image,
+  exposed as ``DOCKER_HOST``; runs under the given (anyuid) service account.
+* ``sandbox="dind"`` — a privileged ``docker:dind`` sidecar sharing a socket
+  ``emptyDir``; the runner's ``DOCKER_HOST`` points at it.
+
+A per-task k8s-Pod sandbox backend (no privileged) is intentionally out of
+scope for this runner.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from ...core.context import Role
+
+from ._utils import (
+    find_free_port,
+    inject_exgentic_env,
+    make_close,
+    prepare_subprocess_env,
+    serialize_kwargs,
+)
+from .service import HTTPTransport, _wait_for_health
+from .transport import ObjectProxy
+
+_RUNTIME_MOUNT = "/etc/exgentic/runtime.json"
+_DIND_IMAGE = "docker:27-dind"
+
+
+def _kubectl(*args: str, check: bool = True, stdin: str | None = None, **kwargs: Any) -> subprocess.CompletedProcess:
+    kubectl = shutil.which("kubectl") or shutil.which("oc")
+    if kubectl is None:
+        raise RuntimeError("kubectl (or oc) not found on PATH")
+    return subprocess.run([kubectl, *args], check=check, input=stdin, **kwargs)
+
+
+class KubernetesRunner:
+    """Start an ``exgentic serve`` Pod and return an ObjectProxy.
+
+    Parameters
+    ----------
+    target_cls:      Class to instantiate inside the pod (or ``"module:Class"``).
+    env_name/module_path: EnvironmentManager image lookup (mirrors DockerRunner).
+    image:           Container image (registry-pullable by the cluster). Required
+                     in practice — in-cluster builds are out of scope.
+    namespace:       Target namespace (default: current kube-context namespace).
+    service_account: ServiceAccount for the pod (e.g. one bound to anyuid/privileged).
+    resources:       Pod resource requests/limits dict.
+    env_secrets:     Secret names surfaced via ``envFrom: secretRef``.
+    env:             Extra literal env (merged over forwarded provider creds).
+    volumes:         ``{pvc_claim_name: mount_path}`` PVC mounts (e.g. shared outputs).
+    security_context: Container ``securityContext`` dict (runAsUser, privileged…).
+    node_selector:   Optional node pinning.
+    labels:          Extra pod/service labels.
+    use_job:         Wrap the pod in a Job (``ttlSecondsAfterFinished`` cleanup).
+    health_timeout:  Seconds to wait for ``/health`` (k8s scheduling is slow).
+    port_forward:    Reach the service via ``kubectl port-forward`` (laptop) vs
+                     in-cluster DNS (when the orchestrator itself runs in-cluster).
+    docker_socket:   Provision an in-pod container runtime (see ``sandbox``).
+    sandbox:         ``"podman"`` | ``"dind"`` — in-pod runtime when docker_socket.
+    """
+
+    def __init__(
+        self,
+        target_cls: type | str,
+        *args: Any,
+        env_name: str = "",
+        module_path: str = "",
+        image: str | None = None,
+        namespace: str | None = None,
+        service_account: str | None = None,
+        resources: dict[str, Any] | None = None,
+        env_secrets: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        volumes: dict[str, str] | None = None,
+        security_context: dict[str, Any] | None = None,
+        node_selector: dict[str, str] | None = None,
+        labels: dict[str, str] | None = None,
+        use_job: bool = False,
+        health_timeout: float = 180.0,
+        port_forward: bool = True,
+        docker_socket: bool = False,
+        sandbox: str = "podman",
+        role: Role | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if args:
+            raise ValueError(
+                "KubernetesRunner requires keyword-only constructor arguments. "
+                "Pass all arguments as kwargs instead of positional args."
+            )
+        self._target_cls = target_cls
+        self._kwargs = kwargs
+        self._env_name = env_name
+        self._module_path = module_path
+        self._image = image
+        self._namespace = namespace or self._current_namespace()
+        self._service_account = service_account
+        self._resources = resources
+        self._env_secrets = env_secrets or []
+        self._extra_env = env or {}
+        self._volumes = volumes or {}
+        self._security_context = security_context
+        self._node_selector = node_selector
+        self._extra_labels = labels or {}
+        self._use_job = use_job
+        self._health_timeout = health_timeout
+        self._port_forward = port_forward
+        self._docker_socket = docker_socket
+        self._sandbox = sandbox
+        self._role = role
+
+        self._name = f"exgentic-{uuid4().hex[:8]}"
+        self._local_port = find_free_port() if port_forward else 8080
+        self._pf_proc: subprocess.Popen | None = None
+        self._deleted = False
+
+    # ── helpers ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def _current_namespace() -> str:
+        try:
+            r = _kubectl(
+                "config", "view", "--minify", "-o", "jsonpath={..namespace}",
+                check=False, capture_output=True, text=True,
+            )
+            return r.stdout.strip() or "default"
+        except Exception:
+            return "default"
+
+    def _ensure_image(self) -> str:
+        if self._image:
+            return self._image
+        if not self._env_name:
+            raise RuntimeError(
+                "KubernetesRunner requires an 'image' (registry-pullable by the "
+                "cluster) or an 'env_name' with a pre-built EnvironmentManager image."
+            )
+        from ...environment.instance import get_manager
+
+        image = get_manager().docker_image(self._env_name)
+        if not image:
+            raise RuntimeError(
+                f"No pre-built image for env '{self._env_name}'. Build and push it to "
+                "a cluster-pullable registry, then pass image=<ref> (in-cluster builds "
+                "are out of scope for KubernetesRunner)."
+            )
+        return image
+
+    def _owner_labels(self) -> dict[str, str]:
+        from ...utils.container_reaper import LABEL_OWNER_PID, LABEL_OWNER_TOKEN, OWN_TOKEN
+        import os
+
+        return {
+            "app": self._name,
+            LABEL_OWNER_PID.replace(".", "_"): str(os.getpid()),
+            LABEL_OWNER_TOKEN.replace(".", "_"): OWN_TOKEN,
+            **self._extra_labels,
+        }
+
+    # ── manifest builders ────────────────────────────────────────────
+
+    def _pod_spec(self, image: str, cls_ref: str, kwargs_flag: str, kwargs_value: str,
+                  env: dict[str, str], runtime_json: str | None) -> dict[str, Any]:
+        serve_cmd = [
+            "exgentic", "serve", "--cls", cls_ref, kwargs_flag, kwargs_value,
+            "--host", "0.0.0.0", "--port", "8080",
+        ]
+        container_env = [{"name": k, "value": v} for k, v in {**env, **self._extra_env}.items()]
+        volumes: list[dict[str, Any]] = []
+        mounts: list[dict[str, Any]] = []
+        if runtime_json is not None:
+            volumes.append({"name": "runtime", "configMap": {"name": f"{self._name}-cfg"}})
+            mounts.append({"name": "runtime", "mountPath": "/etc/exgentic", "readOnly": True})
+        for claim, path in self._volumes.items():
+            vname = f"pvc-{claim}"
+            volumes.append({"name": vname, "persistentVolumeClaim": {"claimName": claim}})
+            mounts.append({"name": vname, "mountPath": path})
+
+        runner_container: dict[str, Any] = {
+            "name": "runner",
+            "image": image,
+            "command": serve_cmd,
+            "ports": [{"containerPort": 8080}],
+            "env": container_env,
+            "volumeMounts": mounts,
+        }
+        if self._env_secrets:
+            runner_container["envFrom"] = [{"secretRef": {"name": s}} for s in self._env_secrets]
+        if self._resources:
+            runner_container["resources"] = self._resources
+        if self._security_context:
+            runner_container["securityContext"] = self._security_context
+
+        containers = [runner_container]
+
+        # SWE-bench & friends: a container runtime inside the pod.
+        if self._docker_socket:
+            if self._sandbox == "dind":
+                sock = {"name": "dind-sock", "emptyDir": {}}
+                volumes.append(sock)
+                mounts.append({"name": "dind-sock", "mountPath": "/var/run"})
+                runner_container.setdefault("env", []).append(
+                    {"name": "DOCKER_HOST", "value": "unix:///var/run/docker.sock"}
+                )
+                containers.append({
+                    "name": "dind",
+                    "image": _DIND_IMAGE,
+                    "securityContext": {"privileged": True},
+                    "env": [{"name": "DOCKER_TLS_CERTDIR", "value": ""}],
+                    "volumeMounts": [{"name": "dind-sock", "mountPath": "/var/run"}],
+                })
+            else:  # rootless podman baked into the image
+                runner_container.setdefault("env", []).append(
+                    {"name": "DOCKER_HOST", "value": "unix:///tmp/podman.sock"}
+                )
+
+        spec: dict[str, Any] = {
+            "restartPolicy": "Never",
+            "containers": containers,
+            "volumes": volumes,
+        }
+        if self._service_account:
+            spec["serviceAccountName"] = self._service_account
+        if self._node_selector:
+            spec["nodeSelector"] = self._node_selector
+        return spec
+
+    def _manifests(self, image: str, cls_ref: str, kwargs_flag: str, kwargs_value: str,
+                   env: dict[str, str], runtime_json: str | None) -> dict[str, Any]:
+        labels = self._owner_labels()
+        items: list[dict[str, Any]] = []
+
+        if runtime_json is not None:
+            items.append({
+                "apiVersion": "v1", "kind": "ConfigMap",
+                "metadata": {"name": f"{self._name}-cfg", "namespace": self._namespace, "labels": labels},
+                "data": {"runtime.json": runtime_json},
+            })
+
+        pod_spec = self._pod_spec(image, cls_ref, kwargs_flag, kwargs_value, env, runtime_json)
+        pod_meta = {"labels": labels}
+        if self._use_job:
+            items.append({
+                "apiVersion": "batch/v1", "kind": "Job",
+                "metadata": {"name": self._name, "namespace": self._namespace, "labels": labels},
+                "spec": {
+                    "ttlSecondsAfterFinished": 3600, "backoffLimit": 0,
+                    "template": {"metadata": pod_meta, "spec": pod_spec},
+                },
+            })
+        else:
+            items.append({
+                "apiVersion": "v1", "kind": "Pod",
+                "metadata": {"name": self._name, "namespace": self._namespace, **pod_meta},
+                "spec": pod_spec,
+            })
+
+        items.append({
+            "apiVersion": "v1", "kind": "Service",
+            "metadata": {"name": f"{self._name}-svc", "namespace": self._namespace, "labels": labels},
+            "spec": {
+                "selector": {"app": self._name},
+                "ports": [{"port": 8080, "targetPort": 8080}],
+            },
+        })
+        return {"apiVersion": "v1", "kind": "List", "items": items}
+
+    # ── lifecycle ────────────────────────────────────────────────────
+
+    def start(self) -> ObjectProxy:
+        image = self._ensure_image()
+        cls_ref = (
+            self._target_cls if isinstance(self._target_cls, str)
+            else f"{self._target_cls.__module__}:{self._target_cls.__qualname__}"
+        )
+        kwargs_flag, kwargs_value = serialize_kwargs(self._kwargs)
+
+        env = prepare_subprocess_env()
+        inject_exgentic_env(env, role=self._role)
+        # runtime.json travels via a ConfigMap (no host bind mount in k8s).
+        runtime_json: str | None = None
+        runtime_file = env.pop("EXGENTIC_RUNTIME_FILE", None)
+        if runtime_file and Path(runtime_file).is_file():
+            runtime_json = Path(runtime_file).read_text()
+            env["EXGENTIC_RUNTIME_FILE"] = _RUNTIME_MOUNT
+
+        manifests = self._manifests(image, cls_ref, kwargs_flag, kwargs_value, env, runtime_json)
+        _kubectl("apply", "-f", "-", stdin=json.dumps(manifests), capture_output=True, text=True)
+        atexit.register(self._delete)
+
+        url = self._connect()
+        try:
+            _wait_for_health(url, timeout=self._health_timeout)
+        except TimeoutError:
+            logs = _kubectl("logs", f"pod/{self._name}", "-n", self._namespace, "-c", "runner",
+                            check=False, capture_output=True, text=True)
+            desc = _kubectl("describe", "pod", self._name, "-n", self._namespace,
+                            check=False, capture_output=True, text=True)
+            self._delete()
+            raise TimeoutError(
+                f"Pod {self._name} did not become healthy within {self._health_timeout}s.\n"
+                f"--- describe ---\n{desc.stdout}\n--- logs ---\n{logs.stdout}\n{logs.stderr}"
+            ) from None
+
+        transport = HTTPTransport(url, timeout=600.0)
+        proxy = ObjectProxy(transport)
+        object.__setattr__(proxy, "close", make_close(transport, self._delete))
+        return proxy
+
+    def _connect(self) -> str:
+        """Return the base URL, starting a port-forward when off-cluster."""
+        if not self._port_forward:
+            return f"http://{self._name}-svc.{self._namespace}.svc.cluster.local:8080"
+        # Wait for the pod to be Ready before port-forwarding (the svc has no
+        # endpoints until then, and port-forward to a Pod needs it scheduled).
+        _kubectl("wait", f"pod/{self._name}", "-n", self._namespace,
+                 "--for=condition=Ready", f"--timeout={int(self._health_timeout)}s",
+                 check=False, capture_output=True, text=True)
+        kubectl = shutil.which("kubectl") or shutil.which("oc")
+        self._pf_proc = subprocess.Popen(
+            [kubectl, "port-forward", "-n", self._namespace,
+             f"svc/{self._name}-svc", f"{self._local_port}:8080"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        time.sleep(1.5)
+        return f"http://127.0.0.1:{self._local_port}"
+
+    def _delete(self) -> None:
+        if self._deleted:
+            return
+        self._deleted = True
+        if self._pf_proc is not None:
+            self._pf_proc.terminate()
+            self._pf_proc = None
+        from ...utils.container_reaper import LABEL_OWNER_TOKEN, OWN_TOKEN
+
+        sel = f"{LABEL_OWNER_TOKEN.replace('.', '_')}={OWN_TOKEN}"
+        _kubectl(
+            "delete", "pod,job,service,configmap", "-n", self._namespace,
+            "-l", sel, "--ignore-not-found", "--wait=false",
+            check=False, capture_output=True, text=True,
+        )

--- a/src/exgentic/adapters/runners/kubernetes.py
+++ b/src/exgentic/adapters/runners/kubernetes.py
@@ -15,30 +15,17 @@ dependency).  Reach the service either over in-cluster DNS
 (``<svc>.<ns>.svc.cluster.local``) or, when driving from a laptop, over a
 ``kubectl port-forward`` (``port_forward=True``).
 
-SWE-bench and other ``docker_socket=True`` benchmarks need a container
-runtime *inside* the pod (there is no host Docker socket to bind-mount).
-When ``docker_socket=True`` the runner provisions one so the existing
-sibling-container + ``run_evaluation`` grading code runs unchanged:
-
-* ``sandbox="dind"`` — a privileged ``docker:dind`` sidecar runs ``dockerd``
-  and shares ``/var/run`` with the runner; ``DOCKER_HOST`` points at its
-  socket. Self-contained: works with any image.
-* ``sandbox="podman"`` (default) — rootless, no privileged. The runner image
-  must provide ``podman``; the runner starts ``podman system service`` on
-  ``unix:///tmp/podman.sock`` (backgrounded before ``exgentic serve``) and
-  points ``DOCKER_HOST`` at it. If the image has no podman, use ``dind``.
-
-For SWE-bench specifically there is also a docker-free, non-privileged
-alternative that does not need this runner at all: a per-task Pod backend
-(``SWEBENCH_SANDBOX=kubernetes``) where each task's environment is its own Pod
-built from the instance image - see ``benchmarks/swebench/kube_sandbox.py``.
+The runner is deliberately a thin "run ``exgentic serve`` in a Pod" mechanism
+with no container-runtime concerns. SWE-bench, which needs a per-task
+environment, has its own docker-free, non-privileged backend that creates one
+Pod per task from the instance image - see
+``benchmarks/swebench/kube_sandbox.py`` (``SWEBENCH_SANDBOX=kubernetes``).
 """
 
 from __future__ import annotations
 
 import atexit
 import json
-import shlex
 import shutil
 import subprocess
 import time
@@ -60,7 +47,6 @@ from .service import HTTPTransport, _wait_for_health
 from .transport import ObjectProxy
 
 _RUNTIME_MOUNT = "/etc/exgentic/runtime.json"
-_DIND_IMAGE = "docker:27-dind"
 
 
 def _kubectl(*args: str, check: bool = True, stdin: str | None = None, **kwargs: Any) -> subprocess.CompletedProcess:
@@ -92,8 +78,6 @@ class KubernetesRunner:
     health_timeout:  Seconds to wait for ``/health`` (k8s scheduling is slow).
     port_forward:    Reach the service via ``kubectl port-forward`` (laptop) vs
                      in-cluster DNS (when the orchestrator itself runs in-cluster).
-    docker_socket:   Provision an in-pod container runtime (see ``sandbox``).
-    sandbox:         ``"podman"`` | ``"dind"`` — in-pod runtime when docker_socket.
     """
 
     def __init__(
@@ -116,8 +100,6 @@ class KubernetesRunner:
         use_job: bool = False,
         health_timeout: float = 180.0,
         port_forward: bool = True,
-        docker_socket: bool = False,
-        sandbox: str = "podman",
         role: Role | None = None,
         **kwargs: Any,
     ) -> None:
@@ -144,8 +126,6 @@ class KubernetesRunner:
         self._use_job = use_job
         self._health_timeout = health_timeout
         self._port_forward = port_forward
-        self._docker_socket = docker_socket
-        self._sandbox = sandbox
         self._role = role
 
         self._name = f"exgentic-{uuid4().hex[:8]}"
@@ -230,40 +210,9 @@ class KubernetesRunner:
         if self._security_context:
             runner_container["securityContext"] = self._security_context
 
-        containers = [runner_container]
-
-        # SWE-bench & friends: a container runtime inside the pod.
-        if self._docker_socket:
-            if self._sandbox == "dind":
-                sock = {"name": "dind-sock", "emptyDir": {}}
-                volumes.append(sock)
-                mounts.append({"name": "dind-sock", "mountPath": "/var/run"})
-                runner_container.setdefault("env", []).append(
-                    {"name": "DOCKER_HOST", "value": "unix:///var/run/docker.sock"}
-                )
-                containers.append({
-                    "name": "dind",
-                    "image": _DIND_IMAGE,
-                    "securityContext": {"privileged": True},
-                    "env": [{"name": "DOCKER_TLS_CERTDIR", "value": ""}],
-                    "volumeMounts": [{"name": "dind-sock", "mountPath": "/var/run"}],
-                })
-            else:  # rootless podman served from inside the runner image
-                sock = "unix:///tmp/podman.sock"
-                runner_container.setdefault("env", []).append(
-                    {"name": "DOCKER_HOST", "value": sock}
-                )
-                # The image must provide podman; start its API service in the
-                # background, then exec the serve command so DOCKER_HOST is live.
-                inner = " ".join(shlex.quote(c) for c in serve_cmd)
-                runner_container["command"] = [
-                    "sh", "-c",
-                    f"podman system service --time=0 {sock} >/tmp/podman.log 2>&1 & exec {inner}",
-                ]
-
         spec: dict[str, Any] = {
             "restartPolicy": "Never",
-            "containers": containers,
+            "containers": [runner_container],
             "volumes": volumes,
         }
         if self._service_account:

--- a/src/exgentic/adapters/runners/kubernetes.py
+++ b/src/exgentic/adapters/runners/kubernetes.py
@@ -99,6 +99,7 @@ class KubernetesRunner:
         image: str | None = None,
         namespace: str | None = None,
         service_account: str | None = None,
+        image_pull_secrets: list[str] | None = None,
         resources: dict[str, Any] | None = None,
         env_secrets: list[str] | None = None,
         env: dict[str, str] | None = None,
@@ -126,6 +127,7 @@ class KubernetesRunner:
         self._image = image
         self._namespace = namespace or self._current_namespace()
         self._service_account = service_account
+        self._image_pull_secrets = image_pull_secrets or []
         self._resources = resources
         self._env_secrets = env_secrets or []
         self._extra_env = env or {}
@@ -252,6 +254,8 @@ class KubernetesRunner:
         }
         if self._service_account:
             spec["serviceAccountName"] = self._service_account
+        if self._image_pull_secrets:
+            spec["imagePullSecrets"] = [{"name": n} for n in self._image_pull_secrets]
         if self._node_selector:
             spec["nodeSelector"] = self._node_selector
         return spec
@@ -363,11 +367,12 @@ class KubernetesRunner:
         if self._pf_proc is not None:
             self._pf_proc.terminate()
             self._pf_proc = None
-        from ...utils.container_reaper import LABEL_OWNER_TOKEN, OWN_TOKEN
-
-        sel = f"{LABEL_OWNER_TOKEN.replace('.', '_')}={OWN_TOKEN}"
+        # Scope teardown to THIS instance (app=<name>): concurrent per-task
+        # sessions share one owner token, so deleting by token would reap
+        # siblings. The owner-token label stays on the resources for the
+        # process-wide reaper's best-effort sweep on abnormal exit.
         _kubectl(
             "delete", "pod,job,service,configmap", "-n", self._namespace,
-            "-l", sel, "--ignore-not-found", "--wait=false",
+            "-l", f"app={self._name}", "--ignore-not-found", "--wait=false",
             check=False, capture_output=True, text=True,
         )

--- a/src/exgentic/agents/litellm_tool_calling/instance.py
+++ b/src/exgentic/agents/litellm_tool_calling/instance.py
@@ -86,17 +86,19 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
             ]
         ] = []
         self._step_count = 0
-        # Repeated-tool-call loop breaker. Gemma-4 (and reasoning models generally)
+        # Repeated-tool-call HARD loop breaker. Gemma-4 (and reasoning models generally)
         # can degenerate into re-issuing the *identical* tool call forever - e.g. re-
         # running the same reproduction script hundreds of times without ever editing
-        # the source (vLLM #40080; the logit distribution collapses toward repeating
-        # and sampler penalties only "partially help"). When the same (name, arguments)
-        # is emitted N times in a row, queue a nudge that gets appended to the next tool
-        # result so the model gets *different* feedback and breaks out of the loop.
+        # the source (vLLM #40080; the logit distribution collapses toward repeating and
+        # sampler penalties only "partially help" - a soft nudge gets ignored). So once the
+        # same (name, arguments) repeats _max_repeated_tool_calls times in a row, react()
+        # REFUSES to execute it: it injects a synthetic "blocked" tool result and re-queries
+        # the model in-place so it must pick a different action. After _max_hard_block_retries
+        # unproductive re-queries the session is ended (the trajectory has collapsed).
         self._max_repeated_tool_calls = 3
+        self._max_hard_block_retries = 3
         self._last_tool_sig = None
         self._tool_repeat = 0
-        self._repeat_nudge: str | None = None
         self._cost_data = LiteLLMCostReport.initialize_empty(model_name=self.model)
 
         # Check model accessibility
@@ -166,46 +168,28 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
                     content = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
                 except TypeError:
                     content = str(value)
-                if self._repeat_nudge:
-                    content = f"{content}\n\n[SYSTEM NOTICE] {self._repeat_nudge}"
-                    self._repeat_nudge = None
                 self._add_message(ChatCompletionToolMessage(role="tool", tool_call_id=tool_call_id, content=content))
             else:
                 self._add_message(ChatCompletionUserMessage(role="user", content=str(obs)))
 
-    def _check_repeated_tool_calls(self, tool_calls: list) -> None:
-        """Detect a degenerate loop where the model re-issues the identical tool call.
+    def _repeat_count(self, tool_calls: list) -> int:
+        """Track consecutive identical tool-call signatures; return the current run length.
 
-        Tracks the (name, arguments) signature of each turn's tool calls. After
-        ``self._max_repeated_tool_calls`` identical calls in a row, queues a nudge that
-        ``_observe`` appends to the next tool result, so the model sees *different* text
-        and breaks out instead of looping forever (gemma-4 repetition collapse, vLLM
-        #40080). Self-resets after nudging so it fires again if the loop continues.
+        Gemma-4 (and reasoning models) can collapse into re-issuing the *identical* tool
+        call forever (vLLM #40080). ``react`` uses this count to HARD-BLOCK execution once
+        the same (name, arguments) repeats ``_max_repeated_tool_calls`` times in a row.
         """
         if not tool_calls:
             self._last_tool_sig = None
             self._tool_repeat = 0
-            return
+            return 0
         sig = tuple((tc.get("name"), tc.get("arguments")) for tc in tool_calls)
         if sig == self._last_tool_sig:
             self._tool_repeat += 1
         else:
             self._last_tool_sig = sig
             self._tool_repeat = 1
-        if self._tool_repeat >= self._max_repeated_tool_calls:
-            self.logger.warning(
-                "Repeated identical tool call x%d - injecting loop-breaker nudge",
-                self._tool_repeat,
-            )
-            self._repeat_nudge = (
-                f"You have issued this exact same command {self._tool_repeat} times in a "
-                "row and received the same result each time. Stop repeating it - the "
-                "output already confirms the behavior. Take a DIFFERENT action now: edit "
-                "the relevant source file to fix the bug (then re-run to verify), or "
-                "inspect a different file. Do not run this same command again."
-            )
-            self._tool_repeat = 0
-            self._last_tool_sig = None
+        return self._tool_repeat
 
     def _assistant_tools(self) -> list[dict[str, Any]]:
         """Returns list of available tools in openai format.
@@ -369,23 +353,40 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
 
         self._observe(observation)
 
-        response = self._completion(
-            model=self.model,
-            messages=self.messages,
-            tools=self._assistant_tools(),
-            **({"tool_choice": self.model_settings.tool_choice} if self.model_settings.tool_choice else {}),
-            caching=self._use_cache,
-        )
+        # Hard loop interrupt: if the model emits the *identical* tool call past the repeat
+        # threshold, refuse to execute it - inject a synthetic "blocked" tool result and
+        # re-query the model in-place so it must choose a DIFFERENT action. After
+        # _max_hard_block_retries unproductive re-queries, end the session (the trajectory
+        # has provably collapsed; vLLM #40080). Re-queries do NOT consume an agent step.
+        hard_blocks = 0
+        while True:
+            response = self._completion(
+                model=self.model,
+                messages=self.messages,
+                tools=self._assistant_tools(),
+                **({"tool_choice": self.model_settings.tool_choice} if self.model_settings.tool_choice else {}),
+                caching=self._use_cache,
+            )
 
-        self._register_cost(response.usage)
+            self._register_cost(response.usage)
 
-        choice = response["choices"][0]
-        message = choice["message"]
-        finish_reason = choice.get("finish_reason")
+            choice = response["choices"][0]
+            message = choice["message"]
+            finish_reason = choice.get("finish_reason")
 
-        if finish_reason == "tool_calls":
+            if finish_reason != "tool_calls":
+                actions = MessageAction(arguments=Message(content=message.content))
+                self._add_message(
+                    ChatCompletionAssistantMessage(
+                        role="assistant",
+                        content=message.content,
+                    )
+                )
+                self.logger.info(f"Invoking action: {actions}")
+                return actions
+
             tool_calls = self._extract_tool_calls(message)
-            self._check_repeated_tool_calls(tool_calls)
+            repeat = self._repeat_count(tool_calls)
             self._add_message(
                 ChatCompletionAssistantMessage(
                     role="assistant",
@@ -402,18 +403,42 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
                     ],
                 )
             )
-            actions = self._registry.tool_calls_to_action(tool_calls)
-        else:
-            actions = MessageAction(arguments=Message(content=message.content))
-            self._add_message(
-                ChatCompletionAssistantMessage(
-                    role="assistant",
-                    content=message.content,
-                )
-            )
 
-        self.logger.info(f"Invoking action: {actions}")
-        return actions
+            if tool_calls and repeat >= self._max_repeated_tool_calls:
+                if hard_blocks >= self._max_hard_block_retries:
+                    self.logger.warning(
+                        "Finished: identical tool call still repeating after %d hard blocks "
+                        "- ending degenerate session",
+                        hard_blocks,
+                    )
+                    return None
+                hard_blocks += 1
+                self.logger.warning(
+                    "HARD-BLOCK identical tool call x%d (block %d/%d) - refusing to execute, re-querying",
+                    repeat,
+                    hard_blocks,
+                    self._max_hard_block_retries,
+                )
+                block_msg = (
+                    f"[BLOCKED] This exact command was just issued {repeat} times in a row and "
+                    "was NOT executed. Repeating it cannot make progress - the result will not "
+                    "change. You MUST take a DIFFERENT action now: edit the relevant source file "
+                    "with str_replace/create to fix the bug, view a different file, or call "
+                    "finish if you are done. Do not issue this same command again."
+                )
+                for tool_call in tool_calls:
+                    self._add_message(
+                        ChatCompletionToolMessage(
+                            role="tool",
+                            tool_call_id=tool_call["id"],
+                            content=block_msg,
+                        )
+                    )
+                continue
+
+            actions = self._registry.tool_calls_to_action(tool_calls)
+            self.logger.info(f"Invoking action: {actions}")
+            return actions
 
     def _completion(self, **kwargs):
         call_kwargs = self.model_settings.model_dump(

--- a/src/exgentic/agents/litellm_tool_calling/instance.py
+++ b/src/exgentic/agents/litellm_tool_calling/instance.py
@@ -99,6 +99,12 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
         self._max_hard_block_retries = 3
         self._last_tool_sig = None
         self._tool_repeat = 0
+        # The model can also degenerate into text-only responses (no tool call) forever:
+        # exgentic replies "Sending a message is not allowed" and the model repeats. The
+        # hard-block only catches repeated TOOL CALLS, so cap consecutive no-action
+        # (message) responses and end the session once exceeded.
+        self._max_consecutive_messages = 5
+        self._consecutive_messages = 0
         self._cost_data = LiteLLMCostReport.initialize_empty(model_name=self.model)
 
         # Check model accessibility
@@ -375,6 +381,17 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
             finish_reason = choice.get("finish_reason")
 
             if finish_reason != "tool_calls":
+                # Text-only response = no valid action. The model degenerates into emitting
+                # these forever (each gets "Sending a message is not allowed"); end the
+                # session once it repeats past the cap (the trajectory has collapsed).
+                self._consecutive_messages += 1
+                if self._consecutive_messages >= self._max_consecutive_messages:
+                    self.logger.warning(
+                        "Finished: %d consecutive no-action (text-only) responses "
+                        "- ending degenerate session",
+                        self._consecutive_messages,
+                    )
+                    return None
                 actions = MessageAction(arguments=Message(content=message.content))
                 self._add_message(
                     ChatCompletionAssistantMessage(
@@ -436,6 +453,7 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
                     )
                 continue
 
+            self._consecutive_messages = 0  # valid action -> reset the no-action loop counter
             actions = self._registry.tool_calls_to_action(tool_calls)
             self.logger.info(f"Invoking action: {actions}")
             return actions

--- a/src/exgentic/agents/litellm_tool_calling/instance.py
+++ b/src/exgentic/agents/litellm_tool_calling/instance.py
@@ -86,6 +86,17 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
             ]
         ] = []
         self._step_count = 0
+        # Repeated-tool-call loop breaker. Gemma-4 (and reasoning models generally)
+        # can degenerate into re-issuing the *identical* tool call forever - e.g. re-
+        # running the same reproduction script hundreds of times without ever editing
+        # the source (vLLM #40080; the logit distribution collapses toward repeating
+        # and sampler penalties only "partially help"). When the same (name, arguments)
+        # is emitted N times in a row, queue a nudge that gets appended to the next tool
+        # result so the model gets *different* feedback and breaks out of the loop.
+        self._max_repeated_tool_calls = 3
+        self._last_tool_sig = None
+        self._tool_repeat = 0
+        self._repeat_nudge: str | None = None
         self._cost_data = LiteLLMCostReport.initialize_empty(model_name=self.model)
 
         # Check model accessibility
@@ -155,9 +166,46 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
                     content = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
                 except TypeError:
                     content = str(value)
+                if self._repeat_nudge:
+                    content = f"{content}\n\n[SYSTEM NOTICE] {self._repeat_nudge}"
+                    self._repeat_nudge = None
                 self._add_message(ChatCompletionToolMessage(role="tool", tool_call_id=tool_call_id, content=content))
             else:
                 self._add_message(ChatCompletionUserMessage(role="user", content=str(obs)))
+
+    def _check_repeated_tool_calls(self, tool_calls: list) -> None:
+        """Detect a degenerate loop where the model re-issues the identical tool call.
+
+        Tracks the (name, arguments) signature of each turn's tool calls. After
+        ``self._max_repeated_tool_calls`` identical calls in a row, queues a nudge that
+        ``_observe`` appends to the next tool result, so the model sees *different* text
+        and breaks out instead of looping forever (gemma-4 repetition collapse, vLLM
+        #40080). Self-resets after nudging so it fires again if the loop continues.
+        """
+        if not tool_calls:
+            self._last_tool_sig = None
+            self._tool_repeat = 0
+            return
+        sig = tuple((tc.get("name"), tc.get("arguments")) for tc in tool_calls)
+        if sig == self._last_tool_sig:
+            self._tool_repeat += 1
+        else:
+            self._last_tool_sig = sig
+            self._tool_repeat = 1
+        if self._tool_repeat >= self._max_repeated_tool_calls:
+            self.logger.warning(
+                "Repeated identical tool call x%d - injecting loop-breaker nudge",
+                self._tool_repeat,
+            )
+            self._repeat_nudge = (
+                f"You have issued this exact same command {self._tool_repeat} times in a "
+                "row and received the same result each time. Stop repeating it - the "
+                "output already confirms the behavior. Take a DIFFERENT action now: edit "
+                "the relevant source file to fix the bug (then re-run to verify), or "
+                "inspect a different file. Do not run this same command again."
+            )
+            self._tool_repeat = 0
+            self._last_tool_sig = None
 
     def _assistant_tools(self) -> list[dict[str, Any]]:
         """Returns list of available tools in openai format.
@@ -337,6 +385,7 @@ class LiteLLMToolCallingAgentInstance(AgentInstance):
 
         if finish_reason == "tool_calls":
             tool_calls = self._extract_tool_calls(message)
+            self._check_repeated_tool_calls(tool_calls)
             self._add_message(
                 ChatCompletionAssistantMessage(
                     role="assistant",

--- a/src/exgentic/benchmarks/swebench/config.yaml
+++ b/src/exgentic/benchmarks/swebench/config.yaml
@@ -5,7 +5,9 @@ session:
   timeout: 1000                   # Default timeout for bash commands (seconds)
   environment_pull_timeout: 600   # Timeout for Docker container startup/pull (seconds)
   observation_size_limit: 10000   # Max characters in observation output
-  max_interactions: 200           # Max actions per session (null for unlimited)
+  max_interactions: 1000          # Max actions per session (null for unlimited).
+                                  # Must exceed --max-steps (500) so the step cap,
+                                  # not this action cap, is the binding limit.
   timeout_template: |
     The last command <command>{command}<command> timed out and has been killed.
     The output of the command was:

--- a/src/exgentic/benchmarks/swebench/kube_sandbox.py
+++ b/src/exgentic/benchmarks/swebench/kube_sandbox.py
@@ -178,9 +178,11 @@ def grade_in_pod(env: KubernetesEnvironment, instance: dict, model_patch: str,
 
     from .swebench_evaluation import HarnessResult, is_patch_valid
 
+    import os
+
     instance_id = instance["instance_id"]
     valid = is_patch_valid(model_patch)
-    ts = make_test_spec(instance)
+    ts = make_test_spec(instance, namespace=os.environ.get("SWEBENCH_IMAGE_NAMESPACE", "swebench"))
     base = instance["base_commit"]
 
     # Clean checkout at base, then apply exactly the submitted patch (matches

--- a/src/exgentic/benchmarks/swebench/kube_sandbox.py
+++ b/src/exgentic/benchmarks/swebench/kube_sandbox.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shlex
 import shutil
 import subprocess
@@ -69,6 +70,12 @@ class KubernetesEnvironment:
         self.image_pull_secrets = image_pull_secrets or []
         self.cwd = cwd
         self.timeout = timeout
+        # Pod lifetime is decoupled from the per-command timeout: a session can run
+        # for far longer than any single bash command (esp. middleware modes whose
+        # per-step latency is higher), and the pod must outlive the WHOLE session so
+        # grade_in_pod can still kubectl-exec into it at the end. If the pod's sleep
+        # expired mid-session the task silently went ungraded. Generous, env-tunable.
+        self.pod_ttl = int(os.environ.get("SWEBENCH_POD_TTL", "14400"))
         self.pull_timeout = pull_timeout
         self.env = env or {}
         self.pod_name = f"swebench-{uuid4().hex[:8]}"
@@ -81,8 +88,9 @@ class KubernetesEnvironment:
             "name": "task",
             "image": self.image,
             # The instance image's filesystem (repo at /testbed, conda env) is
-            # what we exec into; just keep it alive.
-            "command": ["sleep", str(self.timeout)],
+            # what we exec into; keep it alive for the whole session (pod_ttl),
+            # NOT just one command timeout, so end-of-session grading can exec in.
+            "command": ["sleep", str(self.pod_ttl)],
             "workingDir": self.cwd,
             "imagePullPolicy": "IfNotPresent",
         }

--- a/src/exgentic/benchmarks/swebench/kube_sandbox.py
+++ b/src/exgentic/benchmarks/swebench/kube_sandbox.py
@@ -208,10 +208,26 @@ def grade_in_pod(env: KubernetesEnvironment, instance: dict, model_patch: str,
         KEY_PREDICTION: model_patch or "",
         "model_name_or_path": "exgentic",
     }
-    report = get_eval_report(ts, prediction, str(test_output_path), include_tests_status=True)
-    logger.info(f"KUBE | grade {instance_id}: resolved={report.get(instance_id, {}).get('resolved')}")
+    per_instance = get_eval_report(ts, prediction, str(test_output_path), include_tests_status=True)
+    inst = per_instance.get(instance_id, {})
+    resolved = bool(inst.get("resolved", False))
+    logger.info(f"KUBE | grade {instance_id}: resolved={resolved}")
+
+    # The score is assembled from two shapes (matching the docker harness):
+    #  (1) a per-instance report.json in benchmark_dir, scanned for resolved +
+    #      per-test (FAIL_TO_PASS / PASS_TO_PASS) results;
+    #  (2) the run-summary shape consumed by _apply_harness_data.
+    try:
+        (test_output_path.parent / "report.json").write_text(json.dumps(per_instance))
+    except OSError as e:  # pragma: no cover - best effort
+        logger.warning(f"KUBE | could not write report.json: {e}")
+    summary = {
+        "submitted_ids": [instance_id],
+        "completed_ids": [instance_id],
+        "resolved_instances": 1 if resolved else 0,
+    }
     return HarnessResult(
-        harness_report=report,
+        harness_report=summary,
         patch=model_patch or "",
         patch_valid=valid,
         harness_ran=True,

--- a/src/exgentic/benchmarks/swebench/kube_sandbox.py
+++ b/src/exgentic/benchmarks/swebench/kube_sandbox.py
@@ -216,7 +216,21 @@ def grade_in_pod(env: KubernetesEnvironment, instance: dict, model_patch: str,
         if ap["returncode"] != 0:
             logger.warning(f"KUBE | model patch did not apply cleanly:\n{ap['output'][-2000:]}")
 
-    env.write_file("/eval.sh", ts.eval_script)
+    # Old SWE-bench repos (astropy era) build their editable install via
+    # setuptools.dep_util, removed in setuptools>=70. If the grading env's setuptools
+    # is too new, the rebuild + conftest import fail silently and pytest can't collect
+    # -> every FAIL_TO_PASS is marked failed even when the fix is correct. Pin <70 in
+    # the runtime env (legacy setup.py uses the *runtime* setuptools, so PIP_CONSTRAINT
+    # alone is not enough) only when dep_util is actually missing, and constrain later
+    # pip so the eval script can't re-upgrade past it. No-op for envs already <70.
+    setuptools_guard = (
+        "source /opt/miniconda3/bin/activate testbed 2>/dev/null || true\n"
+        "printf 'setuptools<70\\n' > /tmp/exg_setuptools_constraint.txt\n"
+        "export PIP_CONSTRAINT=/tmp/exg_setuptools_constraint.txt\n"
+        "python -c 'import setuptools.dep_util' 2>/dev/null || "
+        "pip install 'setuptools<70' -q 2>/dev/null || true\n"
+    )
+    env.write_file("/eval.sh", setuptools_guard + ts.eval_script)
     result = env.execute("chmod +x /eval.sh && /eval.sh 2>&1")
     test_output_path.parent.mkdir(parents=True, exist_ok=True)
     test_output_path.write_text(result["output"])

--- a/src/exgentic/benchmarks/swebench/kube_sandbox.py
+++ b/src/exgentic/benchmarks/swebench/kube_sandbox.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (C) 2026, The Exgentic organization and its contributors.
+
+"""Pod-native SWE-bench sandbox (no docker / no privileged).
+
+The default SWE-bench path runs each task's environment as a Docker container
+(minisweagent's ``DockerEnvironment`` + the docker-based ``run_evaluation``
+harness), which needs a container runtime in the pod (privileged DinD or
+rootless podman).
+
+This module is the cloud-native alternative: each task's environment becomes
+its **own sibling Kubernetes Pod**, created from the SWE-bench instance image
+(``swebench/sweb.eval...``). The agent's bash actions run via ``kubectl exec``,
+and grading runs the *same* SWE-bench eval script (from ``make_test_spec``)
+inside that pod, parsed by SWE-bench's own ``get_eval_report``. So there is no
+docker, no DinD, and no privileged container - the instance image runs as root
+under the ``anyuid`` SCC, nothing more.
+
+``KubernetesEnvironment.execute`` is shape-compatible with minisweagent's
+environments (``{"output": str, "returncode": int}``), so the Session's
+``run_bash`` / ``generate_patch`` use it unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+_DEFAULT_CWD = "/testbed"
+
+
+def _kubectl_bin() -> str:
+    exe = shutil.which("kubectl") or shutil.which("oc")
+    if exe is None:
+        raise RuntimeError("kubectl (or oc) not found on PATH")
+    return exe
+
+
+class KubernetesEnvironment:
+    """Run one SWE-bench task in a dedicated Pod, exec'ing via kubectl.
+
+    Mirrors minisweagent's ``DockerEnvironment`` (``docker run`` -> Pod,
+    ``docker exec`` -> ``kubectl exec``) so the agent loop is unchanged.
+    """
+
+    def __init__(
+        self,
+        *,
+        image: str,
+        namespace: str,
+        service_account: str | None = None,
+        image_pull_secrets: list[str] | None = None,
+        cwd: str = _DEFAULT_CWD,
+        timeout: int = 1800,
+        pull_timeout: int = 900,
+        env: dict[str, str] | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self.logger = logger or logging.getLogger("exgentic.swebench.kube")
+        self.image = image
+        self.namespace = namespace
+        self.service_account = service_account
+        self.image_pull_secrets = image_pull_secrets or []
+        self.cwd = cwd
+        self.timeout = timeout
+        self.pull_timeout = pull_timeout
+        self.env = env or {}
+        self.pod_name = f"swebench-{uuid4().hex[:8]}"
+        self._deleted = False
+        self._start_pod()
+
+    # ── pod lifecycle ────────────────────────────────────────────────
+    def _manifest(self) -> dict[str, Any]:
+        container: dict[str, Any] = {
+            "name": "task",
+            "image": self.image,
+            # The instance image's filesystem (repo at /testbed, conda env) is
+            # what we exec into; just keep it alive.
+            "command": ["sleep", str(self.timeout)],
+            "workingDir": self.cwd,
+            "imagePullPolicy": "IfNotPresent",
+        }
+        spec: dict[str, Any] = {"restartPolicy": "Never", "containers": [container]}
+        if self.service_account:
+            spec["serviceAccountName"] = self.service_account
+        if self.image_pull_secrets:
+            spec["imagePullSecrets"] = [{"name": n} for n in self.image_pull_secrets]
+        return {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "name": self.pod_name,
+                "namespace": self.namespace,
+                "labels": {"app": self.pod_name, "exgentic.swebench": "task"},
+            },
+            "spec": spec,
+        }
+
+    def _start_pod(self) -> None:
+        self.logger.info(f"KUBE | creating task pod {self.pod_name} (image {self.image})")
+        self._run(["apply", "-f", "-"], stdin=json.dumps(self._manifest()))
+        # Image pull of a SWE-bench instance image can be slow on a cold node.
+        r = self._run(
+            ["wait", f"pod/{self.pod_name}", "--for=condition=Ready",
+             f"--timeout={self.pull_timeout}s"],
+            check=False,
+        )
+        if r.returncode != 0:
+            desc = self._run(["describe", "pod", self.pod_name], check=False).stdout
+            self.cleanup()
+            raise RuntimeError(
+                f"Task pod {self.pod_name} not Ready within {self.pull_timeout}s.\n{desc}"
+            )
+        self.logger.info(f"KUBE | task pod {self.pod_name} ready")
+
+    def _run(self, args: list[str], *, stdin: str | None = None,
+             check: bool = True, timeout: int | None = None) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [_kubectl_bin(), "-n", self.namespace, *args],
+            input=stdin, text=True, encoding="utf-8", errors="replace",
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            timeout=timeout, check=check,
+        )
+
+    # ── agent contract (minisweagent-compatible) ─────────────────────
+    def execute(self, command: str, cwd: str = "", *, timeout: int | None = None) -> dict[str, Any]:
+        cwd = cwd or self.cwd
+        exports = "".join(f"export {k}={shlex.quote(v)}; " for k, v in self.env.items())
+        script = f"{exports}cd {shlex.quote(cwd)} && {command}"
+        try:
+            r = self._run(
+                ["exec", self.pod_name, "-c", "task", "--", "bash", "-lc", script],
+                check=False, timeout=timeout or self.timeout,
+            )
+            return {"output": r.stdout, "returncode": r.returncode}
+        except subprocess.TimeoutExpired as e:
+            return {"output": (e.stdout or "") + "\n<timeout>", "returncode": 124}
+
+    def write_file(self, path: str, content: str) -> None:
+        """Stream *content* into *path* inside the pod (kubectl exec stdin)."""
+        self._run(
+            ["exec", "-i", self.pod_name, "-c", "task", "--",
+             "sh", "-c", f"cat > {shlex.quote(path)}"],
+            stdin=content,
+        )
+
+    # ── teardown ─────────────────────────────────────────────────────
+    def cleanup(self) -> None:
+        if self._deleted:
+            return
+        self._deleted = True
+        try:
+            self._run(["delete", "pod", self.pod_name, "--ignore-not-found", "--wait=false"],
+                      check=False)
+        except Exception:  # noqa: BLE001 - best-effort teardown
+            pass
+
+    def __del__(self) -> None:
+        self.cleanup()
+
+
+def grade_in_pod(env: KubernetesEnvironment, instance: dict, model_patch: str,
+                 test_output_path: Path, logger: logging.Logger):
+    """Grade a SWE-bench task inside its own pod, reusing SWE-bench's own eval
+    script + report parser (no docker harness).
+
+    Returns a ``swebench_evaluation.HarnessResult``.
+    """
+    from swebench.harness.constants import KEY_INSTANCE_ID, KEY_PREDICTION
+    from swebench.harness.grading import get_eval_report
+    from swebench.harness.test_spec.test_spec import make_test_spec
+
+    from .swebench_evaluation import HarnessResult, is_patch_valid
+
+    instance_id = instance["instance_id"]
+    valid = is_patch_valid(model_patch)
+    ts = make_test_spec(instance)
+    base = instance["base_commit"]
+
+    # Clean checkout at base, then apply exactly the submitted patch (matches
+    # swebench's run_instance semantics: container starts clean, model patch
+    # applied, then the eval script applies the test patch and runs the tests).
+    env.execute(f"git reset --hard {shlex.quote(base)} && git clean -fdxq")
+    if valid:
+        env.write_file("/tmp/model.patch", model_patch)
+        ap = env.execute(
+            "git apply -v /tmp/model.patch || "
+            "patch --batch --fuzz=5 -p1 -i /tmp/model.patch"
+        )
+        if ap["returncode"] != 0:
+            logger.warning(f"KUBE | model patch did not apply cleanly:\n{ap['output'][-2000:]}")
+
+    env.write_file("/eval.sh", ts.eval_script)
+    result = env.execute("chmod +x /eval.sh && /eval.sh 2>&1")
+    test_output_path.parent.mkdir(parents=True, exist_ok=True)
+    test_output_path.write_text(result["output"])
+
+    prediction = {
+        KEY_INSTANCE_ID: instance_id,
+        KEY_PREDICTION: model_patch or "",
+        "model_name_or_path": "exgentic",
+    }
+    report = get_eval_report(ts, prediction, str(test_output_path), include_tests_status=True)
+    logger.info(f"KUBE | grade {instance_id}: resolved={report.get(instance_id, {}).get('resolved')}")
+    return HarnessResult(
+        harness_report=report,
+        patch=model_patch or "",
+        patch_valid=valid,
+        harness_ran=True,
+    )

--- a/src/exgentic/benchmarks/swebench/kube_sandbox.py
+++ b/src/exgentic/benchmarks/swebench/kube_sandbox.py
@@ -94,7 +94,17 @@ class KubernetesEnvironment:
             "workingDir": self.cwd,
             "imagePullPolicy": "IfNotPresent",
         }
-        spec: dict[str, Any] = {"restartPolicy": "Never", "containers": [container]}
+        # Run as root: SWE-bench instance images own /testbed (repo + .git) as root.
+        # Without this, OpenShift's SCC assigns a random uid that cannot write the
+        # root-owned source files AND trips git's "dubious ownership" guard, so
+        # `git add -A && git diff` returns empty -> correct fixes are captured as an
+        # empty patch and scored 0. (exgentic-task SA carries anyuid, so root schedules.)
+        container["securityContext"] = {"runAsUser": 0}
+        spec: dict[str, Any] = {
+            "restartPolicy": "Never",
+            "containers": [container],
+            "securityContext": {"runAsUser": 0},
+        }
         if self.service_account:
             spec["serviceAccountName"] = self.service_account
         if self.image_pull_secrets:

--- a/src/exgentic/benchmarks/swebench/swebench_benchmark.py
+++ b/src/exgentic/benchmarks/swebench/swebench_benchmark.py
@@ -43,6 +43,50 @@ class SubmitPatchAction(FinishAction):
     arguments: SubmitPatchArgs
 
 
+# --- Structured file-editor tools -------------------------------------------
+# A bash-only agent has to edit source via heredocs/sed, which gemma-4 (and weaker
+# models) get wrong, so they default to re-running the repro forever instead of
+# editing. These give a reliable view/create/str_replace seam (the standard
+# SWE-bench editor); they run through the same sandbox as bash.
+
+
+class ViewArgs(BaseModel):
+    path: str = Field(description="Path of the file to view")
+    view_range: list[int] | None = Field(
+        default=None,
+        description="Optional [start, end] 1-indexed line range; omit to view the whole file",
+    )
+
+
+class ViewAction(SingleAction):
+    name: str = "view"
+    arguments: ViewArgs
+
+
+class CreateArgs(BaseModel):
+    path: str = Field(description="Path of the file to create (overwrites if it exists)")
+    file_text: str = Field(description="Full text content to write to the file")
+
+
+class CreateAction(SingleAction):
+    name: str = "create"
+    arguments: CreateArgs
+
+
+class StrReplaceArgs(BaseModel):
+    path: str = Field(description="Path of the file to edit")
+    old_str: str = Field(
+        description="Exact text to replace; must occur EXACTLY ONCE in the file "
+        "(include surrounding lines for uniqueness)",
+    )
+    new_str: str = Field(description="Replacement text")
+
+
+class StrReplaceAction(SingleAction):
+    name: str = "str_replace"
+    arguments: StrReplaceArgs
+
+
 class SessionScore(BaseSessionScore):
     instance_id: str = ""
     agent: dict[str, Any] = Field(default_factory=dict)

--- a/src/exgentic/benchmarks/swebench/swebench_eval.py
+++ b/src/exgentic/benchmarks/swebench/swebench_eval.py
@@ -90,8 +90,16 @@ def run_bash(
 
 
 def generate_patch(env, cwd: str, base_commit: str) -> str:
-    """Generate patch from staged changes."""
-    command = f"git add -A && git diff --staged {base_commit} | cat"
+    """Generate patch from staged changes.
+
+    safe.directory '*' makes git trust the repo even when /testbed is owned by a
+    different uid than the exec user (otherwise git refuses with "dubious ownership"
+    and emits nothing to stdout -> an empty, silently-wrong patch).
+    """
+    command = (
+        "git config --global --add safe.directory '*' 2>/dev/null; "
+        f"git add -A && git diff --staged {base_commit} | cat"
+    )
     output = env.execute(command=command, cwd=cwd)
     return output["output"]
 

--- a/src/exgentic/benchmarks/swebench/swebench_eval.py
+++ b/src/exgentic/benchmarks/swebench/swebench_eval.py
@@ -435,7 +435,10 @@ class SWEBenchSession(Session):
 
         from .kube_sandbox import KubernetesEnvironment
 
-        ts = make_test_spec(self._instance)
+        # namespace= gives the *pullable* image name (e.g.
+        # swebench/sweb.eval.x86_64.<id>) rather than the local build key.
+        img_ns = os.environ.get("SWEBENCH_IMAGE_NAMESPACE", "swebench")
+        ts = make_test_spec(self._instance, namespace=img_ns)
         ns = (
             os.environ.get("EXGENTIC_KUBERNETES_NAMESPACE")
             or os.environ.get("POD_NAMESPACE")

--- a/src/exgentic/benchmarks/swebench/swebench_eval.py
+++ b/src/exgentic/benchmarks/swebench/swebench_eval.py
@@ -35,7 +35,13 @@ from ...utils.logging import hook_loggers_into_session
 from ...utils.paths import get_run_id
 from ...utils.settings import ExgenticSettings
 from . import swebench_evaluation, swebench_logs, swebench_metrics
-from .swebench_benchmark import BashAction, SubmitPatchAction
+from .swebench_benchmark import (
+    BashAction,
+    CreateAction,
+    StrReplaceAction,
+    SubmitPatchAction,
+    ViewAction,
+)
 
 # =============================================================================
 # Configuration
@@ -207,6 +213,82 @@ class SWEBenchSession(Session):
         )
         return result
 
+    def _run_editor_py(self, snippet: str) -> str:
+        """Run a self-contained python snippet in the sandbox via bash, base64-encoded
+        so we never fight shell/heredoc quoting (the exact failure mode that made the
+        bash-only agent's edits unreliable)."""
+        import base64
+
+        b64 = base64.b64encode(snippet.encode("utf-8")).decode()
+        cmd = f"python3 -c \"import base64;exec(base64.b64decode('{b64}').decode())\""
+        return run_bash(
+            command=cmd,
+            env=self.env,
+            timeout=self._timeout,
+            size_limit=self._observation_size_limit,
+            timeout_template=self._timeout_template,
+        )
+
+    def _handle_view(self, action: ViewAction) -> str:
+        path = action.arguments.path
+        vr = action.arguments.view_range
+        self.logger.info(f"STEP | {self._step_count:<3} | ACTION | view | path: {path} | range: {vr}")
+        snippet = (
+            "import sys\n"
+            f"p={path!r}; vr={vr!r}\n"
+            "try:\n"
+            "    lines=open(p,encoding='utf-8',errors='surrogateescape').read().splitlines()\n"
+            "except FileNotFoundError:\n"
+            "    print('ERROR: file not found: '+p); sys.exit(1)\n"
+            "a,b=(vr[0],vr[1]) if vr and len(vr)==2 else (1,len(lines))\n"
+            "a=max(1,a); b=min(len(lines),b)\n"
+            "for i in range(a,b+1):\n"
+            "    print(f'{i:6d}\\t{lines[i-1]}')\n"
+        )
+        return self._run_editor_py(snippet)
+
+    def _handle_create(self, action: CreateAction) -> str:
+        import base64
+
+        path = action.arguments.path
+        self.logger.info(f"STEP | {self._step_count:<3} | ACTION | create | path: {path}")
+        b64 = base64.b64encode(action.arguments.file_text.encode("utf-8")).decode()
+        snippet = (
+            "import base64,os\n"
+            f"p={path!r}\n"
+            f"d=base64.b64decode({b64!r}).decode('utf-8','surrogateescape')\n"
+            "os.makedirs(os.path.dirname(p) or '.',exist_ok=True)\n"
+            "open(p,'w',encoding='utf-8',errors='surrogateescape').write(d)\n"
+            "print('OK: wrote '+str(len(d))+' chars to '+p)\n"
+        )
+        return self._run_editor_py(snippet)
+
+    def _handle_str_replace(self, action: StrReplaceAction) -> str:
+        import base64
+
+        path = action.arguments.path
+        self.logger.info(f"STEP | {self._step_count:<3} | ACTION | str_replace | path: {path}")
+        b64old = base64.b64encode(action.arguments.old_str.encode("utf-8")).decode()
+        b64new = base64.b64encode(action.arguments.new_str.encode("utf-8")).decode()
+        snippet = (
+            "import base64,sys\n"
+            f"p={path!r}\n"
+            f"old=base64.b64decode({b64old!r}).decode('utf-8','surrogateescape')\n"
+            f"new=base64.b64decode({b64new!r}).decode('utf-8','surrogateescape')\n"
+            "try:\n"
+            "    s=open(p,encoding='utf-8',errors='surrogateescape').read()\n"
+            "except FileNotFoundError:\n"
+            "    print('ERROR: file not found: '+p); sys.exit(1)\n"
+            "c=s.count(old)\n"
+            "if c==0:\n"
+            "    print('ERROR: old_str not found in '+p+'. Use view to copy the exact text.'); sys.exit(1)\n"
+            "if c>1:\n"
+            "    print('ERROR: old_str occurs '+str(c)+' times; must be unique - add surrounding lines.'); sys.exit(1)\n"
+            "open(p,'w',encoding='utf-8',errors='surrogateescape').write(s.replace(old,new,1))\n"
+            "print('OK: replaced 1 occurrence in '+p)\n"
+        )
+        return self._run_editor_py(snippet)
+
     def _handle_submit_patch(self, action: SubmitPatchAction) -> str:
         self.logger.info(f"STEP | {self._step_count:<3} | ACTION | submit_patch | summary: {action.arguments.summary}")
         self._final_patch = generate_patch(
@@ -353,6 +435,31 @@ class SWEBenchSession(Session):
                 description="Run a bash command in the repo root and get the output",
                 action_cls=BashAction,
                 handler=self._handle_bash,
+            )
+            self._registry.add_action(
+                name="view",
+                description=(
+                    "View a file's contents with line numbers. Use this before"
+                    " editing to copy the exact text for str_replace."
+                ),
+                action_cls=ViewAction,
+                handler=self._handle_view,
+            )
+            self._registry.add_action(
+                name="str_replace",
+                description=(
+                    "Edit a file by replacing an exact unique string. Prefer this"
+                    " over bash/sed for source edits - it is reliable and the change"
+                    " is captured in the final patch. old_str must occur exactly once."
+                ),
+                action_cls=StrReplaceAction,
+                handler=self._handle_str_replace,
+            )
+            self._registry.add_action(
+                name="create",
+                description="Create (or overwrite) a file with the given text.",
+                action_cls=CreateAction,
+                handler=self._handle_create,
             )
             self._registry.add_action(
                 name="finish",

--- a/src/exgentic/benchmarks/swebench/swebench_eval.py
+++ b/src/exgentic/benchmarks/swebench/swebench_eval.py
@@ -295,6 +295,24 @@ class SWEBenchSession(Session):
         if self._final_patch is None:
             self.logger.info("SCORE | Harness evaluation skipped: no patch available for evaluation")
             return None
+
+        import os
+
+        if os.environ.get("SWEBENCH_SANDBOX", "").lower() == "kubernetes":
+            try:
+                from .kube_sandbox import grade_in_pod
+
+                return grade_in_pod(
+                    env=self.env,
+                    instance=self._instance,
+                    model_patch=self._final_patch,
+                    test_output_path=self.paths.benchmark_dir / "test_output.txt",
+                    logger=self.logger,
+                )
+            except Exception as e:  # noqa: BLE001 - grading must not crash the run
+                self.logger.exception(f"SCORE | Pod grading failed: {e}")
+                return None
+
         try:
             return swebench_evaluation.run_harness(
                 patch=self._final_patch,
@@ -371,7 +389,14 @@ class SWEBenchSession(Session):
     # -------------------------------------------------------------------------
 
     def _setup_environment(self) -> None:
-        """Initialize the Docker environment for the task."""
+        """Initialize the task environment (Docker container, or a Pod when
+        ``SWEBENCH_SANDBOX=kubernetes`` - no docker/privileged)."""
+        import os
+
+        if os.environ.get("SWEBENCH_SANDBOX", "").lower() == "kubernetes":
+            self._setup_kube_environment()
+            return
+
         self.logger.info("ENV | Setting up environment")
         from ...utils.container_reaper import docker_run_label_args
         from ...utils.logging import capture_stdio_to_session
@@ -397,6 +422,46 @@ class SWEBenchSession(Session):
 
         if self.container_base_commit != self._instance["base_commit"]:
             self.logger.error(
+                f"ENV | Base commit mismatch: expected {self._instance['base_commit']} "
+                f"| got {self.container_base_commit}"
+            )
+
+    def _setup_kube_environment(self) -> None:
+        """Pod-native env: each task runs in its own Pod from the SWE-bench
+        instance image, exec'd via kubectl. No docker, no privileged."""
+        import os
+
+        from swebench.harness.test_spec.test_spec import make_test_spec
+
+        from .kube_sandbox import KubernetesEnvironment
+
+        ts = make_test_spec(self._instance)
+        ns = (
+            os.environ.get("EXGENTIC_KUBERNETES_NAMESPACE")
+            or os.environ.get("POD_NAMESPACE")
+            or "default"
+        )
+        sa = os.environ.get("SWEBENCH_SANDBOX_SA") or None
+        pull = [
+            s.strip()
+            for s in os.environ.get("EXGENTIC_KUBERNETES_IMAGE_PULL_SECRETS", "").split(",")
+            if s.strip()
+        ]
+        self.logger.info(f"ENV | Pod sandbox: image {ts.instance_image_key} in ns {ns}")
+        self.env = KubernetesEnvironment(
+            image=ts.instance_image_key,
+            namespace=ns,
+            service_account=sa,
+            image_pull_secrets=pull,
+            cwd=self.container_repo_dir,
+            timeout=self._timeout if isinstance(self._timeout, int) else 1800,
+            pull_timeout=self._environment_pull_timeout,
+            logger=self.logger,
+        )
+        result = self.env.execute(command="git rev-parse HEAD", cwd=self.container_repo_dir)
+        self.container_base_commit = result["output"].strip()
+        if self.container_base_commit != self._instance["base_commit"]:
+            self.logger.warning(
                 f"ENV | Base commit mismatch: expected {self._instance['base_commit']} "
                 f"| got {self.container_base_commit}"
             )

--- a/src/exgentic/core/runner_mixin.py
+++ b/src/exgentic/core/runner_mixin.py
@@ -39,6 +39,7 @@ class RunnerMixin:
                 "env_name": f"{kind}/{self.slug_name}",
                 "module_path": type(self).__module__,
                 "sandbox": s.kubernetes_sandbox,
+                "port_forward": s.kubernetes_port_forward,
             }
             if self.docker_socket:
                 kw["docker_socket"] = True
@@ -48,6 +49,10 @@ class RunnerMixin:
                 kw["namespace"] = s.kubernetes_namespace
             if s.kubernetes_service_account:
                 kw["service_account"] = s.kubernetes_service_account
+            if s.kubernetes_image_pull_secrets:
+                kw["image_pull_secrets"] = [
+                    n.strip() for n in s.kubernetes_image_pull_secrets.split(",") if n.strip()
+                ]
             # Results persist on a shared PVC mounted at the output_dir path
             # (host bind mounts have no meaning in-cluster).
             if s.kubernetes_output_pvc:

--- a/src/exgentic/core/runner_mixin.py
+++ b/src/exgentic/core/runner_mixin.py
@@ -38,11 +38,8 @@ class RunnerMixin:
             kw: dict[str, Any] = {
                 "env_name": f"{kind}/{self.slug_name}",
                 "module_path": type(self).__module__,
-                "sandbox": s.kubernetes_sandbox,
                 "port_forward": s.kubernetes_port_forward,
             }
-            if self.docker_socket:
-                kw["docker_socket"] = True
             if s.kubernetes_image:
                 kw["image"] = s.kubernetes_image
             if s.kubernetes_namespace:

--- a/src/exgentic/core/runner_mixin.py
+++ b/src/exgentic/core/runner_mixin.py
@@ -33,6 +33,29 @@ class RunnerMixin:
                 "module_path": type(self).__module__,
             }
 
+        if runner == "kubernetes":
+            s = get_settings()
+            kw: dict[str, Any] = {
+                "env_name": f"{kind}/{self.slug_name}",
+                "module_path": type(self).__module__,
+                "sandbox": s.kubernetes_sandbox,
+            }
+            if self.docker_socket:
+                kw["docker_socket"] = True
+            if s.kubernetes_image:
+                kw["image"] = s.kubernetes_image
+            if s.kubernetes_namespace:
+                kw["namespace"] = s.kubernetes_namespace
+            if s.kubernetes_service_account:
+                kw["service_account"] = s.kubernetes_service_account
+            # Results persist on a shared PVC mounted at the output_dir path
+            # (host bind mounts have no meaning in-cluster).
+            if s.kubernetes_output_pvc:
+                ctx = try_get_context()
+                output_dir = ctx.output_dir if ctx is not None else s.output_dir
+                kw["volumes"] = {s.kubernetes_output_pvc: str(Path(output_dir).resolve())}
+            return kw
+
         if runner != "docker":
             return {}
 

--- a/src/exgentic/integrations/litellm/config.py
+++ b/src/exgentic/integrations/litellm/config.py
@@ -5,7 +5,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -19,7 +20,13 @@ class LitellmSettings:
     log_level: str
     drop_params: bool = True
     modify_params: bool = True
-    timeout: int = 180
+    # Per-request timeout. The default 180s is too short for the first call of a
+    # cold span/full-recompute middleware deploy (the warmup prefill can run for
+    # minutes), which surfaced as "Model not accessible: TimeoutError()" at step 0.
+    # Env-tunable so a sweep can raise it without a code change.
+    timeout: int = field(
+        default_factory=lambda: int(os.environ.get("EXGENTIC_LITELLM_TIMEOUT", "600"))
+    )
 
 
 def configure_litellm(

--- a/src/exgentic/utils/cost.py
+++ b/src/exgentic/utils/cost.py
@@ -47,10 +47,16 @@ def litellm_tokens_cost(input_tokens: int, output_tokens: int, model_name: str) 
             )
         except Exception:
             continue
-    raise ValueError(
-        f"No pricing info found for model '{model_name}'. "
-        f"Add it to the name_map in exgentic/utils/cost.py or check litellm model support."
+    # Self-hosted / custom models (e.g. a vLLM-served checkpoint) have no public
+    # pricing in litellm. Cost tracking should degrade gracefully, not crash the
+    # run - report zero cost. Add an entry to name_map above if real pricing is
+    # wanted.
+    import logging
+
+    logging.getLogger(__name__).debug(
+        "No pricing info for model '%s'; reporting zero cost.", model_name
     )
+    return TokensCost(input_cost=0.0, output_cost=0.0, total_cost=0.0)
 
 
 class CostReport(BaseModel):

--- a/src/exgentic/utils/settings.py
+++ b/src/exgentic/utils/settings.py
@@ -54,7 +54,6 @@ class ExgenticSettings(BaseSettings):
     kubernetes_service_account: str | None = None
     kubernetes_image_pull_secrets: str | None = None  # comma-separated secret names
     kubernetes_output_pvc: str | None = None
-    kubernetes_sandbox: str = "podman"
     # In-cluster orchestrators reach the spawned service over cluster DNS; set
     # EXGENTIC_KUBERNETES_PORT_FORWARD=false there. Laptops keep it true.
     kubernetes_port_forward: bool = True

--- a/src/exgentic/utils/settings.py
+++ b/src/exgentic/utils/settings.py
@@ -52,8 +52,12 @@ class ExgenticSettings(BaseSettings):
     kubernetes_image: str | None = None
     kubernetes_namespace: str | None = None
     kubernetes_service_account: str | None = None
+    kubernetes_image_pull_secrets: str | None = None  # comma-separated secret names
     kubernetes_output_pvc: str | None = None
     kubernetes_sandbox: str = "podman"
+    # In-cluster orchestrators reach the spawned service over cluster DNS; set
+    # EXGENTIC_KUBERNETES_PORT_FORWARD=false there. Laptops keep it true.
+    kubernetes_port_forward: bool = True
 
     _litellm_cache_configured: bool = False
 

--- a/src/exgentic/utils/settings.py
+++ b/src/exgentic/utils/settings.py
@@ -18,7 +18,7 @@ load_dotenv(DOTENV_PATH)
 if TYPE_CHECKING:
     from ..integrations.litellm.config import LitellmSettings
 
-RunnerName = Literal["direct", "thread", "process", "service", "docker", "venv"]
+RunnerName = Literal["direct", "thread", "process", "service", "docker", "venv", "kubernetes"]
 LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 
@@ -46,6 +46,14 @@ class ExgenticSettings(BaseSettings):
     dotenv_path: str = str(DOTENV_PATH)
     otel_enabled: bool = False
     otel_record_content: bool = True
+
+    # Kubernetes runner defaults (used when runner="kubernetes"). Env:
+    # EXGENTIC_KUBERNETES_IMAGE / _NAMESPACE / _SERVICE_ACCOUNT / _OUTPUT_PVC / _SANDBOX.
+    kubernetes_image: str | None = None
+    kubernetes_namespace: str | None = None
+    kubernetes_service_account: str | None = None
+    kubernetes_output_pvc: str | None = None
+    kubernetes_sandbox: str = "podman"
 
     _litellm_cache_configured: bool = False
 


### PR DESCRIPTION
## What

First-class support for running exgentic evaluations **inside a Kubernetes cluster**, so the eval lifecycle no longer has to live on a laptop driving a remote endpoint over port-forward. vLLM (or any model endpoint) becomes just another in-cluster Service. Two small, orthogonal pieces - **neither needs privileged**:

### 1. `KubernetesRunner` (`runner="kubernetes"`)

A cloud-native sibling of `DockerRunner`. `with_runner(cls, runner="kubernetes", ...)` creates a ConfigMap + Pod + ClusterIP Service running `exgentic serve`, waits for `/health`, and returns the same `ObjectProxy` over the same `HTTPTransport` - nothing in the programming model changes; the object just lives in a Pod.

- Manifests are applied with `kubectl apply` as JSON, so it adds no dependency (no PyYAML, no kubernetes client).
- Reachable over in-cluster DNS (`<svc>.<ns>.svc.cluster.local`) when the orchestrator runs in-cluster, or `kubectl port-forward` from a laptop (`port_forward=True`).
- Registered like the other runners: dispatch branch, `RunnerName`, settings (`EXGENTIC_KUBERNETES_*`), `runner_mixin`. Per-instance teardown and `imagePullSecrets` included.
- Deliberately thin: no container-runtime concerns live in the runner.

### 2. Pod-native SWE-bench sandbox (`SWEBENCH_SANDBOX=kubernetes`)

A docker-free, non-privileged backend for SWE-bench. Each task's environment becomes its own Pod, built from the SWE-bench instance image:

- `KubernetesEnvironment` mirrors minisweagent's `DockerEnvironment` (`docker exec` -> `kubectl exec`), so the agent loop is unchanged - the only contract is `execute(command, cwd) -> {"output", "returncode"}`.
- Grading runs SWE-bench's own eval script (`make_test_spec(...).eval_script`) inside the same Pod and parses with SWE-bench's own `get_eval_report` - same tests, same parser, just `kubectl exec` instead of the docker harness.
- The instance image runs as root under the `anyuid` SCC: no privileged, no DinD, no docker socket. Each per-task Session is its own Pod (clean isolation, natural parallelism).

## Why

Running a large batch of SWE-bench experiments, I needed the orchestrator + agents to run in-cluster rather than on a laptop: VPN / port-forward drops were surfacing as model-server 5xx and killing long runs. This keeps the whole run in the cluster.

## Testing

- `KubernetesRunner` round-trip validated live on OpenShift: manifest -> `exgentic serve` -> `/health` -> transport call -> cleanup (trivial `Calculator`, with `imagePullSecrets` pull and per-instance teardown).
- Pod-native SWE-bench sandbox is under live validation on the same cluster (gemma served in-cluster); will update with results.

## Out of scope (follow-up)

A generalized non-privileged Pod sandbox backend for arbitrary `docker_socket=True` benchmarks (beyond SWE-bench).
