### PR TITLE
fix(build): build.sh reports false failure on successful builds

### DIFF
--- a/misc/benchmark_mcp_images/build.sh
+++ b/misc/benchmark_mcp_images/build.sh
@@ -110,9 +110,13 @@ EOF
     FAIL_COUNT=0
 
     if build_image "$BENCHMARK" "exgentic-mcp" "BENCHMARK_NAME" "$RUNTIME" "$TAG" "$USE_CACHE" "$PUSH_TO_GHCR" "$MULTIPLATFORM"; then
-        ((SUCCESS_COUNT++))
+        # Plain arithmetic assignment, not a standalone ((expr++)) command: under
+        # `set -e`, ((x++)) with x=0 evaluates to the pre-increment value (0),
+        # which bash treats as command failure and exits the script immediately
+        # -- even though the build just succeeded. $((x + 1)) has no such trap.
+        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
     else
-        ((FAIL_COUNT++))
+        FAIL_COUNT=$((FAIL_COUNT + 1))
     fi
     echo ""
 


### PR DESCRIPTION
## Problem

\`((SUCCESS_COUNT++))\` with \`SUCCESS_COUNT\` starting at \`0\` evaluates to
the pre-increment value (\`0\`), which bash treats as a failed command
under \`set -e\` — so the script exits immediately right after a
successful build, before ever printing the build summary, and reports
exit code 1 despite the build having actually succeeded. The same latent
bug applies to \`FAIL_COUNT\` on the first real failure (it would exit
before \`print_error\` even runs).

Found while building \`exgentic-mcp-tau2\` for a downstream integration —
\`./build.sh tau2\` printed \`[INFO] ✓ Successfully built
localhost/exgentic-mcp-tau2:latest\` and then exited 1 with no error
message. Confirmed the image genuinely built fine (\`podman images\`
showed it).

## Fix

Switched both counters to plain arithmetic assignment (\`$((x + 1))\`),
which has no such trap — only a bare \`((expr))\` command's own exit
status is subject to this, not an assignment.

Base is \`feature/mcp-command\` (this script only exists there, not on
\`main\` yet) so this is easy to review/merge independently of the larger
\`#187\`.