### PR TITLE
fix(venv): drain subprocess pipes and forward HOME to fix appworld MCP startup

### DIFF
--- a/src/exgentic/adapters/runners/_utils.py
+++ b/src/exgentic/adapters/runners/_utils.py
@@ -101,10 +101,17 @@ def prepare_subprocess_env() -> dict[str, str]:
     :data:`_FORWARD_PREFIXES`).  Exgentic context and settings travel
     via ``runtime.json`` (see :func:`inject_exgentic_env`), so no
     ``EXGENTIC_*`` vars need to be forwarded here.
+
+    ``HOME`` is always forwarded: Python's ``Path.home()`` and many CLI
+    tools rely on it to locate config and data directories (e.g. the
+    EnvironmentManager resolves ``~/.exgentic`` from ``HOME``).
     """
     import os
 
-    return {k: v for k, v in os.environ.items() if k.endswith(_FORWARD_SUFFIXES) or k.startswith(_FORWARD_PREFIXES)}
+    env = {k: v for k, v in os.environ.items() if k.endswith(_FORWARD_SUFFIXES) or k.startswith(_FORWARD_PREFIXES)}
+    if "HOME" in os.environ:
+        env["HOME"] = os.environ["HOME"]
+    return env
 
 
 def inject_exgentic_env(env: dict[str, str], role: Role | None = None) -> None:

--- a/src/exgentic/adapters/runners/venv.py
+++ b/src/exgentic/adapters/runners/venv.py
@@ -17,8 +17,11 @@ from __future__ import annotations
 import atexit
 import os
 import shutil
+import signal
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -32,11 +35,19 @@ from ._utils import (
     prepare_subprocess_env,
     serialize_kwargs,
 )
-from .service import HTTPTransport, _wait_for_health
+from .service import HTTPTransport
 from .transport import ObjectProxy
 
 _HEALTH_TIMEOUT = 120.0
 _TRANSPORT_TIMEOUT = 600.0
+
+
+class _ProcessExitedError(RuntimeError):
+    """Raised when the venv subprocess exits before becoming healthy.
+
+    Distinct from TimeoutError so the caller can tell a crash (process
+    died with a real error) apart from a genuine health-check timeout.
+    """
 
 
 def _uv(*args: str, check: bool = True, **kwargs: Any) -> subprocess.CompletedProcess:
@@ -90,6 +101,12 @@ class VenvRunner:
         self._health_timeout = health_timeout or _HEALTH_TIMEOUT
         self._role = role
         self._process: subprocess.Popen | None = None
+        # Background threads drain the subprocess pipes so a chatty child
+        # can never deadlock by filling the OS pipe buffer (~64KB). Output
+        # accumulates in these buffers for diagnostics.
+        self._stdout_chunks: list[bytes] = []
+        self._stderr_chunks: list[bytes] = []
+        self._drain_threads: list[threading.Thread] = []
 
     # ── venv handling ─────────────────────────────────────────────────
 
@@ -143,7 +160,6 @@ class VenvRunner:
 
     def start(self) -> ObjectProxy:
         import logging
-        import time
 
         _log = logging.getLogger(__name__)
 
@@ -190,12 +206,14 @@ class VenvRunner:
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            start_new_session=True,
         )
+        self._start_drain_threads()
         atexit.register(self._stop_process)
 
         url = f"http://127.0.0.1:{self._port}"
         try:
-            _wait_for_health(url, timeout=self._health_timeout)
+            self._wait_for_health_with_process_check(url, timeout=self._health_timeout)
             t4 = time.perf_counter()
             msg = (
                 f"VenvRunner.start env={self._env_name} ensure_venv={t1 - t0:.3f}s "
@@ -203,24 +221,87 @@ class VenvRunner:
             )
             _log.info(msg)
             print(msg, flush=True)
-        except TimeoutError:
-            proc = self._process
-            if proc is not None:
-                proc.terminate()
-                stdout, stderr = proc.communicate(timeout=5)
-            else:
-                stdout, stderr = b"", b""
+        except (TimeoutError, _ProcessExitedError):
+            # The wait method already framed an informative message (crash
+            # exit code, or timeout) and included the drained output, so
+            # just clean up the process and re-raise it unchanged.
             self._stop_process()
-            raise TimeoutError(
-                f"Venv service did not become healthy within {self._health_timeout}s.\n"
-                f"stdout:\n{stdout.decode(errors='replace')}\n"
-                f"stderr:\n{stderr.decode(errors='replace')}"
-            ) from None
+            raise
 
-        transport = HTTPTransport(url, timeout=_TRANSPORT_TIMEOUT)
+        # Liveness callable so RPCs fail fast if the venv subprocess
+        # dies mid-session instead of hanging on httpx's transport timeout.
+        def _is_alive() -> bool:
+            proc = self._process
+            return proc is not None and proc.poll() is None
+
+        transport = HTTPTransport(url, timeout=_TRANSPORT_TIMEOUT, is_alive=_is_alive)
         proxy = ObjectProxy(transport)
         object.__setattr__(proxy, "close", make_close(transport, self._stop_process))
         return proxy
+
+    def _start_drain_threads(self) -> None:
+        """Continuously read stdout/stderr so the child never blocks on a full pipe."""
+        proc = self._process
+        if proc is None:
+            return
+
+        def _drain(stream: Any, sink: list[bytes]) -> None:
+            try:
+                for chunk in iter(lambda: stream.read(4096), b""):
+                    sink.append(chunk)
+            except (ValueError, OSError):
+                # Stream closed concurrently (e.g. by _stop_process).
+                pass
+
+        self._drain_threads = []
+        for stream, sink in ((proc.stdout, self._stdout_chunks), (proc.stderr, self._stderr_chunks)):
+            if stream is None:
+                continue
+            t = threading.Thread(target=_drain, args=(stream, sink), daemon=True)
+            t.start()
+            self._drain_threads.append(t)
+
+    def _captured_output(self) -> tuple[str, str]:
+        """Snapshot of the drained stdout/stderr collected so far."""
+        return (
+            b"".join(self._stdout_chunks).decode(errors="replace"),
+            b"".join(self._stderr_chunks).decode(errors="replace"),
+        )
+
+    def _wait_for_health_with_process_check(self, url: str, timeout: float) -> None:
+        """Wait for the health endpoint, but fail fast if the subprocess exits.
+
+        This prevents waiting the full timeout period when the subprocess
+        crashes immediately (e.g. due to authentication errors during init).
+        On crash it raises ``_ProcessExitedError``; on a genuine timeout it
+        raises ``TimeoutError``. Both carry the drained stdout/stderr.
+        """
+        import httpx
+
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            # Fail fast if the process has already exited.
+            if self._process is not None and self._process.poll() is not None:
+                stdout, stderr = self._captured_output()
+                exit_code = self._process.returncode
+                raise _ProcessExitedError(
+                    f"Venv service process exited with code {exit_code} before becoming healthy.\n"
+                    f"stdout:\n{stdout}\n"
+                    f"stderr:\n{stderr}"
+                )
+
+            try:
+                if httpx.get(f"{url}/health", timeout=2.0).status_code == 200:
+                    return
+            except httpx.HTTPError:
+                pass
+
+            time.sleep(0.1)
+
+        stdout, stderr = self._captured_output()
+        raise TimeoutError(
+            f"Venv service did not become healthy within {timeout}s.\n" f"stdout:\n{stdout}\n" f"stderr:\n{stderr}"
+        )
 
     def _stop_process(self) -> None:
         if self._process is None:
@@ -228,7 +309,8 @@ class VenvRunner:
         proc = self._process
         self._process = None
         try:
-            proc.terminate()
+            # Kill the entire process group (start_new_session=True creates one).
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
             proc.wait(timeout=5)
         except Exception:
             try:

--- a/src/exgentic/benchmarks/appworld/requirements.txt
+++ b/src/exgentic/benchmarks/appworld/requirements.txt
@@ -1,1 +1,2 @@
 appworld @ git+https://github.com/StonyBrookNLP/appworld.git@edc960129fa6889c2b381715ecd108982029f6d1
+httpx2


### PR DESCRIPTION
## Summary

Fixes three bugs that prevented `exgentic mcp --benchmark appworld` from starting.

### Root cause: pipe buffer deadlock

`VenvRunner` captures subprocess stdout/stderr via pipes but never drains them while polling the health endpoint. AppWorld's package imports emit ~65 KB of `StarletteDeprecationWarning`s at load time, filling the 64 KB OS pipe buffer. The subprocess stalls trying to write more warnings and never reaches the uvicorn startup — `VenvRunner` then times out after 120 s reporting an unhelpful "did not become healthy" error with empty stdout/stderr.

**Fix:** `_start_drain_threads()` starts two background threads that continuously read both pipes into in-memory buffers. The buffered output is included in timeout/crash error messages for diagnostics.

### Missing `HOME` forwarding

`prepare_subprocess_env()` strips all env vars except LLM provider credentials. `Path.home()` and `EnvironmentManager` both resolve benchmark data directories from `HOME` (`~/.exgentic`). Without it the subprocess can't locate the installed benchmark data.

**Fix:** Always forward `HOME` in `prepare_subprocess_env()`.

### `httpx2` missing from appworld venv

Starlette's `TestClient` (used by AppWorld's internal FastAPI apps) emits a `DeprecationWarning` that `httpx` is deprecated and requires `httpx2`. While the warning itself is non-fatal, the package is required for the test client to initialise correctly.

**Fix:** Add `httpx2` to `src/exgentic/benchmarks/appworld/requirements.txt`.

### Additional VenvRunner improvements

- `start_new_session=True` + `os.killpg` for clean process-group teardown (prevents orphaned child processes).
- New `_wait_for_health_with_process_check` replaces `_wait_for_health`: raises `_ProcessExitedError` immediately when the subprocess crashes rather than waiting the full timeout before surfacing the error.

## Test plan

- [ ] `exgentic mcp --benchmark appworld` starts successfully and reports "MCP server started"
- [ ] `exgentic mcp --benchmark appworld` action tools load (expect ~468 tools)
- [ ] On subprocess crash, error message includes the crash output (not empty stdout/stderr)
- [ ] `prepare_subprocess_env()` includes `HOME` in its output

🤖 Generated with [Claude Code](https://claude.com/claude-code)